### PR TITLE
Сreate duplicate methods  for Ivano-Frankivsk

### DIFF
--- a/core/src/main/java/greencity/controller/ClientController.java
+++ b/core/src/main/java/greencity/controller/ClientController.java
@@ -110,6 +110,26 @@ public class ClientController {
     }
 
     /**
+     * Controller return link fondy payment. Version for Ivano-Frankivsk
+     *
+     * @return {@link OrderFondyClientDto} dto.
+     * @author Sihovskiy Rostyslav
+     */
+    @ApiOperation(value = "return the link for payment")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = HttpStatuses.OK, response = MakeOrderAgainDto.class),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+    })
+    @PostMapping("/processOrderFondyIF")
+    public ResponseEntity<FondyOrderResponse> processOrderFondyForIF(@Valid @RequestBody OrderFondyClientDto dto)
+        throws Exception {
+        return ResponseEntity.status(HttpStatus.OK).body(ubsClientService.processOrderFondyClientForIF(dto));
+    }
+
+    /**
      * Controller return link liqpay payment .
      *
      * @return {@link OrderLiqpayClienDto} dto.
@@ -127,6 +147,26 @@ public class ClientController {
     public ResponseEntity<LiqPayOrderResponse> processOrderLiqpay(@Valid @RequestBody OrderLiqpayClienDto dto)
         throws Exception {
         return ResponseEntity.status(HttpStatus.OK).body(ubsClientService.proccessOrderLiqpayClient(dto));
+    }
+
+    /**
+     * Controller return link liqpay payment . Version for Ivano-Frankivsk
+     *
+     * @return {@link OrderLiqpayClienDto} dto.
+     * @author Sihovskiy Rostyslav
+     */
+    @ApiOperation(value = "return the link for liqpay payment")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = HttpStatuses.OK, response = MakeOrderAgainDto.class),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+    })
+    @PostMapping("/processOrderLiqpayIF")
+    public ResponseEntity<LiqPayOrderResponse> processOrderLiqpayForIF(@Valid @RequestBody OrderLiqpayClienDto dto)
+        throws Exception {
+        return ResponseEntity.status(HttpStatus.OK).body(ubsClientService.proccessOrderLiqpayClientForIF(dto));
     }
 
     /**

--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -125,6 +125,27 @@ public class OrderController {
     }
 
     /**
+     * Controller saves all entered by user data to database.
+     *
+     * @param userUuid {@link UserVO} id.
+     * @param dto      {@link OrderResponseDto} order data.
+     * @return {@link HttpStatus}.
+     * @author Sihovskiy Rostyslav
+     */
+    @ApiOperation(value = "Process user order.")
+    @ApiResponses(value = {
+        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+    })
+    @PostMapping("/processOrderIF")
+    public ResponseEntity<FondyOrderResponse> processOrderForIF(
+        @ApiIgnore @CurrentUserUuid String userUuid,
+        @Valid @RequestBody OrderResponseDto dto) {
+        return ResponseEntity.status(HttpStatus.OK).body(ubsClientService.saveFullOrderToDBForIF(dto, userUuid));
+    }
+
+    /**
      * Controller checks if received data is valid and stores payment info if is.
      *
      * @param dto {@link PaymentResponseDto} - response order data.
@@ -141,6 +162,28 @@ public class OrderController {
         ubsClientService.validatePayment(dto);
         if (HttpStatus.OK.is2xxSuccessful()) {
             response.sendRedirect("https://ita-social-projects.github.io/GreenCityClient/#/ubs/confirm");
+        }
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /**
+     * Controller checks if received data is valid and stores payment info if is.
+     * Version for Ivano-Frankivsk.
+     *
+     * @param dto {@link PaymentResponseDto} - response order data.
+     * @return {@link HttpStatus} - http status .
+     */
+    @ApiOperation(value = "Receive payment from Fondy.")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = HttpStatuses.OK),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST)
+    })
+    @PostMapping("/receivePaymentIF")
+    public ResponseEntity<HttpStatus> receivePaymentForIF(
+        PaymentResponseDto dto, HttpServletResponse response) throws IOException {
+        ubsClientService.validatePayment(dto);
+        if (HttpStatus.OK.is2xxSuccessful()) {
+            response.sendRedirect("https://if-132.github.io/GreenCityClient/#/ubs/confirm");
         }
         return ResponseEntity.status(HttpStatus.OK).build();
     }
