### PR TITLE
Change order status from "Підтверджено" to "На маршруті" automatically at 00:00 on the day of order fulfillment

### DIFF
--- a/dao/src/main/java/greencity/repository/OrderRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderRepository.java
@@ -223,18 +223,21 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     void updateCancelingReason(Long orderId, String cancellationReason);
 
     /**
-     * Method sets order status by order's status and order's date of export.
+     * Method update orders status from actual status to expected status by specific
+     * date.
      *
-     * @param orderStatus - order status to set
-     * @param currentDate - order date of export
+     * @param actualStatus   - update from order status
+     * @param expectedStatus - update to order status
+     * @param currentDate    - order date of export
      */
     @Modifying
     @Transactional
     @Query(nativeQuery = true,
         value = "UPDATE orders "
-            + "SET order_status = :order_status "
-            + "WHERE order_status = 'CONFIRMED' "
+            + "SET order_status = :expected_status "
+            + "WHERE order_status = :actual_status "
             + "AND date_of_export = :currentDate")
-    void updateOrderStatusOnTheDayOfExport(@Param("order_status") String orderStatus,
+    void updateOrderStatusToExpected(@Param("actual_status") String actualStatus,
+        @Param("expected_status") String expectedStatus,
         @Param("currentDate") LocalDate currentDate);
 }

--- a/dao/src/main/java/greencity/repository/OrderRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderRepository.java
@@ -1,8 +1,8 @@
 package greencity.repository;
 
-import greencity.enums.OrderPaymentStatus;
 import greencity.entity.order.Order;
 import greencity.entity.user.User;
+import greencity.enums.OrderPaymentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -221,4 +221,20 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query(nativeQuery = true,
         value = "UPDATE orders SET cancellation_reason = :cancellationReason WHERE id = :orderId")
     void updateCancelingReason(Long orderId, String cancellationReason);
+
+    /**
+     * Method sets order status by order's status and order's date of export.
+     *
+     * @param orderStatus  - order status to set
+     * @param currentDate - order date of export
+     */
+    @Modifying
+    @Transactional
+    @Query(nativeQuery = true,
+        value = "UPDATE orders "
+            + "SET order_status = :order_status "
+            + "WHERE order_status = 'CONFIRMED' "
+            + "AND date_of_export = :currentDate")
+    void updateOrderStatusOnTheDayOfExport(@Param("order_status") String orderStatus,
+        @Param("currentDate") LocalDate currentDate);
 }

--- a/dao/src/main/java/greencity/repository/OrderRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderRepository.java
@@ -225,7 +225,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     /**
      * Method sets order status by order's status and order's date of export.
      *
-     * @param orderStatus  - order status to set
+     * @param orderStatus - order status to set
      * @param currentDate - order date of export
      */
     @Modifying

--- a/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
@@ -294,4 +294,11 @@ public interface UBSManagementService {
      * @author Hlazova Nataliia.
      */
     Boolean checkEmployeeForOrder(Long orderId, String email);
+
+    /**
+     * This is method which is updates orders status at 00:00 everyday where date of export equals current date.
+     *
+     * @author Anatolii Shapiro.
+     */
+    void updateOrderStatusOnTheDayOfExport();
 }

