### PR TITLE
Refactor OrderResponseDto.java and all usages to add 1 boolean field

### DIFF
--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -55,6 +55,7 @@ public class ModelUtils {
             .orderComment("comment")
             .certificates(Collections.emptySet())
             .pointsToUse(700)
+            .shouldBePaid(true)
             .personalData(PersonalDataDto.builder()
                 .firstName("Anton")
                 .lastName("Antonov")

--- a/service-api/src/main/java/greencity/dto/OrderResponseDto.java
+++ b/service-api/src/main/java/greencity/dto/OrderResponseDto.java
@@ -39,4 +39,7 @@ public class OrderResponseDto implements Serializable {
 
     @Valid
     private PersonalDataDto personalData;
+
+    @NotNull
+    private boolean shouldBePaid;
 }

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -188,17 +188,16 @@ public class UBSClientServiceImpl implements UBSClientService {
 
         getOrder(dto, currentUser, amountOfBagsOrderedMap, sumToPay, order, orderCertificates, userData);
 
-        PaymentRequestDto paymentRequestDto = formPaymentRequest(order.getId(), sumToPay);
-        String html = restClient.getDataFromFondy(paymentRequestDto);
-
-        Document doc = Jsoup.parse(html);
-
-        Elements links = doc.select("a[href]");
-        System.out.println(links.attr("href"));
         eventService.save(OrderHistory.ORDER_FORMED, OrderHistory.CLIENT, order);
-        if (sumToPay == 0) {
+        if (sumToPay == 0 || !dto.isShouldBePaid()) {
             return order.getId().toString();
         } else {
+            PaymentRequestDto paymentRequestDto = formPaymentRequest(order.getId(), sumToPay);
+            String html = restClient.getDataFromFondy(paymentRequestDto);
+
+            Document doc = Jsoup.parse(html);
+            Elements links = doc.select("a[href]");
+            System.out.println(links.attr("href"));
             return links.attr("href");
         }
     }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -150,6 +150,7 @@ public class ModelUtils {
             .orderComment("comment")
             .certificates(Collections.emptySet())
             .pointsToUse(700)
+            .shouldBePaid(true)
             .personalData(PersonalDataDto.builder()
                 .firstName("oleh")
                 .lastName("ivanov")


### PR DESCRIPTION
Refactored OrderResponseDto.java and all usages to add 1 boolean field, wich will be checked on step of choosing to return order id or fondy link.
Modified if return statement in the m.saveFullOrderToDB() to implement checking into project
[issue [#3498]](https://github.com/ita-social-projects/GreenCity/issues/3498)

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
