### PR TITLE
Event history bug #4493

### DIFF
--- a/service/src/main/java/greencity/service/ubs/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/EventServiceImpl.java
@@ -38,6 +38,9 @@ public class EventServiceImpl implements EventService {
      * @author Yuriy Bahlay.
      */
     public void save(String eventName, String eventAuthor, Order order) {
+        if (eventName.isEmpty()) {
+            return;
+        }
         Event event = new Event();
         event.setEventDate(LocalDateTime.now());
         event.setEventName(eventName);

--- a/service/src/test/java/greencity/service/ubs/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/EventServiceImplTest.java
@@ -40,6 +40,13 @@ class EventServiceImplTest {
     }
 
     @Test
+    void saveEmptyEventTest() {
+        Order order = ModelUtils.getOrder();
+        eventService.save("", "admin", order);
+        verify(eventRepository, times(0)).save(any());
+    }
+
+    @Test
     void changesWithResponsibleEmployeeTest() {
         String existedCallManager = eventService.changesWithResponsibleEmployee(2L, Boolean.TRUE);
         String unExistedCallManager = eventService.changesWithResponsibleEmployee(2L, Boolean.FALSE);


### PR DESCRIPTION
[UBS Admin History] When the administrator changes the number of packages for one service, then returns the old value back and clicks "Зберегти" button, there is empty string event record. #4493