--- a/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
@@ -296,7 +296,8 @@ public interface UBSManagementService {
     Boolean checkEmployeeForOrder(Long orderId, String email);
 
     /**
-     * This is method which is updates orders status at 00:00 everyday where date of export equals current date.
+     * This is method which is updates orders status at 00:00 everyday where date of
+     * export equals current date.
      *
      * @author Anatolii Shapiro.
      */

--- a/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
@@ -301,5 +301,5 @@ public interface UBSManagementService {
      *
      * @author Anatolii Shapiro.
      */
-    void updateOrderStatusOnTheDayOfExport();
+    void updateOrderStatusToExpected();
 }

--- a/service/src/main/java/greencity/config/OrderStatusScheduler.java
+++ b/service/src/main/java/greencity/config/OrderStatusScheduler.java
@@ -1,0 +1,27 @@
+package greencity.config;
+
+import greencity.service.ubs.UBSManagementServiceImpl;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Slf4j
+@Configuration
+@EnableScheduling
+@NoArgsConstructor
+public class OrderStatusScheduler {
+    @Autowired
+    UBSManagementServiceImpl ubsManagementService;
+
+    /**
+     * System checks BD at 00.00 daily and sends a message if the status of the
+     * order has changed to "ON_THE_ROUTE" on the day of export.
+     */
+    @Scheduled(cron = "0 0 0 * * *", zone = "Europe/Kiev")
+    public void autoChangeOrderStatusOnTheDayOfExport() {
+        ubsManagementService.updateOrderStatusOnTheDayOfExport();
+    }
+}

--- a/service/src/main/java/greencity/config/OrderStatusScheduler.java
+++ b/service/src/main/java/greencity/config/OrderStatusScheduler.java
@@ -22,6 +22,7 @@ public class OrderStatusScheduler {
      */
     @Scheduled(cron = "0 0 0 * * *", zone = "Europe/Kiev")
     public void autoChangeOrderStatusOnTheDayOfExport() {
+        log.info("Changing order status where status = \"CONFIRMED\" and date of export = day of order fulfillment");
         ubsManagementService.updateOrderStatusOnTheDayOfExport();
     }
 }

--- a/service/src/main/java/greencity/config/OrderStatusScheduler.java
+++ b/service/src/main/java/greencity/config/OrderStatusScheduler.java
@@ -14,15 +14,15 @@ import org.springframework.scheduling.annotation.Scheduled;
 @NoArgsConstructor
 public class OrderStatusScheduler {
     @Autowired
-    UBSManagementServiceImpl ubsManagementService;
+    private UBSManagementServiceImpl ubsManagementService;
 
     /**
-     * System checks BD at 00.00 daily and sends a message if the status of the
-     * order has changed to "ON_THE_ROUTE" on the day of export.
+     * Method auto update the orders status from "CONFIRMED" to "ON_THE_ROUTE" on
+     * the day of export.
      */
     @Scheduled(cron = "0 0 0 * * *", zone = "Europe/Kiev")
-    public void autoChangeOrderStatusOnTheDayOfExport() {
-        log.info("Changing order status where status = \"CONFIRMED\" and date of export = day of order fulfillment");
-        ubsManagementService.updateOrderStatusOnTheDayOfExport();
+    public void autoUpdateOrderStatus() {
+        log.info("Update order status from actual status to expected status by the day of export");
+        ubsManagementService.updateOrderStatusToExpected();
     }
 }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1810,7 +1810,9 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     }
 
     @Override
-    public void updateOrderStatusOnTheDayOfExport() {
-        orderRepository.updateOrderStatusOnTheDayOfExport(OrderStatus.ON_THE_ROUTE.name(), LocalDate.now());
+    public void updateOrderStatusToExpected() {
+        orderRepository.updateOrderStatusToExpected(OrderStatus.CONFIRMED.name(),
+            OrderStatus.ON_THE_ROUTE.name(),
+            LocalDate.now());
     }
 }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1808,4 +1808,9 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                 .build());
         notificationService.notifyBonuses(order, (long) points);
     }
+
+    @Override
+    public void updateOrderStatusOnTheDayOfExport() {
+        orderRepository.updateOrderStatusOnTheDayOfExport(OrderStatus.ON_THE_ROUTE.name(), LocalDate.now());
+    }
 }

