### PR TITLE
Fix history

### DIFF
--- a/service-api/src/main/java/greencity/dto/OrderDetailStatusRequestDto.java
+++ b/service-api/src/main/java/greencity/dto/OrderDetailStatusRequestDto.java
@@ -12,4 +12,5 @@ public class OrderDetailStatusRequestDto {
     String orderStatus;
     String orderPaymentStatus;
     String adminComment;
+    String cancellationComment;
 }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -624,8 +624,8 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                 || order.getOrderStatus() == OrderStatus.NOT_TAKEN_OUT) {
                 Long confirmWasteWas =
                     updateOrderRepository.getConfirmWaste(orderId, entry.getKey().longValue());
-                if (!entry.getValue().equals(confirmWasteWas)){
-                    Long confirmWaste = confirmWasteWas == null ? 0 :confirmWasteWas;
+                if (entry.getValue().longValue() != confirmWasteWas) {
+                    Long confirmWaste = confirmWasteWas == null ? 0 : confirmWasteWas;
                     if (countOfChanges == 0) {
                         values.append(OrderHistory.CHANGE_ORDER_DETAILS + " ");
                     }
@@ -648,13 +648,14 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                 || order.getOrderStatus() == OrderStatus.CANCELED) {
                 Long exporterWasteWas = updateOrderRepository.getExporterWaste(orderId,
                     entry.getKey().longValue());
-                if (!exporterWasteWas.equals(entry.getValue().longValue())) {
+                if (entry.getValue().longValue() != exporterWasteWas) {
+                    Long exporterWaste = exporterWasteWas == null ? 0 : exporterWasteWas;
                     if (countOfChanges == 0) {
                         values.append(OrderHistory.CHANGE_ORDER_DETAILS + " ");
                         countOfChanges++;
                     }
                     values.append(bagTranslation).append(" ").append(capacity).append(" л: ")
-                        .append(exporterWasteWas)
+                        .append(exporterWaste)
                         .append(" шт на ").append(entry.getValue()).append(" шт.");
                 }
             }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -624,13 +624,13 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                 || order.getOrderStatus() == OrderStatus.NOT_TAKEN_OUT) {
                 Long confirmWasteWas =
                     updateOrderRepository.getConfirmWaste(orderId, entry.getKey().longValue());
-                if (nonNull(confirmWasteWas)
-                    && !confirmWasteWas.equals(entry.getValue().longValue())) {
+                if (!entry.getValue().equals(confirmWasteWas)){
+                    Long confirmWaste = confirmWasteWas == null ? 0 :confirmWasteWas;
                     if (countOfChanges == 0) {
                         values.append(OrderHistory.CHANGE_ORDER_DETAILS + " ");
                     }
                     values.append(bagTranslation).append(" ").append(capacity).append(" л: ")
-                        .append(confirmWasteWas)
+                        .append(confirmWaste)
                         .append(" шт на ").append(entry.getValue()).append(" шт.");
                 }
             }
@@ -864,7 +864,8 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                         + order.getImageReasonNotTakingBags(),
                     currentUser.getRecipientName() + "  " + currentUser.getRecipientSurname(), order);
             } else if (order.getOrderStatus() == OrderStatus.CANCELED) {
-                eventService.save(OrderHistory.ORDER_CANCELLED + "  " + order.getCancellationComment(),
+                order.setCancellationComment(dto.getCancellationComment());
+                eventService.save(OrderHistory.ORDER_CANCELLED + "  " + dto.getCancellationComment(),
                     currentUser.getRecipientName() + "  " + currentUser.getRecipientSurname(), order);
             } else if (order.getOrderStatus() == OrderStatus.DONE) {
                 eventService.save(OrderHistory.ORDER_DONE,


### PR DESCRIPTION
Fixed next bugs with history
When u change confirmed wastes for the first time - changes are not saved to the history
When u change exported wastes - changes are never saved to the history
When u change status to canceled - u get null in value of order.getCancellationComment()