### PR TITLE
fix get-data-for-order #4944

### DIFF
--- a/dao/src/main/java/greencity/repository/ServiceRepository.java
+++ b/dao/src/main/java/greencity/repository/ServiceRepository.java
@@ -25,16 +25,4 @@ public interface ServiceRepository extends JpaRepository<Service, Long> {
      * @author Julia Seti
      */
     Optional<Service> findServiceByTariffsInfoId(Long tariffId);
-
-    /**
-     * Method that return sum of full price by courier id.
-     *
-     * @param courierId {@link Long}
-     * @return {@link Integer}
-     * @author Maksym Kuzbyt
-     */
-    @Query(nativeQuery = true,
-        value = "select sum(full_price) from service s "
-            + "where s.courier_id = :courierId ")
-    Integer findFullPriceByCourierId(@Param("courierId") Long courierId);
 }

--- a/dao/src/main/java/greencity/repository/ServiceRepository.java
+++ b/dao/src/main/java/greencity/repository/ServiceRepository.java
@@ -2,21 +2,10 @@ package greencity.repository;
 
 import greencity.entity.order.Service;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ServiceRepository extends JpaRepository<Service, Long> {
-    /**
-     * Method that return service by id.
-     *
-     * @param id {@link Long}
-     * @return {@link Service}
-     * @author Vadym Makitra
-     */
-    Optional<Service> findServiceById(Long id);
-
     /**
      * Method that return service by TariffsInfo id.
      *
@@ -25,16 +14,4 @@ public interface ServiceRepository extends JpaRepository<Service, Long> {
      * @author Julia Seti
      */
     Optional<Service> findServiceByTariffsInfoId(Long tariffId);
-
-    /**
-     * Method that return sum of full price by courier id.
-     *
-     * @param courierId {@link Long}
-     * @return {@link Integer}
-     * @author Maksym Kuzbyt
-     */
-    @Query(nativeQuery = true,
-        value = "select sum(full_price) from service s "
-            + "where s.courier_id = :courierId ")
-    Integer findFullPriceByCourierId(@Param("courierId") Long courierId);
 }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -335,7 +335,9 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         CounterOrderDetailsDto prices = getPriceDetails(orderId);
         List<BagInfoDto> bagInfo = new ArrayList<>();
         List<Bag> bags = bagRepository.findAll();
-        Integer fullPrice = serviceRepository.findFullPriceByCourierId(order.getTariffsInfo().getCourier().getId());
+        Integer servicePrice = serviceRepository.findServiceByTariffsInfoId(order.getTariffsInfo().getId())
+            .map(it -> it.getPrice())
+            .orElse(0);
         OrderAddress address = order.getUbsUser().getAddress();
         bags.forEach(bag -> {
             BagInfoDto bagInfoDto = modelMapper.map(bag, BagInfoDto.class);
@@ -366,7 +368,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             .exportDetailsDto(getOrderExportDetails(orderId))
             .employeePositionDtoRequest(getAllEmployeesByPosition(orderId, email))
             .comment(order.getComment())
-            .courierPricePerPackage(fullPrice)
+            .courierPricePerPackage(servicePrice)
             .courierInfo(modelMapper.map(order.getTariffsInfo(), CourierInfoDto.class))
             .build();
     }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -3359,6 +3359,7 @@ public class ModelUtils {
                 .build()))
             .receivingStationList(Set.of(getReceivingStation()))
             .courier(getCourier())
+            .service(getService())
             .build();
     }
 

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -1519,6 +1519,7 @@ class UBSManagementServiceImplTest {
         when(certificateRepository.findCertificate(1L)).thenReturn(ModelUtils.getCertificateList());
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(getOrderForGetOrderStatusData2Test()));
         when(bagRepository.findAll()).thenReturn(ModelUtils.getBag2list());
+        when(serviceRepository.findServiceByTariffsInfoId(1L)).thenReturn(Optional.of(getService()));
         when(modelMapper.map(ModelUtils.getBaglist().get(0), BagInfoDto.class)).thenReturn(bagInfoDto);
         when(orderStatusTranslationRepository.getOrderStatusTranslationById(6L))
             .thenReturn(Optional.ofNullable(getStatusTranslation()));
