### PR TITLE
#4607 Fixed the 403 HTTP failure response in quantityUnreadenNotifications endpoint

### DIFF
--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -90,7 +90,6 @@ public class NotificationController {
         @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
         @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
-    @PreAuthorize("@preAuthorizer.hasAuthority('SEE_MESSAGES_PAGE', authentication)")
     @GetMapping(value = "quantityUnreadenNotifications")
     public ResponseEntity<Long> getAllUnreadenNotificationsForCurrentUser(
         @ApiIgnore @CurrentUserUuid String userUuid) {


### PR DESCRIPTION
Oleh Vatuliak
issue https://github.com/ita-social-projects/GreenCity/issues/4607

Summary of issue
Fixed the 403 HTTP failure response for https://greencity-ubs.testgreencity.ga/notifications/quantityUnreadenNotifications

Summary of change
Removed redundant PreAuthorize annotation
