### PR TITLE
[UBS Admin. Orders. Order details] With query with null the data is not saved in the database #5126

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1056,8 +1056,9 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     /**
      * Method returns update export details by order id.
      *
-     * @param id  of {@link Long} order id;
-     * @param dto of{@link ExportDetailsDtoUpdate}
+     * @param id    of {@link Long} order id;
+     * @param dto   of{@link ExportDetailsDtoUpdate}
+     * @param email {@link String} email;
      * @return {@link ExportDetailsDto};
      * @author Orest Mahdziak
      */
@@ -1065,60 +1066,75 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     public ExportDetailsDto updateOrderExportDetails(Long id, ExportDetailsDtoUpdate dto, String email) {
         Order order = orderRepository.findById(id)
             .orElseThrow(() -> new NotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST + id));
+        final List<ReceivingStation> receivingStation = getAllReceivingStations();
+        order.setReceivingStation(getUpdatedReceivingStation(dto.getReceivingStationId(), order));
+        order.setDateOfExport(getUpdatedDateExport(dto.getDateExport(), order));
+        order.setDeliverFrom(getUpdatedDeliveryFrom(dto.getTimeDeliveryFrom(), order));
+        order.setDeliverTo(getUpdatedDeliveryTo(dto.getTimeDeliveryTo(), order));
+        orderRepository.save(order);
+        collectEventsAboutOrderExportDetails(order.getReceivingStation(), order.getDeliverFrom(), order, email);
+        return buildExportDto(order, receivingStation);
+    }
+
+    private List<ReceivingStation> getAllReceivingStations() {
         List<ReceivingStation> receivingStation = receivingStationRepository.findAll();
         if (receivingStation.isEmpty()) {
             throw new NotFoundException(RECEIVING_STATION_NOT_FOUND);
         }
-        if (order.getOrderStatus() == OrderStatus.FORMED
-            || order.getOrderStatus() == OrderStatus.CANCELED
-            || order.getOrderStatus() == OrderStatus.BROUGHT_IT_HIMSELF) {
-            order.setReceivingStation(null);
-            order.setDateOfExport(null);
-            order.setDeliverTo(null);
-            order.setDeliverFrom(null);
-        } else {
-            if (nonNull(dto.getReceivingStationId())) {
-                ReceivingStation station = receivingStationRepository.findById(dto.getReceivingStationId())
-                    .orElseThrow(() -> new NotFoundException(
-                        RECEIVING_STATION_NOT_FOUND_BY_ID + dto.getReceivingStationId()));
-                order.setReceivingStation(station);
-            }
-            String dateExport = dto.getDateExport() != null ? dto.getDateExport() : null;
-            String timeDeliveryFrom = dto.getTimeDeliveryFrom() != null ? dto.getTimeDeliveryFrom() : null;
-            String timeDeliveryTo = dto.getTimeDeliveryTo() != null ? dto.getTimeDeliveryTo() : null;
-            if (dateExport != null) {
-                String[] date = dateExport.split("T");
-                order.setDateOfExport(LocalDate.parse(date[0]));
-            }
-            if (timeDeliveryFrom != null) {
-                LocalDateTime dateTime = LocalDateTime.parse(timeDeliveryFrom);
-                order.setDeliverFrom(dateTime);
-            }
-            if (timeDeliveryTo != null) {
-                LocalDateTime dateAndTimeDeliveryTo = LocalDateTime.parse(timeDeliveryTo);
-                order.setDeliverTo(dateAndTimeDeliveryTo);
-            }
+        return receivingStation;
+    }
+
+    private ReceivingStation getUpdatedReceivingStation(Long receivingStationId, Order order) {
+        if (nonNull(receivingStationId)) {
+            return receivingStationRepository.findById(receivingStationId)
+                .orElseThrow(() -> new NotFoundException(
+                    RECEIVING_STATION_NOT_FOUND_BY_ID + receivingStationId));
+        } else if (isOrderStatusFormedOrCanceledOrBroughtHimself(order)) {
+            return null;
         }
-        orderRepository.save(order);
-        final String receivingStationValue = order.getReceivingStation() != null
-            ? order.getReceivingStation().getName()
-            : null;
-        final LocalDateTime deliverFrom = order.getDeliverFrom();
-        collectEventsAboutOrderExportDetails(receivingStationValue, deliverFrom, order, email);
-        return buildExportDto(order, receivingStation);
+        return order.getReceivingStation();
+    }
+
+    private LocalDate getUpdatedDateExport(String dateExport, Order order) {
+        if (dateExport != null) {
+            String[] date = dateExport.split("T");
+            return LocalDate.parse(date[0]);
+        } else if (isOrderStatusFormedOrCanceledOrBroughtHimself(order)) {
+            return null;
+        }
+        return order.getDateOfExport();
+    }
+
+    private LocalDateTime getUpdatedDeliveryFrom(String timeDeliveryFrom, Order order) {
+        if (timeDeliveryFrom != null) {
+            return LocalDateTime.parse(timeDeliveryFrom);
+        } else if (isOrderStatusFormedOrCanceledOrBroughtHimself(order)) {
+            return null;
+        }
+        return order.getDeliverFrom();
+    }
+
+    private LocalDateTime getUpdatedDeliveryTo(String timeDeliveryTo, Order order) {
+        if (timeDeliveryTo != null) {
+            return LocalDateTime.parse(timeDeliveryTo);
+        } else if (isOrderStatusFormedOrCanceledOrBroughtHimself(order)) {
+            return null;
+        }
+        return order.getDeliverTo();
     }
 
     /**
      * This is private method which collect's event for order export details.
      *
-     * @param receivingStationValue {@link String}.
-     * @param deliverFrom           {@link LocalDateTime}.
-     * @param order                 {@link Order}.
+     * @param receivingStation {@link ReceivingStation}.
+     * @param deliverFrom      {@link LocalDateTime}.
+     * @param order            {@link Order}.
+     * @param email            {@link String}.
      * @author Yuriy Bahlay.
      */
-    private void collectEventsAboutOrderExportDetails(String receivingStationValue, LocalDateTime deliverFrom,
+    private void collectEventsAboutOrderExportDetails(ReceivingStation receivingStation, LocalDateTime deliverFrom,
         Order order, String email) {
-        if (receivingStationValue != null || deliverFrom != null) {
+        if (receivingStation != null || deliverFrom != null) {
             eventService.saveEvent(OrderHistory.UPDATE_EXPORT_DETAILS, email, order);
         }
     }
@@ -1679,9 +1695,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                         dto.getPositionId(),
                         email));
             } else {
-                if (order.getOrderStatus() == OrderStatus.FORMED
-                    || order.getOrderStatus() == OrderStatus.CANCELED
-                    || order.getOrderStatus() == OrderStatus.BROUGHT_IT_HIMSELF) {
+                if (isOrderStatusFormedOrCanceledOrBroughtHimself(order)) {
                     List<EmployeeOrderPosition> employeeOrderPositions = employeeOrderPositionRepository
                         .findAllByOrderId(orderId);
                     if (!employeeOrderPositions.isEmpty()) {
@@ -1692,6 +1706,12 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         } catch (Exception e) {
             throw new BadRequestException(e.getMessage());
         }
+    }
+
+    private boolean isOrderStatusFormedOrCanceledOrBroughtHimself(Order order) {
+        return order.getOrderStatus() == OrderStatus.FORMED
+            || order.getOrderStatus() == OrderStatus.CANCELED
+            || order.getOrderStatus() == OrderStatus.BROUGHT_IT_HIMSELF;
     }
 
     private void checkAvailableOrderForEmployee(Order order, String email) {

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -18,7 +18,6 @@ import greencity.dto.address.AddressInfoDto;
 import greencity.dto.bag.AdditionalBagInfoDto;
 import greencity.dto.bag.BagForUserDto;
 import greencity.dto.bag.BagMappingDto;
-import greencity.dto.bag.BagTransDto;
 import greencity.dto.bag.BagInfoDto;
 import greencity.dto.bag.BagDto;
 import greencity.dto.bag.BagOrderDto;
@@ -2583,6 +2582,54 @@ public class ModelUtils {
                 .positionId(2L)
                 .employeeId(2L)
                 .build()))
+            .build();
+    }
+
+    public static UpdateOrderPageAdminDto updateOrderPageAdminDtoWithStatusCanceled() {
+        return UpdateOrderPageAdminDto.builder()
+            .generalOrderInfo(OrderDetailStatusRequestDto
+                .builder()
+                .orderStatus(String.valueOf(OrderStatus.FORMED))
+                .build())
+            .exportDetailsDto(ExportDetailsDtoUpdate
+                .builder()
+                .dateExport(null)
+                .timeDeliveryFrom(null)
+                .timeDeliveryTo(null)
+                .receivingStationId(null)
+                .build())
+            .build();
+    }
+
+    public static UpdateOrderPageAdminDto updateOrderPageAdminDtoWithStatusBroughtItHimself() {
+        return UpdateOrderPageAdminDto.builder()
+            .generalOrderInfo(OrderDetailStatusRequestDto
+                .builder()
+                .orderStatus(String.valueOf(OrderStatus.BROUGHT_IT_HIMSELF))
+                .build())
+            .exportDetailsDto(ExportDetailsDtoUpdate
+                .builder()
+                .dateExport(null)
+                .timeDeliveryFrom(null)
+                .timeDeliveryTo(null)
+                .receivingStationId(null)
+                .build())
+            .build();
+    }
+
+    public static UpdateOrderPageAdminDto updateOrderPageAdminDtoWithStatusFormed() {
+        return UpdateOrderPageAdminDto.builder()
+            .generalOrderInfo(OrderDetailStatusRequestDto
+                .builder()
+                .orderStatus(String.valueOf(OrderStatus.FORMED))
+                .build())
+            .exportDetailsDto(ExportDetailsDtoUpdate
+                .builder()
+                .dateExport(null)
+                .timeDeliveryFrom(null)
+                .timeDeliveryTo(null)
+                .receivingStationId(null)
+                .build())
             .build();
     }
 

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2585,6 +2585,22 @@ public class ModelUtils {
             .build();
     }
 
+    public static UpdateOrderPageAdminDto updateOrderPageAdminDtoWithNullFields() {
+        return UpdateOrderPageAdminDto.builder()
+            .generalOrderInfo(OrderDetailStatusRequestDto
+                .builder()
+                .orderStatus(String.valueOf(OrderStatus.CONFIRMED))
+                .build())
+            .exportDetailsDto(ExportDetailsDtoUpdate
+                .builder()
+                .dateExport(null)
+                .timeDeliveryFrom(null)
+                .timeDeliveryTo(null)
+                .receivingStationId(null)
+                .build())
+            .build();
+    }
+
     public static UpdateOrderPageAdminDto updateOrderPageAdminDtoWithStatusCanceled() {
         return UpdateOrderPageAdminDto.builder()
             .generalOrderInfo(OrderDetailStatusRequestDto

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -1409,6 +1409,106 @@ class UBSManagementServiceImplTest {
     }
 
     @Test
+    void updateOrderAdminPageInfoWithStatusFormedTest() {
+        Order order = ModelUtils.getOrder();
+        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(getTariffsInfo());
+        order.setOrderStatus(OrderStatus.FORMED);
+        EmployeeOrderPosition employeeOrderPosition = ModelUtils.getEmployeeOrderPosition();
+        Employee employee = ModelUtils.getEmployee();
+        List<Long> tariffsInfoIds = new ArrayList<>();
+        tariffsInfoIds.add(1L);
+        UpdateOrderPageAdminDto updateOrderPageAdminDto = ModelUtils.updateOrderPageAdminDtoWithStatusFormed();
+
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(orderRepository.save(order)).thenReturn(order);
+        when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
+        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(ModelUtils.getPayment()));
+        when(receivingStationRepository.findAll()).thenReturn(List.of(ModelUtils.getReceivingStation()));
+        when(employeeOrderPositionRepository.findAllByOrderId(1L)).thenReturn(List.of(employeeOrderPosition));
+
+        ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, 1L, "en", "test@gmail.com");
+
+        verify(orderRepository, times(3)).findById(1L);
+        verify(orderRepository, times(2)).save(order);
+        verify(employeeRepository, times(1)).findByEmail("test@gmail.com");
+        verify(employeeRepository).findTariffsInfoForEmployee(employee.getId());
+        verify(paymentRepository).findAllByOrderId(1L);
+        verify(receivingStationRepository).findAll();
+        verify(employeeOrderPositionRepository).findAllByOrderId(1L);
+        verify(employeeOrderPositionRepository).deleteAll(List.of(employeeOrderPosition));
+        verifyNoMoreInteractions(orderRepository, employeeRepository, paymentRepository, receivingStationRepository,
+                employeeOrderPositionRepository);
+    }
+
+    @Test
+    void updateOrderAdminPageInfoWithStatusCanceledTest() {
+        Order order = ModelUtils.getOrder();
+        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(getTariffsInfo());
+        order.setOrderStatus(OrderStatus.CANCELED);
+        EmployeeOrderPosition employeeOrderPosition = ModelUtils.getEmployeeOrderPosition();
+        Employee employee = ModelUtils.getEmployee();
+        List<Long> tariffsInfoIds = new ArrayList<>();
+        tariffsInfoIds.add(1L);
+        UpdateOrderPageAdminDto updateOrderPageAdminDto = ModelUtils.updateOrderPageAdminDtoWithStatusCanceled();
+
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(orderRepository.save(order)).thenReturn(order);
+        when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
+        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(ModelUtils.getPayment()));
+        when(receivingStationRepository.findAll()).thenReturn(List.of(ModelUtils.getReceivingStation()));
+        when(employeeOrderPositionRepository.findAllByOrderId(1L)).thenReturn(List.of(employeeOrderPosition));
+
+        ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, 1L, "en", "test@gmail.com");
+
+        verify(orderRepository, times(3)).findById(1L);
+        verify(orderRepository, times(2)).save(order);
+        verify(employeeRepository, times(1)).findByEmail("test@gmail.com");
+        verify(employeeRepository).findTariffsInfoForEmployee(employee.getId());
+        verify(paymentRepository).findAllByOrderId(1L);
+        verify(receivingStationRepository).findAll();
+        verify(employeeOrderPositionRepository).findAllByOrderId(1L);
+        verify(employeeOrderPositionRepository).deleteAll(List.of(employeeOrderPosition));
+        verifyNoMoreInteractions(orderRepository, employeeRepository, paymentRepository, receivingStationRepository,
+                employeeOrderPositionRepository);
+    }
+
+    @Test
+    void updateOrderAdminPageInfoWithStatusBroughtItHimselfTest() {
+        Order order = ModelUtils.getOrder();
+        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(getTariffsInfo());
+        order.setOrderStatus(OrderStatus.BROUGHT_IT_HIMSELF);
+        EmployeeOrderPosition employeeOrderPosition = ModelUtils.getEmployeeOrderPosition();
+        Employee employee = ModelUtils.getEmployee();
+        List<Long> tariffsInfoIds = new ArrayList<>();
+        tariffsInfoIds.add(1L);
+        UpdateOrderPageAdminDto updateOrderPageAdminDto =
+            ModelUtils.updateOrderPageAdminDtoWithStatusBroughtItHimself();
+
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(orderRepository.save(order)).thenReturn(order);
+        when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
+        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(ModelUtils.getPayment()));
+        when(receivingStationRepository.findAll()).thenReturn(List.of(ModelUtils.getReceivingStation()));
+        when(employeeOrderPositionRepository.findAllByOrderId(1L)).thenReturn(List.of(employeeOrderPosition));
+
+        ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, 1L, "en", "test@gmail.com");
+
+        verify(orderRepository, times(3)).findById(1L);
+        verify(orderRepository, times(2)).save(order);
+        verify(employeeRepository, times(1)).findByEmail("test@gmail.com");
+        verify(employeeRepository).findTariffsInfoForEmployee(employee.getId());
+        verify(paymentRepository).findAllByOrderId(1L);
+        verify(receivingStationRepository).findAll();
+        verify(employeeOrderPositionRepository).findAllByOrderId(1L);
+        verify(employeeOrderPositionRepository).deleteAll(List.of(employeeOrderPosition));
+        verifyNoMoreInteractions(orderRepository, employeeRepository, paymentRepository, receivingStationRepository,
+                employeeOrderPositionRepository);
+    }
+
+    @Test
     void updateOrderAdminPageInfoTestThrowsException() {
         UpdateOrderPageAdminDto updateOrderPageAdminDto = updateOrderPageAdminDto();
         Order order = ModelUtils.getOrder();
@@ -1700,7 +1800,6 @@ class UBSManagementServiceImplTest {
         Order order = getOrder();
         ExportDetailsDtoUpdate testDetails = getExportDetailsRequest();
         var receivingStation = ModelUtils.getReceivingStation();
-        when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(receivingStation));
         when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
         when(receivingStationRepository.findAll()).thenReturn(Collections.emptyList());
         assertThrows(NotFoundException.class,

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -1438,7 +1438,7 @@ class UBSManagementServiceImplTest {
         verify(employeeOrderPositionRepository).findAllByOrderId(1L);
         verify(employeeOrderPositionRepository).deleteAll(List.of(employeeOrderPosition));
         verifyNoMoreInteractions(orderRepository, employeeRepository, paymentRepository, receivingStationRepository,
-                employeeOrderPositionRepository);
+            employeeOrderPositionRepository);
     }
 
     @Test
@@ -1471,7 +1471,7 @@ class UBSManagementServiceImplTest {
         verify(employeeOrderPositionRepository).findAllByOrderId(1L);
         verify(employeeOrderPositionRepository).deleteAll(List.of(employeeOrderPosition));
         verifyNoMoreInteractions(orderRepository, employeeRepository, paymentRepository, receivingStationRepository,
-                employeeOrderPositionRepository);
+            employeeOrderPositionRepository);
     }
 
     @Test