@@ -368,6 +411,29 @@ public class OrderController {
     }
 
     /**
+     * Controller saves all entered by user data to database from LiqPay. Version
+     * for Ivano-Frankivsk
+     *
+     * @param userUuid {@link UserVO} id.
+     * @param dto      {@link OrderResponseDto} order data.
+     * @return {@link LiqPayOrderResponse}.
+     * @author Sihovskiy Rostyslav
+     */
+    @ApiOperation(value = "Process user order.")
+    @ApiResponses(value = {
+        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+    })
+    @PostMapping("/processLiqPayOrderIF")
+    public ResponseEntity<LiqPayOrderResponse> processLiqPayOrderForIF(
+        @ApiIgnore @CurrentUserUuid String userUuid,
+        @Valid @RequestBody OrderResponseDto dto) {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ubsClientService.saveFullOrderToDBFromLiqPayForIF(dto, userUuid));
+    }
+
+    /**
      * Controller checks if received data is valid and stores payment info if is.
      *
      * @param dto {@link PaymentResponseDtoLiqPay} - response order data.
@@ -384,6 +450,28 @@ public class OrderController {
         ubsClientService.validateLiqPayPayment(dto);
         if (HttpStatus.OK.is2xxSuccessful()) {
             response.sendRedirect("https://ita-social-projects.github.io/GreenCityClient/#/ubs/confirm");
+        }
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /**
+     * Controller checks if received data is valid and stores payment info if is.
+     * Version for Ivano-Frankivsk
+     *
+     * @param dto {@link PaymentResponseDtoLiqPay} - response order data.
+     * @return {@link HttpStatus} - http status.
+     */
+    @ApiOperation(value = "Receive payment.")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = HttpStatuses.OK),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST)
+    })
+    @PostMapping(value = "/receiveLiqPayPaymentIF")
+    public ResponseEntity<HttpStatus> receiveLiqPayPaymentForIF(
+        PaymentResponseDtoLiqPay dto, HttpServletResponse response) throws IOException {
+        ubsClientService.validateLiqPayPayment(dto);
+        if (HttpStatus.OK.is2xxSuccessful()) {
+            response.sendRedirect("https://if-132.github.io/GreenCityClient/#/ubs/confirm");
         }
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/service-api/src/main/java/greencity/service/ubs/UBSClientService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSClientService.java
@@ -55,6 +55,17 @@ public interface UBSClientService {
     FondyOrderResponse saveFullOrderToDB(OrderResponseDto dto, String uuid);
 
     /**
+     * Methods saves all entered by user data to database. Version for
+     * Ivano-Frankivsk.
+     *
+     * @param dto  {@link OrderResponseDto} user entered data;
+     * @param uuid current {@link User}'s uuid;
+     * @return {@link PaymentRequestDto} which contains data to pay order out.
+     * @author Sihovskiy Rostyslav
+     */
+    FondyOrderResponse saveFullOrderToDBForIF(OrderResponseDto dto, String uuid);
+
+    /**
      * Method get status of order from db by id.
      *
      * @return - payment status
@@ -273,6 +284,17 @@ public interface UBSClientService {
     LiqPayOrderResponse saveFullOrderToDBFromLiqPay(OrderResponseDto dto, String uuid);
 
     /**
+     * Methods saves all entered by user data to database. Version for
+     * Ivano-Frankivsk
+     *
+     * @param dto  {@link OrderResponseDto} user entered data;
+     * @param uuid current {@link User}'s uuid;
+     * @return {@link LiqPayOrderResponse} order id and liqpay payment button.
+     * @author Sikhovskiy Rostyslav
+     */
+    LiqPayOrderResponse saveFullOrderToDBFromLiqPayForIF(OrderResponseDto dto, String uuid);
+
+    /**
      * Method validates received payment response.
      * 
      * @param dto {@link PaymentResponseDtoLiqPay}
@@ -314,10 +336,26 @@ public interface UBSClientService {
     FondyOrderResponse processOrderFondyClient(OrderFondyClientDto dto) throws Exception;
 
     /**
+     * Method return link with Fondy payment. Version for Ivano-Frankivsk.
+     *
+     * @param dto - current OrderFondyClientDto dto.
+     * @author Sihovskiy Rostyslav
+     */
+    FondyOrderResponse processOrderFondyClientForIF(OrderFondyClientDto dto) throws Exception;
+
+    /**
      * Method return link with liqpay payment .
      *
      * @param dto - current OrderLiqpayClientDto dto.
      * @author Max Boiarchuk
      */
     LiqPayOrderResponse proccessOrderLiqpayClient(OrderLiqpayClienDto dto) throws Exception;
+
+    /**
+     * Method return link with liqpay payment. Version for Ivano-Frankivsk.
+     *
+     * @param dto - current OrderLiqpayClientDto dto.
+     * @author Sikhovskiy Rostyslav
+     */
+    LiqPayOrderResponse proccessOrderLiqpayClientForIF(OrderLiqpayClienDto dto) throws Exception;
 }


### PR DESCRIPTION
Сreate duplicate methods for processing and redirecting Fondy and LiqPay payments for Ivano-Frankivsk
ClientController Endpoints:
 /processOrderFondyIF instead of /processOrderFondy
/processOrderLiqpayIF instead of /processOrderLiqpay

OrderController Endpoints:
/processOrderIF instead of /processOrder
/receivePaymentIF instead of /receivePayment
/processLiqPayOrderIF instead of /processLiqPayOrder
/receiveLiqPayPaymentIF instead of /receiveLiqPayPayment

