### PR TITLE
#5036 fix @ToString and @EqualsAndHashCode in TariffsInfo

### DIFF
--- a/dao/src/main/java/greencity/entity/order/TariffsInfo.java
+++ b/dao/src/main/java/greencity/entity/order/TariffsInfo.java
@@ -18,8 +18,8 @@ import java.util.Set;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString(exclude = {"services", "bags", "receivingStationList", "tariffLocations", "orders", "employees", "creator"})
-@EqualsAndHashCode(exclude = {"services", "bags", "receivingStationList", "tariffLocations", "orders", "employees",
+@ToString(exclude = {"service", "bags", "receivingStationList", "tariffLocations", "orders", "employees", "creator"})
+@EqualsAndHashCode(exclude = {"service", "bags", "receivingStationList", "tariffLocations", "orders", "employees",
     "courier", "creator"})
 
 public class TariffsInfo {


### PR DESCRIPTION
Board with tickets

* [Main ticket](https://github.com/ita-social-projects/GreenCity/issues/5036)


## Summary of issue

The "Error mapping" error was thrown, Because of the incorrectly spelled field name in @tostring and @EqualsAndHashCode.
Need to replace "services" with "service".

## Summary of change

"service" fields changed to "service".
The error is resolved and no exception is thrown.

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