@@ -1505,7 +1505,7 @@ class UBSManagementServiceImplTest {
         verify(employeeOrderPositionRepository).findAllByOrderId(1L);
         verify(employeeOrderPositionRepository).deleteAll(List.of(employeeOrderPosition));
         verifyNoMoreInteractions(orderRepository, employeeRepository, paymentRepository, receivingStationRepository,
-                employeeOrderPositionRepository);
+            employeeOrderPositionRepository);
     }
 
     @Test

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -1509,6 +1509,36 @@ class UBSManagementServiceImplTest {
     }
 
     @Test
+    void updateOrderAdminPageInfoWithNullFieldsTest() {
+        Order order = ModelUtils.getOrder();
+        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(getTariffsInfo());
+        order.setOrderStatus(OrderStatus.BROUGHT_IT_HIMSELF);
+        EmployeeOrderPosition employeeOrderPosition = ModelUtils.getEmployeeOrderPosition();
+        Employee employee = ModelUtils.getEmployee();
+        List<Long> tariffsInfoIds = new ArrayList<>();
+        tariffsInfoIds.add(1L);
+        UpdateOrderPageAdminDto updateOrderPageAdminDto =
+            ModelUtils.updateOrderPageAdminDtoWithNullFields();
+
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(orderRepository.save(order)).thenReturn(order);
+        when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
+        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(ModelUtils.getPayment()));
+        when(receivingStationRepository.findAll()).thenReturn(List.of(ModelUtils.getReceivingStation()));
+
+        ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, 1L, "en", "test@gmail.com");
+
+        verify(orderRepository, times(3)).findById(1L);
+        verify(orderRepository, times(2)).save(order);
+        verify(employeeRepository, times(1)).findByEmail("test@gmail.com");
+        verify(employeeRepository).findTariffsInfoForEmployee(employee.getId());
+        verify(paymentRepository).findAllByOrderId(1L);
+        verify(receivingStationRepository).findAll();
+        verifyNoMoreInteractions(orderRepository, employeeRepository, paymentRepository, receivingStationRepository);
+    }
+
+    @Test
     void updateOrderAdminPageInfoTestThrowsException() {
         UpdateOrderPageAdminDto updateOrderPageAdminDto = updateOrderPageAdminDto();
         Order order = ModelUtils.getOrder();


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

## Link to issue

https://github.com/ita-social-projects/GreenCity/issues/5126

## Summary of change

1. Fixed save null order feilds receivingStation, dateOfExport, deliverFrom, deliverTo and delete responsible employees  in updateOrderDetailStatus() at UBSManagementServiceImpl.class if order status changed to 'BROUGHT_IT_HIMSELF', 'CANCELED'  or 'FORMED'.
2. Tests added to UBSManagementServiceImplTest.class.
3. Utiles methods added to ModelUtils.class

## Testing approach

Runing tests for order status 'BROUGHT_IT_HIMSELF', 'CANCELED'  and 'FORMED'.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