@@ -1535,6 +1536,7 @@ class UBSManagementServiceImplTest {
         verify(certificateRepository).findCertificate(1L);
         verify(orderRepository, times(5)).findById(1L);
         verify(bagRepository).findAll();
+        verify(serviceRepository).findServiceByTariffsInfoId(1L);
         verify(modelMapper).map(ModelUtils.getBaglist().get(0), BagInfoDto.class);
         verify(orderStatusTranslationRepository).getOrderStatusTranslationById(6L);
         verify(orderPaymentStatusTranslationRepository).getById(1L);
@@ -1555,6 +1557,7 @@ class UBSManagementServiceImplTest {
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(getOrderForGetOrderStatusData2Test()));
         when(bagRepository.findAll()).thenReturn(ModelUtils.getBag2list());
+        when(serviceRepository.findServiceByTariffsInfoId(1L)).thenReturn(Optional.empty());
         when(modelMapper.map(ModelUtils.getBaglist().get(0), BagInfoDto.class)).thenReturn(bagInfoDto);
         when(orderStatusTranslationRepository.getOrderStatusTranslationById(6L))
             .thenReturn(Optional.ofNullable(getStatusTranslation()));
@@ -1573,6 +1576,7 @@ class UBSManagementServiceImplTest {
         verify(certificateRepository).findCertificate(1L);
         verify(orderRepository, times(5)).findById(1L);
         verify(bagRepository).findAll();
+        verify(serviceRepository).findServiceByTariffsInfoId(1L);
         verify(modelMapper).map(ModelUtils.getBaglist().get(0), BagInfoDto.class);
         verify(orderStatusTranslationRepository).getOrderStatusTranslationById(6L);
         verify(orderPaymentStatusTranslationRepository).getById(1L);
@@ -1593,7 +1597,7 @@ class UBSManagementServiceImplTest {
         when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(bagRepository.findBagByOrderId(1L)).thenReturn(ModelUtils.getBaglist());
-
+        when(serviceRepository.findServiceByTariffsInfoId(1L)).thenReturn(Optional.of(getService()));
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(getOrderForGetOrderStatusData2Test()));
         when(bagRepository.findAll()).thenReturn(ModelUtils.getBag2list());
         when(modelMapper.map(ModelUtils.getBaglist().get(0), BagInfoDto.class)).thenReturn(bagInfoDto);
@@ -1611,6 +1615,7 @@ class UBSManagementServiceImplTest {
         verify(bagRepository).findBagByOrderId(1L);
         verify(orderRepository, times(5)).findById(1L);
         verify(bagRepository).findAll();
+        verify(serviceRepository).findServiceByTariffsInfoId(1L);
         verify(modelMapper).map(ModelUtils.getBaglist().get(0), BagInfoDto.class);
         verify(orderStatusTranslationRepository).getOrderStatusTranslationById(6L);
         verify(orderPaymentStatusTranslationRepository).getById(1L);
@@ -1631,7 +1636,7 @@ class UBSManagementServiceImplTest {
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(bagRepository.findBagByOrderId(1L)).thenReturn(ModelUtils.getBaglist());
         when(certificateRepository.findCertificate(1L)).thenReturn(ModelUtils.getCertificateList());
-
+        when(serviceRepository.findServiceByTariffsInfoId(1L)).thenReturn(Optional.of(getService()));
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(getOrderForGetOrderStatusData2Test()));
         when(bagRepository.findAll()).thenReturn(ModelUtils.getBag2list());
         when(modelMapper.map(ModelUtils.getBaglist().get(0), BagInfoDto.class)).thenReturn(bagInfoDto);


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)

## Link to issue

https://github.com/ita-social-projects/GreenCity/issues/4944

## Summary of change

1. Fixed OrderStatusPageDto.courierPricePerPackage getting in getOrderStatusData() at UBSManagementServiceImpl.class.
2. Changed tests for getOrderStatusData() at UBSManagementServiceImplTest.class.
5. Deleted findFullPriceByCourierId() at  ServiceRepository.

## Testing approach

Tests running in case of existence and absence of service.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
