### PR TITLE
GreenCityUBS bug in saving events 

### DIFF
--- a/dao/src/main/java/greencity/repository/OrderDetailRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderDetailRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UpdateOrderDetailRepository extends JpaRepository<Order, Integer> {
+public interface OrderDetailRepository extends JpaRepository<Order, Integer> {
     /**
      * Method for update Exported value.
      *

--- a/dao/src/main/java/greencity/repository/UpdateOrderDetailRepository.java
+++ b/dao/src/main/java/greencity/repository/UpdateOrderDetailRepository.java
@@ -21,6 +21,18 @@ public interface UpdateOrderDetailRepository extends JpaRepository<Order, Intege
     void updateExporter(Integer valueExported, Long orderId, Long bagId);
 
     /**
+     * Method for get Amount value.
+     *
+     * @param orderId order id {@link Long}
+     * @param bagId   bag id {@link Long}
+     * @author Lilia Mokhnatska
+     */
+
+    @Query(value = "SELECT AMOUNT FROM ORDER_BAG_MAPPING "
+        + "WHERE ORDER_ID = :orderId AND BAG_ID = :bagId", nativeQuery = true)
+    Long getAmount(Long orderId, Long bagId);
+
+    /**
      * Method for update Amount value.
      *
      * @param orderId order id {@link Long}

--- a/dao/src/main/java/greencity/repository/UpdateOrderDetailRepository.java
+++ b/dao/src/main/java/greencity/repository/UpdateOrderDetailRepository.java
@@ -27,7 +27,6 @@ public interface UpdateOrderDetailRepository extends JpaRepository<Order, Intege
      * @param bagId   bag id {@link Long}
      * @author Lilia Mokhnatska
      */
-
     @Query(value = "SELECT AMOUNT FROM ORDER_BAG_MAPPING "
         + "WHERE ORDER_ID = :orderId AND BAG_ID = :bagId", nativeQuery = true)
     Long getAmount(Long orderId, Long bagId);

--- a/dao/src/main/java/greencity/repository/UpdateOrderDetailRepository.java
+++ b/dao/src/main/java/greencity/repository/UpdateOrderDetailRepository.java
@@ -27,8 +27,8 @@ public interface UpdateOrderDetailRepository extends JpaRepository<Order, Intege
      * @param bagId   bag id {@link Long}
      * @author Lilia Mokhnatska
      */
-    @Query(value = "SELECT AMOUNT FROM ORDER_BAG_MAPPING "
-        + "WHERE ORDER_ID = :orderId AND BAG_ID = :bagId", nativeQuery = true)
+    @Query(value = "SELECT obm.amount FROM order_bag_mapping as obm "
+        + "WHERE obm.order_id = :orderId AND obm.bag_id = :bagId", nativeQuery = true)
     Long getAmount(Long orderId, Long bagId);
 
     /**

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -658,20 +658,22 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         for (Map.Entry<Integer, Integer> entry : confirmed.entrySet()) {
             Integer capacity = bagRepository.findCapacityById(entry.getKey());
             Optional<Bag> bagOptional = bagRepository.findById(entry.getKey());
-
             if (bagOptional.isPresent() && checkOrderStatusAboutConfirmWaste(order)) {
                 Optional<Long> confirmWasteWas = Optional.empty();
+                Optional<Long> startAmount = Optional.empty();
                 Bag bag = bagOptional.get();
                 if (Boolean.TRUE.equals(updateOrderRepository.ifRecordExist(orderId, entry.getKey().longValue()) > 0)) {
                     confirmWasteWas =
                         Optional.ofNullable(updateOrderRepository.getConfirmWaste(orderId, entry.getKey().longValue()));
+                    startAmount =
+                        Optional.ofNullable(updateOrderRepository.getAmount(orderId, entry.getKey().longValue()));
                 }
                 if (entry.getValue().longValue() != confirmWasteWas.orElse(0L)) {
                     if (countOfChanges == 0) {
                         values.append(OrderHistory.CHANGE_ORDER_DETAILS + " ");
                     }
                     values.append(bag.getName()).append(" ").append(capacity).append(" л: ")
-                        .append(confirmWasteWas.orElse(0L))
+                        .append(confirmWasteWas.orElse(startAmount.orElse(0L)))
                         .append(" шт на ").append(entry.getValue()).append(" шт.");
                 }
             }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -78,7 +78,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
     private final BagRepository bagRepository;
-    private final UpdateOrderDetailRepository updateOrderRepository;
+    private final OrderDetailRepository orderDetailRepository;
     private final PaymentRepository paymentRepository;
     private final EmployeeRepository employeeRepository;
     private final ReceivingStationRepository receivingStationRepository;
@@ -563,11 +563,11 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         if (nonNull(confirmed)) {
             for (Map.Entry<Integer, Integer> entry : confirmed.entrySet()) {
                 if (Boolean.TRUE
-                    .equals(updateOrderRepository.ifRecordExist(orderId, entry.getKey().longValue()) <= 0)) {
-                    updateOrderRepository.insertNewRecord(orderId, entry.getKey().longValue());
-                    updateOrderRepository.updateAmount(0, orderId, entry.getKey().longValue());
+                    .equals(orderDetailRepository.ifRecordExist(orderId, entry.getKey().longValue()) <= 0)) {
+                    orderDetailRepository.insertNewRecord(orderId, entry.getKey().longValue());
+                    orderDetailRepository.updateAmount(0, orderId, entry.getKey().longValue());
                 }
-                updateOrderRepository
+                orderDetailRepository
                     .updateConfirm(entry.getValue(), orderId,
                         entry.getKey().longValue());
             }
@@ -576,11 +576,11 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         if (nonNull(exported)) {
             for (Map.Entry<Integer, Integer> entry : exported.entrySet()) {
                 if (Boolean.TRUE
-                    .equals(updateOrderRepository.ifRecordExist(orderId, entry.getKey().longValue()) <= 0)) {
-                    updateOrderRepository.insertNewRecord(orderId, entry.getKey().longValue());
-                    updateOrderRepository.updateAmount(0, orderId, entry.getKey().longValue());
+                    .equals(orderDetailRepository.ifRecordExist(orderId, entry.getKey().longValue()) <= 0)) {
+                    orderDetailRepository.insertNewRecord(orderId, entry.getKey().longValue());
+                    orderDetailRepository.updateAmount(0, orderId, entry.getKey().longValue());
                 }
-                updateOrderRepository
+                orderDetailRepository
                     .updateExporter(entry.getValue(), orderId,
                         entry.getKey().longValue());
             }
@@ -662,11 +662,11 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                 Optional<Long> confirmWasteWas = Optional.empty();
                 Optional<Long> initialAmount = Optional.empty();
                 Bag bag = bagOptional.get();
-                if (Boolean.TRUE.equals(updateOrderRepository.ifRecordExist(orderId, entry.getKey().longValue()) > 0)) {
+                if (Boolean.TRUE.equals(orderDetailRepository.ifRecordExist(orderId, entry.getKey().longValue()) > 0)) {
                     confirmWasteWas =
-                        Optional.ofNullable(updateOrderRepository.getConfirmWaste(orderId, entry.getKey().longValue()));
+                        Optional.ofNullable(orderDetailRepository.getConfirmWaste(orderId, entry.getKey().longValue()));
                     initialAmount =
-                        Optional.ofNullable(updateOrderRepository.getAmount(orderId, entry.getKey().longValue()));
+                        Optional.ofNullable(orderDetailRepository.getAmount(orderId, entry.getKey().longValue()));
                 }
                 if (entry.getValue().longValue() != confirmWasteWas.orElse(0L)) {
                     if (countOfChanges == 0) {
@@ -688,10 +688,10 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             if (bagOptional.isPresent() && checkOrderStatusAboutExportedWaste(order)) {
                 Optional<Long> exporterWasteWas = Optional.empty();
                 Bag bag = bagOptional.get();
-                if (Boolean.TRUE.equals(updateOrderRepository.ifRecordExist(orderId, entry.getKey().longValue()) > 0)) {
+                if (Boolean.TRUE.equals(orderDetailRepository.ifRecordExist(orderId, entry.getKey().longValue()) > 0)) {
                     exporterWasteWas =
                         Optional
-                            .ofNullable(updateOrderRepository.getExporterWaste(orderId, entry.getKey().longValue()));
+                            .ofNullable(orderDetailRepository.getExporterWaste(orderId, entry.getKey().longValue()));
                 }
                 if (entry.getValue().longValue() != exporterWasteWas.orElse(0L)) {
                     if (countOfChanges == 0) {

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -660,12 +660,12 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             Optional<Bag> bagOptional = bagRepository.findById(entry.getKey());
             if (bagOptional.isPresent() && checkOrderStatusAboutConfirmWaste(order)) {
                 Optional<Long> confirmWasteWas = Optional.empty();
-                Optional<Long> startAmount = Optional.empty();
+                Optional<Long> initialAmount = Optional.empty();
                 Bag bag = bagOptional.get();
                 if (Boolean.TRUE.equals(updateOrderRepository.ifRecordExist(orderId, entry.getKey().longValue()) > 0)) {
                     confirmWasteWas =
                         Optional.ofNullable(updateOrderRepository.getConfirmWaste(orderId, entry.getKey().longValue()));
-                    startAmount =
+                    initialAmount =
                         Optional.ofNullable(updateOrderRepository.getAmount(orderId, entry.getKey().longValue()));
                 }
                 if (entry.getValue().longValue() != confirmWasteWas.orElse(0L)) {
@@ -673,7 +673,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                         values.append(OrderHistory.CHANGE_ORDER_DETAILS + " ");
                     }
                     values.append(bag.getName()).append(" ").append(capacity).append(" л: ")
-                        .append(confirmWasteWas.orElse(startAmount.orElse(0L)))
+                        .append(confirmWasteWas.orElse(initialAmount.orElse(0L)))
                         .append(" шт на ").append(entry.getValue()).append(" шт.");
                 }
             }

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -981,7 +981,6 @@ class UBSManagementServiceImplTest {
         verify(orderRepository).updateOrderPointsToUse(1L, 0);
     }
 
-    //
     @Test
     void testSetOrderDetailConfirmed() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusConfirmedDto()));
@@ -1010,13 +1009,16 @@ class UBSManagementServiceImplTest {
         when(orderRepository.getOrderDetails(anyLong()))
             .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
-        when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
         when(updateOrderRepository.ifRecordExist(any(), any())).thenReturn(1L);
         when(updateOrderRepository.getAmount(any(), any())).thenReturn(1L);
         ubsManagementService.setOrderDetail(1L,
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsConfirmed(),
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(),
             "test@gmail.com");
+        verify(orderRepository, times(2)).findById(1L);
+        verify(bagRepository, times(2)).findCapacityById(1);
+        verify(bagRepository, times(2)).findById(1);
+        verify(updateOrderRepository, times(3)).ifRecordExist(any(), any());
         verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
         verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         verify(updateOrderRepository).getAmount(any(), any());

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -981,6 +981,7 @@ class UBSManagementServiceImplTest {
         verify(orderRepository).updateOrderPointsToUse(1L, 0);
     }
 
+    //
     @Test
     void testSetOrderDetailConfirmed() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusConfirmedDto()));
@@ -998,6 +999,27 @@ class UBSManagementServiceImplTest {
 
         verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
         verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+    }
+
+    @Test
+    void testSetOrderDetailConfirmed2() {
+        when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusConfirmedDto()));
+        when(bagRepository.findCapacityById(1)).thenReturn(1);
+        doNothing().when(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        doNothing().when(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        when(orderRepository.getOrderDetails(anyLong()))
+            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+        when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
+        when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
+        when(updateOrderRepository.ifRecordExist(any(), any())).thenReturn(1L);
+        when(updateOrderRepository.getAmount(any(), any())).thenReturn(1L);
+        ubsManagementService.setOrderDetail(1L,
+            UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsConfirmed(),
+            UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(),
+            "test@gmail.com");
+        verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        verify(updateOrderRepository).getAmount(any(), any());
     }
 
     @Test
@@ -2111,5 +2133,4 @@ class UBSManagementServiceImplTest {
         when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
         assertEquals(true, ubsManagementService.checkEmployeeForOrder(order.getId(), "test@gmail.com"));
     }
-
 }

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -105,7 +105,7 @@ class UBSManagementServiceImplTest {
     private ObjectMapper objectMapper;
 
     @Mock
-    private UpdateOrderDetailRepository updateOrderRepository;
+    private OrderDetailRepository orderDetailRepository;
 
     @InjectMocks
     private UBSManagementServiceImpl ubsManagementService;
@@ -909,8 +909,8 @@ class UBSManagementServiceImplTest {
     void testSetOrderDetail() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusAdjustmentDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);
-        doNothing().when(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        doNothing().when(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
             .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
@@ -919,8 +919,8 @@ class UBSManagementServiceImplTest {
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsConfirmed(),
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(), "abc");
 
-        verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
     }
 
     @Test
@@ -936,8 +936,8 @@ class UBSManagementServiceImplTest {
         ubsManagementService.setOrderDetail(order.getId(),
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsConfirmed(),
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(), "abc");
-        verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
     }
 
     @Test
@@ -985,8 +985,8 @@ class UBSManagementServiceImplTest {
     void testSetOrderDetailConfirmed() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusConfirmedDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);
-        doNothing().when(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        doNothing().when(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
             .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
@@ -996,21 +996,21 @@ class UBSManagementServiceImplTest {
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(),
             "test@gmail.com");
 
-        verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
     }
 
     @Test
     void testSetOrderDetailConfirmed2() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusConfirmedDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);
-        doNothing().when(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        doNothing().when(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
             .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
-        when(updateOrderRepository.ifRecordExist(any(), any())).thenReturn(1L);
-        when(updateOrderRepository.getAmount(any(), any())).thenReturn(1L);
+        when(orderDetailRepository.ifRecordExist(any(), any())).thenReturn(1L);
+        when(orderDetailRepository.getAmount(any(), any())).thenReturn(1L);
         ubsManagementService.setOrderDetail(1L,
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsConfirmed(),
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(),
@@ -1018,18 +1018,18 @@ class UBSManagementServiceImplTest {
         verify(orderRepository, times(2)).findById(1L);
         verify(bagRepository, times(2)).findCapacityById(1);
         verify(bagRepository, times(2)).findById(1);
-        verify(updateOrderRepository, times(3)).ifRecordExist(any(), any());
-        verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
-        verify(updateOrderRepository).getAmount(any(), any());
+        verify(orderDetailRepository, times(3)).ifRecordExist(any(), any());
+        verify(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).getAmount(any(), any());
     }
 
     @Test
     void testSetOrderDetailFormed() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);
-        doNothing().when(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        doNothing().when(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
             .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
@@ -1038,16 +1038,16 @@ class UBSManagementServiceImplTest {
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsConfirmed(),
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(), "test@gmail.com");
 
-        verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
     }
 
     @Test
     void testSetOrderDetailFormedWithBagNoPresent() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);
-        doNothing().when(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        doNothing().when(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
             .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.empty());
@@ -1056,16 +1056,16 @@ class UBSManagementServiceImplTest {
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsConfirmed(),
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(), "test@gmail.com");
 
-        verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
     }
 
     @Test
     void testSetOrderDetailNotTakenOut() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusNotTakenOutDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);
-        doNothing().when(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        doNothing().when(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
             .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
@@ -1076,16 +1076,16 @@ class UBSManagementServiceImplTest {
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(),
             "abc");
 
-        verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
     }
 
     @Test
     void testSetOrderDetailOnTheRoute() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusOnThe_RouteDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);
-        doNothing().when(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        doNothing().when(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
             .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
@@ -1095,16 +1095,16 @@ class UBSManagementServiceImplTest {
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(),
             "abc");
 
-        verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
     }
 
     @Test
     void testSetOrderDetailsDone() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusDoneDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);
-        doNothing().when(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        doNothing().when(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
             .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
@@ -1113,8 +1113,8 @@ class UBSManagementServiceImplTest {
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(),
             "abc");
 
-        verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
     }
 
     @Test
@@ -1122,8 +1122,8 @@ class UBSManagementServiceImplTest {
         when(orderRepository.findById(1L))
             .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusBROUGHT_IT_HIMSELFDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);
-        doNothing().when(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        doNothing().when(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
             .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
@@ -1132,16 +1132,16 @@ class UBSManagementServiceImplTest {
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(),
             "abc");
 
-        verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
     }
 
     @Test
     void testSetOrderDetailsCanseled() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusCanseledDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);
-        doNothing().when(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        doNothing().when(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
             .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
@@ -1151,8 +1151,8 @@ class UBSManagementServiceImplTest {
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(),
             "abc");
 
-        verify(updateOrderRepository).updateExporter(anyInt(), anyLong(), anyLong());
-        verify(updateOrderRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
     }
 
     @Test


### PR DESCRIPTION
# Green City UBS  bug in writing order history PR


## Summary Of Issue :
Create a new order. Change the confirmed number of bags. Open order history. The changed order details show that the quantity has been changed from 0 to "Підтверджена к-ть" .
![image](https://user-images.githubusercontent.com/113025377/215450089-9fcfb610-ab50-47c4-9126-6752b125e580.png)


It is expected that the changed order details show that the quantity has been changed from "Планована к-ть"  to "Підтверджена к-ть" 

![image](https://user-images.githubusercontent.com/113025377/215454991-ed0f0b8b-4d80-4d3c-a37d-82316267f3d5.png)




## Issue Link :
https://github.com/ita-social-projects/GreenCity/issues/5058

## Summary Of Changes :

1. add getAmount method in UpdateOrderDetailRepository
2. change method collectEventAboutSetOrderDetails in UBSManagementServiceImpl
3. add test for new lines of code



## Code reviewers

- [ ] @github_username


## Added
add getAmount method in UpdateOrderDetailRepository
add test for new lines of code
## Changed 
change method collectEventAboutSetOrderDetails in UBSManagementServiceImpl

## Deleted
-


## How to test :
1. User need to be logged in http://localhost:8060/swagger-ui.html#/own-security-controller
2. Register Token
3. Create an order  https://www.testgreencity.ga/GreenCityClient/#/ubs/order
4. Admin need to be logged in http://localhost:8060/swagger-ui.html#/own-security-controller
5. Register Token 
6. Choose "Деталі замовлення" https://www.testgreencity.ga/GreenCityClient/#/ubs-admin/order/1116 
7. Choose "Підтверджена к-ть" change and submit
8. Choose "Історія замовлення"





## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-#5058: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
