### PR TITLE
Delete_Certificate Controller

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -24,6 +24,7 @@ import greencity.dto.violation.AddingViolationsToUserDto;
 import greencity.dto.violation.UpdateViolationToUserDto;
 import greencity.dto.violation.ViolationDetailInfoDto;
 import greencity.dto.violation.ViolationsInfoDto;
+import greencity.entity.order.Certificate;
 import greencity.entity.parameters.CustomTableView;
 import greencity.filters.CertificateFilterCriteria;
 import greencity.filters.CertificatePage;
@@ -102,7 +103,7 @@ public class ManagementOrderController {
     }
 
     /**
-     * Controller getting all certificates with sorting possibility.
+     * Controller add certificate.
      *
      * @return httpStatus.
      * @author Nazar Struk
@@ -120,6 +121,29 @@ public class ManagementOrderController {
         @Valid @RequestBody CertificateDtoForAdding certificateDtoForAdding) {
         certificateService.addCertificate(certificateDtoForAdding);
         return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    /**
+     * Controller delete certificate.
+     *
+     * @param code {@link String}.
+     * @return {@link HttpStatus} - http status.
+     * @author Hlazova Nataliia
+     */
+
+    @ApiOperation("Delete Certificate")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = HttpStatuses.OK),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+    })
+    @DeleteMapping("/deleteCertificate/{code}")
+    public ResponseEntity<HttpStatus> deleteCertificate(
+        @Valid @PathVariable String code) {
+        certificateService.deleteCertificate(code);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     /**

--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -24,7 +24,6 @@ import greencity.dto.violation.AddingViolationsToUserDto;
 import greencity.dto.violation.UpdateViolationToUserDto;
 import greencity.dto.violation.ViolationDetailInfoDto;
 import greencity.dto.violation.ViolationsInfoDto;
-import greencity.entity.order.Certificate;
 import greencity.entity.parameters.CustomTableView;
 import greencity.filters.CertificateFilterCriteria;
 import greencity.filters.CertificatePage;

--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -136,8 +136,7 @@ public class ManagementOrderController {
         @ApiResponse(code = 200, message = HttpStatuses.OK),
         @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
         @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
-        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN)
     })
     @DeleteMapping("/deleteCertificate/{code}")
     public ResponseEntity<HttpStatus> deleteCertificate(

--- a/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
@@ -138,6 +138,15 @@ class ManagementOrderControllerTest {
     }
 
     @Test
+    void deleteCertificateTest() throws Exception {
+        doNothing().when(certificateService).deleteCertificate("1111-1234");
+
+        mockMvc.perform(delete(ubsLink + "/deleteCertificate" + "/" + "{code}", "1111-1234")
+            .principal(principal)).andExpect(status().isOk());
+        verify(certificateService, times(1)).deleteCertificate("1111-1234");
+    }
+
+    @Test
     void getAddressByOrder() throws Exception {
         this.mockMvc.perform(get(ubsLink + "/read-address-order" + "/{id}", 1L))
             .andExpect(status().isOk());

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -3,6 +3,7 @@ package greencity.constant;
 public final class ErrorMessage {
     public static final String CERTIFICATE_NOT_FOUND_BY_CODE = "Certificate does not exist by this code: ";
     public static final String CERTIFICATE_EXPIRED = "Certificate expired by this code: ";
+    public static final String CERTIFICATE_STATUS = "Certificate has status 'EXPIRED' or 'USED'";
     public static final String CERTIFICATE_IS_USED = "The certificate has been used before or is not activated."
         + " Certificate code: ";
     public static final String CERTIFICATE_IS_NOT_ACTIVATED = "The certificate is not activated yet:";

--- a/service-api/src/main/java/greencity/service/ubs/CertificateService.java
+++ b/service-api/src/main/java/greencity/service/ubs/CertificateService.java
@@ -15,6 +15,13 @@ public interface CertificateService {
     void addCertificate(CertificateDtoForAdding add);
 
     /**
+     * Method delete a certificates.
+     *
+     * @author Hlazova Nataliia
+     */
+    void deleteCertificate(String code);
+
+    /**
      * Method returns all certificates with filtering and sorting data.
      *
      * @return List of {@link greencity.entity.order.Certificate} lists.

--- a/service/src/main/java/greencity/service/ubs/CertificateServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/CertificateServiceImpl.java
@@ -5,7 +5,6 @@ import greencity.dto.certificate.CertificateDtoForAdding;
 import greencity.dto.certificate.CertificateDtoForSearching;
 import greencity.dto.pageble.PageableDto;
 import greencity.entity.enums.CertificateStatus;
-import greencity.entity.enums.MinAmountOfBag;
 import greencity.entity.order.Certificate;
 import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;

--- a/service/src/main/java/greencity/service/ubs/CertificateServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/CertificateServiceImpl.java
@@ -1,9 +1,14 @@
 package greencity.service.ubs;
 
+import greencity.constant.ErrorMessage;
 import greencity.dto.certificate.CertificateDtoForAdding;
 import greencity.dto.certificate.CertificateDtoForSearching;
 import greencity.dto.pageble.PageableDto;
+import greencity.entity.enums.CertificateStatus;
+import greencity.entity.enums.MinAmountOfBag;
 import greencity.entity.order.Certificate;
+import greencity.exceptions.BadRequestException;
+import greencity.exceptions.NotFoundException;
 import greencity.filters.CertificateFilterCriteria;
 import greencity.filters.CertificatePage;
 import greencity.repository.CertificateCriteriaRepo;
@@ -14,6 +19,8 @@ import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static greencity.constant.ErrorMessage.*;
 
 @org.springframework.stereotype.Service
 @RequiredArgsConstructor
@@ -26,6 +33,16 @@ public class CertificateServiceImpl implements CertificateService {
     public void addCertificate(CertificateDtoForAdding add) {
         Certificate certificate = modelMapper.map(add, Certificate.class);
         certificateRepository.save(certificate);
+    }
+
+    @Override
+    public void deleteCertificate(String code) {
+        Certificate certificate = certificateRepository.findById(code)
+                .orElseThrow(() -> new NotFoundException(CERTIFICATE_NOT_FOUND_BY_CODE + code));
+        if (certificate.getCertificateStatus().equals(CertificateStatus.EXPIRED) || certificate.getCertificateStatus().equals(CertificateStatus.USED)) {
+            throw new BadRequestException(ErrorMessage.CERTIFICATE_STATUS);
+        }
+        certificateRepository.delete(certificate);
     }
 
     @Override

--- a/service/src/main/java/greencity/service/ubs/CertificateServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/CertificateServiceImpl.java
@@ -38,8 +38,9 @@ public class CertificateServiceImpl implements CertificateService {
     @Override
     public void deleteCertificate(String code) {
         Certificate certificate = certificateRepository.findById(code)
-                .orElseThrow(() -> new NotFoundException(CERTIFICATE_NOT_FOUND_BY_CODE + code));
-        if (certificate.getCertificateStatus().equals(CertificateStatus.EXPIRED) || certificate.getCertificateStatus().equals(CertificateStatus.USED)) {
+            .orElseThrow(() -> new NotFoundException(CERTIFICATE_NOT_FOUND_BY_CODE + code));
+        if (certificate.getCertificateStatus().equals(CertificateStatus.EXPIRED)
+            || certificate.getCertificateStatus().equals(CertificateStatus.USED)) {
             throw new BadRequestException(ErrorMessage.CERTIFICATE_STATUS);
         }
         certificateRepository.delete(certificate);

--- a/service/src/main/java/greencity/service/ubs/CertificateServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/CertificateServiceImpl.java
@@ -39,8 +39,8 @@ public class CertificateServiceImpl implements CertificateService {
     public void deleteCertificate(String code) {
         Certificate certificate = certificateRepository.findById(code)
             .orElseThrow(() -> new NotFoundException(CERTIFICATE_NOT_FOUND_BY_CODE + code));
-        if (certificate.getCertificateStatus().equals(CertificateStatus.EXPIRED)
-            || certificate.getCertificateStatus().equals(CertificateStatus.USED)) {
+        if (CertificateStatus.EXPIRED.equals(certificate.getCertificateStatus())
+            || CertificateStatus.USED.equals(certificate.getCertificateStatus())) {
             throw new BadRequestException(ErrorMessage.CERTIFICATE_STATUS);
         }
         certificateRepository.delete(certificate);

--- a/service/src/test/java/greencity/service/CertificateServiceImplTest.java
+++ b/service/src/test/java/greencity/service/CertificateServiceImplTest.java
@@ -1,12 +1,16 @@
 package greencity.service;
 
 import greencity.dto.certificate.CertificateDtoForAdding;
+import greencity.entity.enums.CertificateStatus;
 import greencity.entity.order.Certificate;
+import greencity.exceptions.BadRequestException;
+import greencity.exceptions.NotFoundException;
 import greencity.filters.CertificateFilterCriteria;
 import greencity.filters.CertificatePage;
 import greencity.repository.CertificateCriteriaRepo;
 import greencity.repository.CertificateRepository;
 import greencity.service.ubs.CertificateServiceImpl;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -20,6 +24,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -46,6 +51,34 @@ class CertificateServiceImplTest {
         when(modelMapper.map(certificateDtoForAdding, Certificate.class)).thenReturn(certificate);
         certificateService.addCertificate(certificateDtoForAdding);
         verify(certificateRepository, times(1)).save(certificate);
+    }
+
+    @Test
+    void deleteCertificateTest() {
+        Certificate certificate = new Certificate();
+        certificate.setCode("1111-1234")
+            .setCertificateStatus(CertificateStatus.ACTIVE);
+        when(certificateRepository.findById("1111-1234")).thenReturn(Optional.of(certificate));
+        certificateService.deleteCertificate("1111-1234");
+        verify(certificateRepository, times(1)).delete(certificate);
+    }
+
+    @Test
+    void deleteCertificateNotFound() {
+        Assertions.assertThrows(NotFoundException.class, () -> {
+            certificateService.deleteCertificate("1111-1234");
+        });
+    }
+
+    @Test
+    void deleteCertificateBadRequest() {
+        Certificate certificate = new Certificate();
+        certificate.setCode("1111-1234")
+            .setCertificateStatus(CertificateStatus.EXPIRED);
+        when(certificateRepository.findById("1111-1234")).thenReturn(Optional.of(certificate));
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            certificateService.deleteCertificate("1111-1234");
+        });
     }
 
     @Test


### PR DESCRIPTION
A "deleteCertificate" controller has been created to delete the certificate on the [Admin page](https://ita-social-projects.github.io/GreenCityClient/#/ubs-admin/certificates).

We cannot delete controllers with the status 'USED' or 'EXPIRED' because it is required for the history.