--- a/service/src/test/java/greencity/config/OrderStatusSchedulerTest.java
+++ b/service/src/test/java/greencity/config/OrderStatusSchedulerTest.java
@@ -10,7 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class OrderStatusSchedulerTest {
+class OrderStatusSchedulerTest {
 
     @InjectMocks
     OrderStatusScheduler orderStatusScheduler;

--- a/service/src/test/java/greencity/config/OrderStatusSchedulerTest.java
+++ b/service/src/test/java/greencity/config/OrderStatusSchedulerTest.java
@@ -1,0 +1,26 @@
+package greencity.config;
+
+import greencity.service.ubs.UBSManagementServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class OrderStatusSchedulerTest {
+
+    @InjectMocks
+    OrderStatusScheduler orderStatusScheduler;
+
+    @Mock
+    UBSManagementServiceImpl ubsManagementService;
+
+    @Test
+    void autoChangeOrderStatusOnTheDayOfExportTest() {
+        orderStatusScheduler.autoChangeOrderStatusOnTheDayOfExport();
+        verify(ubsManagementService).updateOrderStatusOnTheDayOfExport();
+    }
+}

--- a/service/src/test/java/greencity/config/OrderStatusSchedulerTest.java
+++ b/service/src/test/java/greencity/config/OrderStatusSchedulerTest.java
@@ -1,26 +1,30 @@
 package greencity.config;
 
 import greencity.service.ubs.UBSManagementServiceImpl;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@Slf4j
 @ExtendWith(MockitoExtension.class)
 class OrderStatusSchedulerTest {
-
     @InjectMocks
-    OrderStatusScheduler orderStatusScheduler;
+    private OrderStatusScheduler orderStatusScheduler;
 
     @Mock
-    UBSManagementServiceImpl ubsManagementService;
+    private UBSManagementServiceImpl ubsManagementService;
 
     @Test
     void autoChangeOrderStatusOnTheDayOfExportTest() {
-        orderStatusScheduler.autoChangeOrderStatusOnTheDayOfExport();
-        verify(ubsManagementService).updateOrderStatusOnTheDayOfExport();
+        orderStatusScheduler.autoUpdateOrderStatus();
+        log.info("Update order status from actual status to expected status by the day of export");
+        verify(ubsManagementService, times(1)).updateOrderStatusToExpected();
     }
+
 }

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -50,6 +50,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -2112,4 +2113,10 @@ class UBSManagementServiceImplTest {
         assertEquals(true, ubsManagementService.checkEmployeeForOrder(order.getId(), "test@gmail.com"));
     }
 
+    @Test
+    void updateOrderStatusOnTheDayOfExportTest() {
+        ubsManagementService.updateOrderStatusOnTheDayOfExport();
+        verify(orderRepository).updateOrderStatusOnTheDayOfExport(OrderStatus.ON_THE_ROUTE.name(),
+            LocalDate.now());
+    }
 }

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -2115,8 +2115,9 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateOrderStatusOnTheDayOfExportTest() {
-        ubsManagementService.updateOrderStatusOnTheDayOfExport();
-        verify(orderRepository).updateOrderStatusOnTheDayOfExport(OrderStatus.ON_THE_ROUTE.name(),
+        ubsManagementService.updateOrderStatusToExpected();
+        verify(orderRepository).updateOrderStatusToExpected(OrderStatus.CONFIRMED.name(),
+            OrderStatus.ON_THE_ROUTE.name(),
             LocalDate.now());
     }
 }


### PR DESCRIPTION
dev
## Border

* [Main border ticket](https://github.com/ita-social-projects/GreenCity/issues/5034)


## Code reviewers

- [ ] @ABbondar 
- [ ] @juseti 
- [ ] @JJJazl 
- [ ] @NKorzhik 
- [ ] @LiliaMokhnatska 

## Summary of issue

The order status from "**Підтверджено**" to "**На маршруті**" is not changed and is not set automatically at **00:00** on the day of order fulfillment

1) add new method  in OrderRepository to update order status.

2) implement method in UBSManagementServiceImpl

3) add test for method in UBSManagementServiceImplTest

4) creat OrderStatusScheduler with a method to automatically update the order status at 00:00 at night, where the order status = "CONFIRMED" and date of export = current date

5) add test for OrderStatusScheduler

## Summary of change

1) added new method "updateOrderStatusOnTheDayOfExport()" in OrderRepository to update order status.

2) added method "updateOrderStatusOnTheDayOfExport()" in UBSManagementService, because checkstyle test did not pass.

3) method implementation in UBSManagementServiceImpl

4) added test for "updateOrderStatusOnTheDayOfExport" method in UBSManagementServiceImplTest

5) created OrderStatusScheduler with a method to automatically update the order status at 00:00 at night, where the order status = "CONFIRMED" and date of export = current date

6) added test for OrderStatusScheduler

## Testing approach

Has been tested on local database several times, for several time periods

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
