### PR TITLE
Bug/#4732-ubs-admin-history-fix-403-error

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -85,6 +85,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 UBS_MANAG_LINK + "/get-data-for-order/{id}",
                 UBS_MANAG_LINK + "/violation-details/{id}",
                 UBS_MANAG_LINK + "/{id}/ordersAll",
+                UBS_LINK + "/order_history/{orderId}",
                 ADMIN_EMPL_LINK + "/**",
                 ADMIN_LINK + "/notification/get-all-templates",
                 ADMIN_LINK + "/notification/get-template/{id}",


### PR DESCRIPTION
fixed 403 error when admin try open an appropriate order 