### PR TITLE
Fix bugs with notification about unpaid order #3896, #3917

### DIFF
--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -74,8 +74,10 @@ public class NotificationServiceImpl implements NotificationService {
                 .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
                     order.getId().toString());
             if ((lastNotification.isEmpty()
-                || lastNotification.get().getNotificationTime().isBefore(LocalDateTime.now(clock).minusDays(7).plusSeconds(1)))
-                && order.getOrderDate().isAfter(LocalDateTime.now(clock).minusMonths(1).minusSeconds(1)) && order.getOrderDate().isBefore(LocalDateTime.now(clock).minusDays(3).plusSeconds(1))) {
+                || lastNotification.get().getNotificationTime()
+                    .isBefore(LocalDateTime.now(clock).minusDays(7).plusSeconds(1)))
+                && order.getOrderDate().isAfter(LocalDateTime.now(clock).minusMonths(1).minusSeconds(1))
+                && order.getOrderDate().isBefore(LocalDateTime.now(clock).minusDays(3).plusSeconds(1))) {
                 UserNotification userNotification = new UserNotification();
                 if (lastNotification.isPresent()) {
                     UserNotification oldNotification = lastNotification.get();

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -74,10 +74,13 @@ public class NotificationServiceImpl implements NotificationService {
                 .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
                     order.getId().toString());
             if ((lastNotification.isEmpty()
-                || lastNotification.get().getNotificationTime()
-                    .isBefore(LocalDateTime.now(clock).minusDays(7).plusSeconds(1)))
-                && order.getOrderDate().isAfter(LocalDateTime.now(clock).minusMonths(1).minusSeconds(1))
-                && order.getOrderDate().isBefore(LocalDateTime.now(clock).minusDays(3).plusSeconds(1))) {
+                || (lastNotification.get().getNotificationTime()
+                    .isBefore(LocalDateTime.now(clock).minusDays(7))
+                    || lastNotification.get().getNotificationTime().isEqual(LocalDateTime.now(clock).minusDays(7))))
+                && (order.getOrderDate().isAfter(LocalDateTime.now(clock).minusMonths(1))
+                    || order.getOrderDate().isEqual(LocalDateTime.now(clock).minusMonths(1)))
+                && (order.getOrderDate().isBefore(LocalDateTime.now(clock).minusDays(3))
+                    || order.getOrderDate().isEqual(LocalDateTime.now(clock).minusDays(3)))) {
                 UserNotification userNotification = new UserNotification();
                 if (lastNotification.isPresent()) {
                     UserNotification oldNotification = lastNotification.get();

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -74,8 +74,8 @@ public class NotificationServiceImpl implements NotificationService {
                 .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
                     order.getId().toString());
             if ((lastNotification.isEmpty()
-                || lastNotification.get().getNotificationTime().isBefore(LocalDateTime.now(clock).minusWeeks(1)))
-                && order.getOrderDate().isAfter(LocalDateTime.now(clock).minusMonths(1))) {
+                || lastNotification.get().getNotificationTime().isBefore(LocalDateTime.now(clock).minusDays(7).plusSeconds(1)))
+                && order.getOrderDate().isAfter(LocalDateTime.now(clock).minusMonths(1).minusSeconds(1)) && order.getOrderDate().isBefore(LocalDateTime.now(clock).minusDays(3).plusSeconds(1))) {
                 UserNotification userNotification = new UserNotification();
                 if (lastNotification.isPresent()) {
                     UserNotification oldNotification = lastNotification.get();

--- a/service/src/test/java/greencity/service/NotificationTemplateServiceImplTest.java
+++ b/service/src/test/java/greencity/service/NotificationTemplateServiceImplTest.java
@@ -97,13 +97,15 @@ class NotificationTemplateServiceImplTest {
 
         @Test
         void testNotifyUnpaidOrders() {
-            User user = User.builder().id(42L).build();
-            List<Order> orders = List.of(Order.builder().id(42L).user(user)
-                .orderPaymentStatus(OrderPaymentStatus.UNPAID)
-                .orderDate(LocalDateTime.now(fixedClock).minusMonths(1).plusDays(1)).build(),
-                Order.builder().id(50L).user(user)
-                    .orderPaymentStatus(OrderPaymentStatus.UNPAID)
-                    .orderDate(LocalDateTime.now(fixedClock).minusDays(9)).build());
+            List<Order> orders = List.of(Order.builder().id(1L).user(getUser()).orderPaymentStatus(OrderPaymentStatus.UNPAID)
+                            .orderDate(LocalDateTime.now(fixedClock).minusDays(3))
+                            .build(),
+                    Order.builder().id(2L).user(getUser())
+                            .orderPaymentStatus(OrderPaymentStatus.UNPAID)
+                            .orderDate(LocalDateTime.now(fixedClock).minusMonths(1)).build(),
+                    Order.builder().id(3L).user(getUser())
+                            .orderPaymentStatus(OrderPaymentStatus.UNPAID)
+                            .orderDate(LocalDateTime.now(fixedClock).minusDays(10)).build());
 
             when(orderRepository.findAllByOrderPaymentStatus(OrderPaymentStatus.UNPAID))
                 .thenReturn(orders);
@@ -112,23 +114,27 @@ class NotificationTemplateServiceImplTest {
                 .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
                     orders.get(0).getId().toString());
 
-            UserNotification secondOrderLastNotification = new UserNotification();
-            secondOrderLastNotification.setNotificationType(NotificationType.UNPAID_ORDER);
-            secondOrderLastNotification.setNotificationTime(LocalDateTime.now(fixedClock).minusDays(8));
+            doReturn(Optional.empty()).when(userNotificationRepository)
+                    .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
+                            orders.get(1).getId().toString());
 
-            doReturn(Optional.of(secondOrderLastNotification)).when(userNotificationRepository)
-                .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
-                    orders.get(1).getId().toString());
+            UserNotification thirdOrderLastNotification = new UserNotification();
+            thirdOrderLastNotification.setNotificationType(NotificationType.UNPAID_ORDER);
+            thirdOrderLastNotification.setNotificationTime(LocalDateTime.now(fixedClock).minusWeeks(1));
+
+            doReturn(Optional.of(thirdOrderLastNotification)).when(userNotificationRepository)
+                    .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
+                            orders.get(2).getId().toString());
 
             UserNotification created = new UserNotification();
             created.setNotificationType(NotificationType.UNPAID_ORDER);
             created.setNotificationTime(LocalDateTime.now(fixedClock));
-            created.setUser(orders.get(0).getUser());
-            created.setId(42L);
+            created.setUser(getUser());
+            created.setId(1L);
 
             when(userNotificationRepository.save(any())).thenReturn(created);
 
-            NotificationParameter createdNotificationParameter = NotificationParameter.builder().id(42L)
+            NotificationParameter createdNotificationParameter = NotificationParameter.builder().id(1L)
                 .userNotification(created).key("orderNumber")
                 .value(orders.get(0).getId().toString()).build();
 
@@ -138,8 +144,8 @@ class NotificationTemplateServiceImplTest {
 
             notificationService.notifyUnpaidOrders();
 
-            verify(notificationParameterRepository, times(2)).save(any());
-            verify(userNotificationRepository, times(2)).save(any());
+            verify(notificationParameterRepository, times(3)).save(any());
+            verify(userNotificationRepository, times(3)).save(any());
         }
 
         @Test

--- a/service/src/test/java/greencity/service/NotificationTemplateServiceImplTest.java
+++ b/service/src/test/java/greencity/service/NotificationTemplateServiceImplTest.java
@@ -97,15 +97,16 @@ class NotificationTemplateServiceImplTest {
 
         @Test
         void testNotifyUnpaidOrders() {
-            List<Order> orders = List.of(Order.builder().id(1L).user(getUser()).orderPaymentStatus(OrderPaymentStatus.UNPAID)
-                            .orderDate(LocalDateTime.now(fixedClock).minusDays(3))
-                            .build(),
-                    Order.builder().id(2L).user(getUser())
-                            .orderPaymentStatus(OrderPaymentStatus.UNPAID)
-                            .orderDate(LocalDateTime.now(fixedClock).minusMonths(1)).build(),
-                    Order.builder().id(3L).user(getUser())
-                            .orderPaymentStatus(OrderPaymentStatus.UNPAID)
-                            .orderDate(LocalDateTime.now(fixedClock).minusDays(10)).build());
+            List<Order> orders = List.of(
+                Order.builder().id(1L).user(getUser()).orderPaymentStatus(OrderPaymentStatus.UNPAID)
+                    .orderDate(LocalDateTime.now(fixedClock).minusDays(3))
+                    .build(),
+                Order.builder().id(2L).user(getUser())
+                    .orderPaymentStatus(OrderPaymentStatus.UNPAID)
+                    .orderDate(LocalDateTime.now(fixedClock).minusMonths(1)).build(),
+                Order.builder().id(3L).user(getUser())
+                    .orderPaymentStatus(OrderPaymentStatus.UNPAID)
+                    .orderDate(LocalDateTime.now(fixedClock).minusDays(10)).build());
 
             when(orderRepository.findAllByOrderPaymentStatus(OrderPaymentStatus.UNPAID))
                 .thenReturn(orders);
@@ -115,16 +116,16 @@ class NotificationTemplateServiceImplTest {
                     orders.get(0).getId().toString());
 
             doReturn(Optional.empty()).when(userNotificationRepository)
-                    .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
-                            orders.get(1).getId().toString());
+                .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
+                    orders.get(1).getId().toString());
 
             UserNotification thirdOrderLastNotification = new UserNotification();
             thirdOrderLastNotification.setNotificationType(NotificationType.UNPAID_ORDER);
             thirdOrderLastNotification.setNotificationTime(LocalDateTime.now(fixedClock).minusWeeks(1));
 
             doReturn(Optional.of(thirdOrderLastNotification)).when(userNotificationRepository)
-                    .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
-                            orders.get(2).getId().toString());
+                .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
+                    orders.get(2).getId().toString());
 
             UserNotification created = new UserNotification();
             created.setNotificationType(NotificationType.UNPAID_ORDER);


### PR DESCRIPTION
The messages about unpaid order are received every 7 days for a month after order was formed.
The user receives a message about unpaid order at 18:00 **on the third day** after order was formed. 