### PR TITLE
 Bug fix 500 error from /update-order-detail-status/{id} endpoint when try to change address

### DIFF
--- a/core/src/test/java/greencity/repository/AddressRepositoryTest.java
+++ b/core/src/test/java/greencity/repository/AddressRepositoryTest.java
@@ -72,7 +72,8 @@ class AddressRepositoryTest extends IntegrationTestBase {
     void getAddressByOrderId() {
 
         Address address = ModelUtils.getAddress();
-        Address actual = addressRepository.getAddressByOrderId(1L);
+        // Address actual = addressRepository.getAddressByOrderId(1L);
+        Address actual = addressRepository.findById(1L).orElseThrow();
 
         Assertions.assertEquals(Optional.of(address.getUser().getId()), Optional.of(actual.getUser().getId()));
         Assertions.assertEquals(Optional.of(address.getCoordinates()), Optional.of(actual.getCoordinates()));

--- a/core/src/test/java/greencity/repository/AddressRepositoryTest.java
+++ b/core/src/test/java/greencity/repository/AddressRepositoryTest.java
@@ -72,7 +72,6 @@ class AddressRepositoryTest extends IntegrationTestBase {
     void getAddressByOrderId() {
 
         Address address = ModelUtils.getAddress();
-        // Address actual = addressRepository.getAddressByOrderId(1L);
         Address actual = addressRepository.findById(1L).orElseThrow();
 
         Assertions.assertEquals(Optional.of(address.getUser().getId()), Optional.of(actual.getUser().getId()));

--- a/dao/src/main/java/greencity/repository/AddressRepository.java
+++ b/dao/src/main/java/greencity/repository/AddressRepository.java
@@ -63,15 +63,4 @@ public interface AddressRepository extends CrudRepository<Address, Long> {
     @Query(value = "SELECT * FROM address a"
         + " WHERE user_id =:userId AND a.status != 'DELETED'", nativeQuery = true)
     List<Address> findAllNonDeletedAddressesByUserId(Long userId);
-
-    /**
-     * Method return of {@link Address}addresses for current order.
-     *
-     * @return {@link Address}.
-     */
-    @Query(value = "SELECT * FROM orders as o "
-        + " JOIN ubs_user as ubs ON o.ubs_user_id = ubs.id "
-        + " JOIN address as addr ON addr.id = ubs.address_id "
-        + " WHERE o.id = :orderId", nativeQuery = true)
-    Address getAddressByOrderId(Long orderId);
 }

--- a/dao/src/main/java/greencity/repository/OrderAddressRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderAddressRepository.java
@@ -2,8 +2,19 @@ package greencity.repository;
 
 import greencity.entity.user.ubs.OrderAddress;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderAddressRepository extends JpaRepository<OrderAddress, Long> {
+    /**
+     * Method return of {@link OrderAddress} address for current order.
+     *
+     * @return {@link OrderAddress}.
+     */
+    @Query(value = "SELECT * FROM orders as o "
+        + " JOIN ubs_user as ubs ON o.ubs_user_id = ubs.id "
+        + " JOIN address as addr ON addr.id = ubs.address_id "
+        + " WHERE o.id = :orderId", nativeQuery = true)
+    OrderAddress getOrderAddressByOrderId(Long orderId);
 }

--- a/service/src/main/java/greencity/mapping/order/OrderAddressDtoUpdateMapper.java
+++ b/service/src/main/java/greencity/mapping/order/OrderAddressDtoUpdateMapper.java
@@ -1,14 +1,14 @@
 package greencity.mapping.order;
 
 import greencity.dto.order.OrderAddressDtoResponse;
-import greencity.entity.user.ubs.Address;
+import greencity.entity.user.ubs.OrderAddress;
 import org.modelmapper.AbstractConverter;
 import org.springframework.stereotype.Component;
 
 @Component
-public class OrderAddressDtoUpdateMapper extends AbstractConverter<Address, OrderAddressDtoResponse> {
+public class OrderAddressDtoUpdateMapper extends AbstractConverter<OrderAddress, OrderAddressDtoResponse> {
     @Override
-    protected OrderAddressDtoResponse convert(Address dtoUpdate) {
+    protected OrderAddressDtoResponse convert(OrderAddress dtoUpdate) {
         return OrderAddressDtoResponse.builder()
             .district(dtoUpdate.getDistrict())
             .districtEng(dtoUpdate.getDistrictEn())

--- a/service/src/main/java/greencity/mapping/order/ReadAddressByOrderDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/order/ReadAddressByOrderDtoMapper.java
@@ -2,6 +2,7 @@ package greencity.mapping.order;
 
 import greencity.dto.order.ReadAddressByOrderDto;
 import greencity.entity.user.ubs.Address;
+import greencity.entity.user.ubs.OrderAddress;
 import org.modelmapper.AbstractConverter;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Component;
@@ -11,14 +12,14 @@ import org.springframework.stereotype.Component;
  * {@link ReadAddressByOrderDto}.
  */
 @Component
-public class ReadAddressByOrderDtoMapper extends AbstractConverter<Address, ReadAddressByOrderDto> {
+public class ReadAddressByOrderDtoMapper extends AbstractConverter<OrderAddress, ReadAddressByOrderDto> {
     /**
-     * Method convert {@link Address} to {@link ReadAddressByOrderDto}.
+     * Method convert {@link OrderAddress} to {@link ReadAddressByOrderDto}.
      *
      * @return {@link ReadAddressByOrderDto}
      */
     @Override
-    protected ReadAddressByOrderDto convert(Address address) {
+    protected ReadAddressByOrderDto convert(OrderAddress address) {
         return ReadAddressByOrderDto.builder()
             .district(address.getDistrict())
             .entranceNumber(address.getEntranceNumber())

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -71,6 +71,7 @@ import static java.util.Objects.nonNull;
 public class UBSManagementServiceImpl implements UBSManagementService {
     private final AddressRepository addressRepository;
     private final OrderRepository orderRepository;
+    private final OrderAddressRepository orderAddressRepository;
     private final ModelMapper modelMapper;
     private final CertificateRepository certificateRepository;
     private final UserRemoteClient userRemoteClient;
@@ -301,9 +302,9 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         String email) {
         Order order = orderRepository.findById(orderId)
             .orElseThrow(() -> new NotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST));
-        Optional<Address> addressForAdminPage = addressRepository.findById(dtoUpdate.getAddressId());
+        Optional<OrderAddress> addressForAdminPage = orderAddressRepository.findById(dtoUpdate.getAddressId());
         if (addressForAdminPage.isPresent()) {
-            addressRepository.save(updateAddressOrderInfo(addressForAdminPage.get(), dtoUpdate));
+            orderAddressRepository.save(updateAddressOrderInfo(addressForAdminPage.get(), dtoUpdate));
             eventService.saveEvent(OrderHistory.WASTE_REMOVAL_ADDRESS_CHANGE, email, order);
             return addressForAdminPage.map(value -> modelMapper.map(value, OrderAddressDtoResponse.class));
         } else {
@@ -975,7 +976,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         dto.setOrderId(order.getId());
     }
 
-    private Address updateAddressOrderInfo(Address address, OrderAddressExportDetailsDtoUpdate dto) {
+    private OrderAddress updateAddressOrderInfo(OrderAddress address, OrderAddressExportDetailsDtoUpdate dto) {
         Optional.ofNullable(dto.getAddressCity()).ifPresent(address::setCity);
         Optional.ofNullable(dto.getAddressCityEng()).ifPresent(address::setCityEn);
         Optional.ofNullable(dto.getAddressRegion()).ifPresent(address::setRegion);

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -291,7 +291,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         if (orderRepository.findById(orderId).isEmpty()) {
             throw new NotFoundException(NOT_FOUND_ADDRESS_BY_ORDER_ID + orderId);
         }
-        return modelMapper.map(addressRepository.getAddressByOrderId(orderId), ReadAddressByOrderDto.class);
+        return modelMapper.map(orderAddressRepository.getOrderAddressByOrderId(orderId), ReadAddressByOrderDto.class);
     }
 
     /**

--- a/service/src/test/java/greencity/mapping/order/OrderAddressDtoUpdateMapperTest.java
+++ b/service/src/test/java/greencity/mapping/order/OrderAddressDtoUpdateMapperTest.java
@@ -2,8 +2,7 @@ package greencity.mapping.order;
 
 import greencity.ModelUtils;
 import greencity.dto.order.OrderAddressDtoResponse;
-import greencity.entity.user.ubs.Address;
-import greencity.mapping.order.OrderAddressDtoUpdateMapper;
+import greencity.entity.user.ubs.OrderAddress;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,7 +18,7 @@ class OrderAddressDtoUpdateMapperTest {
     @Test
     void convert() {
 
-        Address address = ModelUtils.getAddress();
+        OrderAddress address = ModelUtils.getOrderAddress();
 
         OrderAddressDtoResponse expected = OrderAddressDtoResponse.builder()
             .district("Distinct")

--- a/service/src/test/java/greencity/mapping/order/ReadAddressByOrderDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/order/ReadAddressByOrderDtoMapperTest.java
@@ -2,8 +2,7 @@ package greencity.mapping.order;
 
 import greencity.ModelUtils;
 import greencity.dto.order.ReadAddressByOrderDto;
-import greencity.entity.user.ubs.Address;
-import greencity.mapping.order.ReadAddressByOrderDtoMapper;
+import greencity.entity.user.ubs.OrderAddress;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,7 +17,7 @@ class ReadAddressByOrderDtoMapperTest {
 
     @Test
     void convert() {
-        Address address = ModelUtils.getAddress();
+        OrderAddress address = ModelUtils.getOrderAddress();
         ReadAddressByOrderDto expected = ReadAddressByOrderDto.builder()
             .district(address.getDistrict())
             .entranceNumber(address.getEntranceNumber())
@@ -27,7 +26,7 @@ class ReadAddressByOrderDtoMapperTest {
             .houseNumber(address.getHouseNumber())
             .comment(address.getAddressComment())
             .build();
-        ReadAddressByOrderDto actual = readAddressByOrderDtoMapper.convert(ModelUtils.getAddress());
+        ReadAddressByOrderDto actual = readAddressByOrderDtoMapper.convert(ModelUtils.getOrderAddress());
 
         assertEquals(expected, actual);
     }


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)

## Code reviewers

- NKorzhik
- Markiro1
- juseti
- sergoliarnik
- JoseCaste

## Summary of issue

500 error when try to update address for order by /update-order-detail-status/{id} endpoint

## Summary of change

1) added OrderAddressRepository field in UBSManagementServiceImpl
2) changed method updateAddress() in UBSManagementServiceImpl. Not it`s working with OrderAddress entity instead Address
3) changed method convert() in OrderAddressDtoUpdateMapper to convert in OrderAddressDtoResponse from OrderAddress                         
4) added mock of OrderAddressRepository in UBSManagementServiceImplTest
5) deleted mock of AddressRepository in UBSManagementServiceImplTest
6) changed test for OrderAddressDtoUpdateMapperTest
7) changed method testUpdateAddress() and updateOrderAdminPageInfoTest() in UBSManagementServiceImplTest
8) added method getOrderAddressByOrderId() in OrderAddressRepository
9) deleted method getAddressByOrderId() in AddressRepository
10) changed integration test method getAddressByOrderId() in AddressRepositoryTest
11) changed ReadAddressByOrderDtoMapper class and method convert(). Now it is working with OrderAddress entity instead Address  
12) changed method convert() in ReadAddressByOrderDtoMapperTest
13) changed method getAddressByOrderId() in UBSManagementServiceImpl to use OrderAddressRepository instead AddressRepository

## Testing approach

send request to /update-order-detail-status/{id} endpoint for any existing order id and try to change address parameteress 

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
