### PR TITLE
[UBS] Fixed bugs in order controller

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -147,7 +147,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 UBS_LINK + "/client/**")
             .hasAnyRole("USER", "ADMIN")
             .antMatchers(HttpMethod.DELETE,
-                UBS_LINK + "/userProfile/**")
+                UBS_LINK + "/userProfile/**",
+                UBS_LINK + "/**/delete-order-address")
             .hasAnyRole("USER", "ADMIN")
             .antMatchers(UBS_LINK + "/client/delete-order/{id}")
             .hasAnyRole("USER", "ADMIN")

--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -148,7 +148,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .hasAnyRole("USER", "ADMIN")
             .antMatchers(HttpMethod.DELETE,
                 UBS_LINK + "/userProfile/**",
-                UBS_LINK + "/**/delete-order-address")
+                UBS_LINK + "/order-addresses/**")
             .hasAnyRole("USER", "ADMIN")
             .antMatchers(UBS_LINK + "/client/delete-order/{id}")
             .hasAnyRole("USER", "ADMIN")

--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -199,7 +199,7 @@ public class OrderController {
         @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
         @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
-    @PostMapping("/{id}/delete-order-address")
+    @DeleteMapping("/{id}/delete-order-address")
     public ResponseEntity<OrderWithAddressesResponseDto> deleteOrderAddress(
         @Valid @PathVariable("id") Long id,
         @ApiIgnore @CurrentUserUuid String uuid) {

--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -199,7 +199,7 @@ public class OrderController {
         @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
         @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
-    @DeleteMapping("/{id}/delete-order-address")
+    @DeleteMapping("/order-addresses/{id}")
     public ResponseEntity<OrderWithAddressesResponseDto> deleteOrderAddress(
         @Valid @PathVariable("id") Long id,
         @ApiIgnore @CurrentUserUuid String uuid) {

--- a/core/src/test/java/greencity/controller/OrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/OrderControllerTest.java
@@ -263,7 +263,7 @@ class OrderControllerTest {
 
     @Test
     void deleteOrderAddressTest() throws Exception {
-        mockMvc.perform(post("/ubs" + "/{id}" + "/delete-order-address", 1L))
+        mockMvc.perform(delete("/ubs" + "/{id}" + "/delete-order-address", 1L))
             .andExpect(status().isOk());
     }
 

--- a/core/src/test/java/greencity/controller/OrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/OrderControllerTest.java
@@ -263,7 +263,7 @@ class OrderControllerTest {
 
     @Test
     void deleteOrderAddressTest() throws Exception {
-        mockMvc.perform(delete("/ubs" + "/{id}" + "/delete-order-address", 1L))
+        mockMvc.perform(delete("/ubs" + "/order-addresses" + "/{id}", 1L))
             .andExpect(status().isOk());
     }
 

--- a/dao/src/main/java/greencity/repository/PaymentRepository.java
+++ b/dao/src/main/java/greencity/repository/PaymentRepository.java
@@ -27,12 +27,12 @@ public interface PaymentRepository extends CrudRepository<Payment, Long> {
     void deletePaymentById(Long paymentId);
 
     /**
-     * This method find payment by order.
-     * 
+     * This method finds all payments by order.
+     *
      * @param order {@link Order}
-     * @return {@link Payment}
+     * @return {@link List} of {@link Payment}
      */
-    Payment findPaymentByOrder(Order order);
+    List<Payment> findAllByOrder(Order order);
 
     /**
      * This method find amount by orderId.

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -375,6 +375,9 @@ public class UBSClientServiceImpl implements UBSClientService {
     public OrderWithAddressesResponseDto deleteCurrentAddressForOrder(Long addressId, String uuid) {
         Address address = addressRepo.findById(addressId).orElseThrow(
             () -> new NotFoundOrderAddressException(ErrorMessage.NOT_FOUND_ADDRESS_ID_FOR_CURRENT_USER + addressId));
+        if (AddressStatus.DELETED.equals(address.getAddressStatus())) {
+            throw new NotFoundOrderAddressException(ErrorMessage.NOT_FOUND_ADDRESS_ID_FOR_CURRENT_USER + addressId);
+        }
         if (!address.getUser().equals(userRepository.findByUuid(uuid))) {
             throw new AccessDeniedException(CANNOT_DELETE_ADDRESS);
         }
@@ -1131,7 +1134,8 @@ public class UBSClientServiceImpl implements UBSClientService {
         if (map == null) {
             return null;
         }
-        Payment payment = paymentRepository.findPaymentByOrder(order);
+        List<Payment> payments = paymentRepository.findAllByOrder(order);
+        Payment payment = payments.get(payments.size() - 1);
         String status = (String) map.get("status");
         if (status.equals("success")) {
             payment.setResponseStatus(status);

--- a/service/src/test/java/greencity/service/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/UBSClientServiceImplTest.java
@@ -626,7 +626,6 @@ class UBSClientServiceImplTest {
         when(addressRepository.findAllByUserId(user.getId())).thenReturn(addresses);
         when(modelMapper.map(addresses.get(1), AddressDto.class)).thenReturn(addressDtos.get(1));
 
-        address.setAddressStatus(AddressStatus.DELETED);
         ubsService.deleteCurrentAddressForOrder(address.getId(), uuid);
         verify(addressRepository, times(1)).save(address);
     }
@@ -634,6 +633,15 @@ class UBSClientServiceImplTest {
     @Test
     void testDeleteUnexistingAddress() {
         when(addressRepository.findById(42L)).thenReturn(Optional.empty());
+        assertThrows(NotFoundOrderAddressException.class,
+            () -> ubsService.deleteCurrentAddressForOrder(42L, "35467585763t4sfgchjfuyetf"));
+    }
+
+    @Test
+    void testDeleteDeletedAddress() {
+        Address address = getTestAddresses(getTestUser()).get(0);
+        address.setAddressStatus(AddressStatus.DELETED);
+        when(addressRepository.findById(42L)).thenReturn(Optional.of(address));
         assertThrows(NotFoundOrderAddressException.class,
             () -> ubsService.deleteCurrentAddressForOrder(42L, "35467585763t4sfgchjfuyetf"));
     }


### PR DESCRIPTION
Fixed bugs specified in issues 3943, 3944.
Changed [/ubs/{id}/delete-order-address] HTTP method from POST to DELETE.
Fixed 
error 500 in [/ubs/getLiqPayStatus/{orderId}] when trying to get status for order with 2 or more payments.