### PR TITLE
Order address2

### DIFF
--- a/dao/src/main/java/greencity/entity/enums/AddressStatus.java
+++ b/dao/src/main/java/greencity/entity/enums/AddressStatus.java
@@ -1,0 +1,7 @@
+package greencity.entity.enums;
+
+public enum AddressStatus {
+    NEW,
+    DELETED,
+    IN_ORDER
+}

--- a/dao/src/main/java/greencity/entity/user/ubs/Address.java
+++ b/dao/src/main/java/greencity/entity/user/ubs/Address.java
@@ -51,6 +51,9 @@ public class Address {
     @Column(columnDefinition = "boolean default false", nullable = false)
     private Boolean actual;
 
+    @Column(nullable = false)
+    private String status;
+
     @Embedded
     private Coordinates coordinates;
 }

--- a/dao/src/main/java/greencity/entity/user/ubs/Address.java
+++ b/dao/src/main/java/greencity/entity/user/ubs/Address.java
@@ -1,6 +1,7 @@
 package greencity.entity.user.ubs;
 
 import greencity.entity.coords.Coordinates;
+import greencity.entity.enums.AddressStatus;
 import greencity.entity.user.User;
 import java.util.List;
 import lombok.*;
@@ -51,8 +52,9 @@ public class Address {
     @Column(columnDefinition = "boolean default false", nullable = false)
     private Boolean actual;
 
-    @Column(nullable = false)
-    private String status;
+    @Column(name = "status",nullable = false)
+    @Enumerated(EnumType.STRING)
+    private AddressStatus addressStatus;
 
     @Embedded
     private Coordinates coordinates;

--- a/dao/src/main/java/greencity/entity/user/ubs/Address.java
+++ b/dao/src/main/java/greencity/entity/user/ubs/Address.java
@@ -52,7 +52,7 @@ public class Address {
     @Column(columnDefinition = "boolean default false", nullable = false)
     private Boolean actual;
 
-    @Column(name = "status",nullable = false)
+    @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
     private AddressStatus addressStatus;
 

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -23,4 +23,5 @@
     <include file="db/changelog/logs/ch-add-columns-recipient-values-Struk.xml"/>
     <include file="db/changelog/logs/сh-add-column-active-to-address-Veremchuk.xml"/>
     <include file="db/changelog/logs/сh-fk_ubs_users_and_addreses-Veremchuk.xml"/>
+    <include file="db/changelog/logs/сh-add-new-column-status-to-address-Veremchuk.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/сh-add-new-column-status-to-address-Veremchuk.xml
+++ b/dao/src/main/resources/db/changelog/logs/сh-add-new-column-status-to-address-Veremchuk.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+<changeSet id="Veremchuk-5" author="Veremchuk_Zahar">
+    <addColumn tableName="address">
+        <column name="status" type="VARCHAR(15)" defaultValue="NEW">
+            <constraints nullable="false"/>
+        </column>
+    </addColumn>
+</changeSet>
+</databaseChangeLog>

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -159,13 +159,15 @@ public class UBSClientServiceImpl implements UBSClientService {
         Set<Certificate> orderCertificates = new HashSet<>();
         sumToPay = formCertificatesToBeSavedAndCalculateOrderSum(dto, orderCertificates, order, sumToPay);
 
-        UBSuser userData = formUserDataToBeSaved(dto.getPersonalData(), currentUser);
+        UBSuser userData;
+        userData = formUserDataToBeSaved(dto.getPersonalData(), currentUser);
 
         Address address = addressRepo.findById(dto.getAddressId()).orElseThrow(() -> new NotFoundOrderAddressException(
             ErrorMessage.NOT_FOUND_ADDRESS_ID_FOR_CURRENT_USER + dto.getAddressId()));
 
         if (address.getAddressStatus().equals(AddressStatus.DELETED)) {
-            throw new NotFoundOrderAddressException(ErrorMessage.NOT_FOUND_ADDRESS_ID_FOR_CURRENT_USER + address.getId());
+            throw new NotFoundOrderAddressException(
+                ErrorMessage.NOT_FOUND_ADDRESS_ID_FOR_CURRENT_USER + address.getId());
         }
 
         if (!address.getUser().equals(currentUser)) {
@@ -173,7 +175,9 @@ public class UBSClientServiceImpl implements UBSClientService {
                 ErrorMessage.NOT_FOUND_ADDRESS_ID_FOR_CURRENT_USER + dto.getAddressId());
         }
         address.setAddressStatus(AddressStatus.IN_ORDER);
+
         userData.setAddress(address);
+
         if (userData.getAddress().getComment() == null) {
             userData.getAddress().setComment(dto.getPersonalData().getAddressComment());
         }
@@ -226,20 +230,17 @@ public class UBSClientServiceImpl implements UBSClientService {
         Address address;
         Address forOrderAfterUpdate;
 
-        if (dtoRequest.getId() != 0 ) {
-
+        if (dtoRequest.getId() != 0) {
             address = addressRepo.findById(dtoRequest.getId()).orElse(null);
             forOrderAfterUpdate = modelMapper.map(dtoRequest, Address.class);
 
-            if (address.getAddressStatus().equals(AddressStatus.DELETED)){
+            if (address.getAddressStatus().equals(AddressStatus.DELETED)) {
                 address = null;
             }
-
-        }else {
+        } else {
             address = null;
             forOrderAfterUpdate = null;
         }
-
 
         if (address == null || !address.getUser().equals(userRepository.findByUuid(uuid))) {
             address = modelMapper.map(dtoRequest, Address.class);
@@ -249,7 +250,6 @@ public class UBSClientServiceImpl implements UBSClientService {
             address.setAddressStatus(AddressStatus.NEW);
         } else {
             if (address.getAddressStatus().equals(AddressStatus.IN_ORDER)) {
-
                 forOrderAfterUpdate.setId(null);
                 forOrderAfterUpdate.setActual(true);
                 forOrderAfterUpdate.setUser(address.getUser());
@@ -349,7 +349,7 @@ public class UBSClientServiceImpl implements UBSClientService {
     }
 
     private int formCertificatesToBeSavedAndCalculateOrderSum(OrderResponseDto dto, Set<Certificate> orderCertificates,
-                                                              Order order, int sumToPay) {
+        Order order, int sumToPay) {
         if (dto.getCertificates() != null) {
             boolean tooManyCertificates = false;
             int certPoints = 0;

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -17,6 +17,7 @@ import static greencity.constant.ErrorMessage.USER_DONT_HAVE_ENOUGH_POINTS;
 
 import greencity.constant.ErrorMessage;
 import greencity.dto.*;
+import greencity.entity.enums.AddressStatus;
 import greencity.entity.enums.CertificateStatus;
 import greencity.entity.enums.OrderStatus;
 import greencity.entity.order.*;
@@ -163,11 +164,15 @@ public class UBSClientServiceImpl implements UBSClientService {
         Address address = addressRepo.findById(dto.getAddressId()).orElseThrow(() -> new NotFoundOrderAddressException(
             ErrorMessage.NOT_FOUND_ADDRESS_ID_FOR_CURRENT_USER + dto.getAddressId()));
 
+        if (address.getAddressStatus().equals(AddressStatus.DELETED)) {
+            throw new NotFoundOrderAddressException(ErrorMessage.NOT_FOUND_ADDRESS_ID_FOR_CURRENT_USER + address.getId());
+        }
+
         if (!address.getUser().equals(currentUser)) {
             throw new NotFoundOrderAddressException(
                 ErrorMessage.NOT_FOUND_ADDRESS_ID_FOR_CURRENT_USER + dto.getAddressId());
         }
-
+        address.setAddressStatus(AddressStatus.IN_ORDER);
         userData.setAddress(address);
         if (userData.getAddress().getComment() == null) {
             userData.getAddress().setComment(dto.getPersonalData().getAddressComment());
@@ -194,6 +199,8 @@ public class UBSClientServiceImpl implements UBSClientService {
         List<AddressDto> addressDtoList = addressRepo.findAllByUserId(id)
             .stream()
             .sorted(Comparator.comparing(Address::getId))
+            .filter(u -> u.getAddressStatus() != AddressStatus.DELETED)
+            .filter(u -> u.getAddressStatus() != AddressStatus.IN_ORDER)
             .map(u -> modelMapper.map(u, AddressDto.class))
             .collect(Collectors.toList());
         return new OrderWithAddressesResponseDto(addressDtoList);
@@ -216,17 +223,45 @@ public class UBSClientServiceImpl implements UBSClientService {
                 addressRepo.save(u);
             });
         }
-        Address address = addressRepo.findById(dtoRequest.getId()).orElse(null);
+        Address address;
+        Address forOrderAfterUpdate;
+
+        if (dtoRequest.getId() != 0 ) {
+
+            address = addressRepo.findById(dtoRequest.getId()).orElse(null);
+            forOrderAfterUpdate = modelMapper.map(dtoRequest, Address.class);
+
+            if (address.getAddressStatus().equals(AddressStatus.DELETED)){
+                address = null;
+            }
+
+        }else {
+            address = null;
+            forOrderAfterUpdate = null;
+        }
+
 
         if (address == null || !address.getUser().equals(userRepository.findByUuid(uuid))) {
             address = modelMapper.map(dtoRequest, Address.class);
             address.setId(null);
             address.setUser(userRepository.findByUuid(uuid));
             address.setActual(true);
+            address.setAddressStatus(AddressStatus.NEW);
         } else {
+            if (address.getAddressStatus().equals(AddressStatus.IN_ORDER)) {
+
+                forOrderAfterUpdate.setId(null);
+                forOrderAfterUpdate.setActual(true);
+                forOrderAfterUpdate.setUser(address.getUser());
+                forOrderAfterUpdate.setAddressStatus(address.getAddressStatus());
+                forOrderAfterUpdate.setComment(address.getComment());
+
+                address.getUbsUsers().forEach(u -> u.setAddress(addressRepo.save(forOrderAfterUpdate)));
+            }
             address = modelMapper.map(dtoRequest, Address.class);
             address.setUser(userRepository.findByUuid(uuid));
             address.setActual(true);
+            address.setAddressStatus(AddressStatus.NEW);
         }
         addressRepo.save(address);
         return findAllAddressesForCurrentOrder(uuid);
@@ -242,10 +277,8 @@ public class UBSClientServiceImpl implements UBSClientService {
         if (!address.getUser().equals(userRepository.findByUuid(uuid))) {
             throw new NotFoundOrderAddressException(ErrorMessage.NOT_FOUND_ADDRESS_ID_FOR_CURRENT_USER + addressId);
         }
-        List<UBSuser> ubsUsers = address.getUbsUsers();
-        ubsUsers.forEach((u) -> u.setAddress(null));
-        ubsUsers.forEach(ubsUserRepository::save);
-        addressRepo.deleteById(addressId);
+        address.setAddressStatus(AddressStatus.DELETED);
+        addressRepo.save(address);
         return findAllAddressesForCurrentOrder(uuid);
     }
 
@@ -316,7 +349,7 @@ public class UBSClientServiceImpl implements UBSClientService {
     }
 
     private int formCertificatesToBeSavedAndCalculateOrderSum(OrderResponseDto dto, Set<Certificate> orderCertificates,
-        Order order, int sumToPay) {
+                                                              Order order, int sumToPay) {
         if (dto.getCertificates() != null) {
             boolean tooManyCertificates = false;
             int certPoints = 0;


### PR DESCRIPTION
At this pull request, Im implement status for order Addresses. Address can have 3 status: NEW, DELETED, IN_ORDER. When user DELETE Address it change address status from NEW to DELETED, also u cant make order with DELETED Address, if u will try input id of DELETED Address it will send you Exceprtion 404. Also now when you try to update Address from last order (Address with status IN_ORDER), it will create different Address, save this in ubs_user where was before old Address (Address with satus IN_ORDER).
And change status of old Address (Address with satus IN_ORDER) on address  with satus NEW but  return with same id. Also by default every new address and updated address will have status NEW