### PR TITLE
refactoring getService #4944

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -129,8 +129,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 SUPER_ADMIN_LINK + "/update-courier",
                 SUPER_ADMIN_LINK + "/update-receiving-station",
                 SUPER_ADMIN_LINK + "/editTariffService/{id}",
-                SUPER_ADMIN_LINK + "/**",
-                "/ubs/superAdmin/editService/{id}")
+                SUPER_ADMIN_LINK + "/editService",
+                SUPER_ADMIN_LINK + "/**")
             .hasAnyRole(ADMIN, UBS_EMPLOYEE)
             .antMatchers(HttpMethod.DELETE,
                 ADMIN_EMPL_LINK + "/**",

--- a/core/src/main/java/greencity/controller/SuperAdminController.java
+++ b/core/src/main/java/greencity/controller/SuperAdminController.java
@@ -187,7 +187,7 @@ class SuperAdminController {
     })
     @PreAuthorize("@preAuthorizer.hasAuthority('SEE_TARIFFS', authentication)")
     @GetMapping("/{tariffId}/getService")
-    public ResponseEntity<ServiceDto> getService(
+    public ResponseEntity<List<ServiceDto>> getService(
         @Valid @PathVariable Long tariffId) {
         return ResponseEntity.status(HttpStatus.OK).body(superAdminService.getService(tariffId));
     }

--- a/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
+++ b/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
@@ -237,24 +237,6 @@ class SuperAdminControllerTest {
     }
 
     @Test
-    void getServiceIfServiceNotFoundException() throws Exception {
-        long tariffId = 1L;
-        Mockito.when(superAdminService.getService(tariffId))
-            .thenThrow(new NotFoundException(ErrorMessage.SERVICE_IS_NOT_FOUND_BY_TARIFF_ID + tariffId));
-
-        mockMvc.perform(get(ubsLink + "/" + tariffId + "/getService")
-            .principal(principal)
-            .param("tariffId", "1L"))
-            .andExpect(status().isNotFound())
-            .andExpect(result -> assertTrue(result.getResolvedException() instanceof NotFoundException))
-            .andExpect(result -> assertEquals(ErrorMessage.SERVICE_IS_NOT_FOUND_BY_TARIFF_ID + tariffId,
-                result.getResolvedException().getMessage()));
-
-        Mockito.verify(superAdminService).getService(tariffId);
-        Mockito.verifyNoMoreInteractions(superAdminService);
-    }
-
-    @Test
     void getServiceIfTariffNotFoundException() throws Exception {
         long tariffId = 1L;
         Mockito.when(superAdminService.getService(tariffId))

--- a/dao/src/main/java/greencity/entity/user/employee/Employee.java
+++ b/dao/src/main/java/greencity/entity/user/employee/Employee.java
@@ -17,7 +17,8 @@ import java.util.Set;
 @Setter
 @Builder
 @Entity
-@EqualsAndHashCode(exclude = {"employeePosition", "attachedOrders", "employeeOrderPositions", "orders", "tariffs"})
+@EqualsAndHashCode(exclude = {"employeePosition", "attachedOrders", "employeeOrderPositions", "orders", "tariffs",
+    "createdServices", "editedServices"})
 @Table(name = "employees")
 public class Employee {
     @Id

--- a/service-api/src/main/java/greencity/service/SuperAdminService.java
+++ b/service-api/src/main/java/greencity/service/SuperAdminService.java
@@ -74,7 +74,7 @@ public interface SuperAdminService {
      * @author Vadym Makitra
      * @author Julia Seti
      */
-    ServiceDto getService(long tariffId);
+    List<ServiceDto> getService(long tariffId);
 
     /**
      * Method for delete service by id.

--- a/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
@@ -65,12 +65,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @org.springframework.stereotype.Service
@@ -206,10 +201,10 @@ public class SuperAdminServiceImpl implements SuperAdminService {
     }
 
     @Override
-    public ServiceDto getService(long tariffId) {
+    public List<ServiceDto> getService(long tariffId) {
         return getServiceByTariffsInfoId(tariffId)
-            .map(it -> modelMapper.map(it, ServiceDto.class))
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.SERVICE_IS_NOT_FOUND_BY_TARIFF_ID + tariffId));
+            .map(it -> List.of(modelMapper.map(it, ServiceDto.class)))
+            .orElse(Collections.emptyList());
     }
 
     @Override

--- a/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
@@ -265,23 +265,11 @@ class SuperAdminServiceImplTest {
         when(serviceRepository.findServiceByTariffsInfoId(1L)).thenReturn(Optional.of(service));
         when(modelMapper.map(service, ServiceDto.class)).thenReturn(serviceDto);
 
-        assertEquals(serviceDto, superAdminService.getService(1L));
+        assertEquals(List.of(serviceDto), superAdminService.getService(1L));
 
         verify(tariffsInfoRepository).existsById(1L);
         verify(serviceRepository).findServiceByTariffsInfoId(1L);
         verify(modelMapper).map(service, ServiceDto.class);
-    }
-
-    @Test
-    void getServiceThrowServiceNotFoundException() {
-        when(tariffsInfoRepository.existsById(1L)).thenReturn(true);
-        when(serviceRepository.findServiceByTariffsInfoId(1L)).thenReturn(Optional.empty());
-
-        assertThrows(NotFoundException.class,
-            () -> superAdminService.getService(1L));
-
-        verify(tariffsInfoRepository).existsById(1L);
-        verify(serviceRepository).findServiceByTariffsInfoId(1L);
     }
 
     @Test


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)

## Link to issue

https://github.com/ita-social-projects/GreenCity/issues/4944

## Summary of change

1. Deleted throw NotFoundException at getService() in SuperAdminServiceImpl.
2. Changed getService() return type from ServiceDto to List<ServiceDto> at SuperAdminService, SuperAdminServiceImpl and SuperAdminController.
3. Changed tests at SuperAdminControllerTest and  SuperAdminServiceImplTest.
4. Added to @EqualsAndHashCode exclud = {"createdServices", "editedServices"} at Employee.class.

## Testing approach

Running tests with different params.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
