### PR TITLE
Change order status from "CONFIRMED" to "ON_THE_ROUTE" automatically at 00:00 on the day of order fulfillment

### DIFF
--- a/dao/src/main/java/greencity/repository/OrderRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderRepository.java
@@ -221,4 +221,23 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query(nativeQuery = true,
         value = "UPDATE orders SET cancellation_reason = :cancellationReason WHERE id = :orderId")
     void updateCancelingReason(Long orderId, String cancellationReason);
+
+    /**
+     * Method update orders status from actual status to expected status by specific
+     * date.
+     *
+     * @param actualStatus   - update from order status
+     * @param expectedStatus - update to order status
+     * @param currentDate    - order date of export
+     */
+    @Modifying
+    @Transactional
+    @Query(nativeQuery = true,
+        value = "UPDATE orders "
+            + "SET order_status = :expected_status "
+            + "WHERE order_status = :actual_status "
+            + "AND date_of_export = :currentDate")
+    void updateOrderStatusToExpected(@Param("actual_status") String actualStatus,
+        @Param("expected_status") String expectedStatus,
+        @Param("currentDate") LocalDate currentDate);
 }

--- a/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
@@ -294,4 +294,12 @@ public interface UBSManagementService {
      * @author Hlazova Nataliia.
      */
     Boolean checkEmployeeForOrder(Long orderId, String email);
+
+    /**
+     * This is method which is updates orders status at 00:00 everyday where date of
+     * export equals current date.
+     *
+     * @author Anatolii Shapiro.
+     */
+    void updateOrderStatusToExpected();
 }

--- a/service/src/main/java/greencity/config/OrderStatusScheduler.java
+++ b/service/src/main/java/greencity/config/OrderStatusScheduler.java
@@ -1,0 +1,28 @@
+package greencity.config;
+
+import greencity.service.ubs.UBSManagementServiceImpl;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Slf4j
+@Configuration
+@EnableScheduling
+@NoArgsConstructor
+public class OrderStatusScheduler {
+    @Autowired
+    private UBSManagementServiceImpl ubsManagementService;
+
+    /**
+     * Method auto update the orders status from "CONFIRMED" to "ON_THE_ROUTE" on
+     * the day of export.
+     */
+    @Scheduled(cron = "0 0 0 * * *", zone = "Europe/Kiev")
+    public void autoUpdateOrderStatus() {
+        log.info("Update order status from actual status to expected status by the day of export");
+        ubsManagementService.updateOrderStatusToExpected();
+    }
+}

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1851,4 +1851,11 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                 .build());
         notificationService.notifyBonuses(order, (long) points);
     }
+
+    @Override
+    public void updateOrderStatusToExpected() {
+        orderRepository.updateOrderStatusToExpected(OrderStatus.CONFIRMED.name(),
+            OrderStatus.ON_THE_ROUTE.name(),
+            LocalDate.now());
+    }
 }

--- a/service/src/test/java/greencity/config/OrderStatusSchedulerTest.java
+++ b/service/src/test/java/greencity/config/OrderStatusSchedulerTest.java
@@ -1,0 +1,30 @@
+package greencity.config;
+
+import greencity.service.ubs.UBSManagementServiceImpl;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class OrderStatusSchedulerTest {
+    @InjectMocks
+    private OrderStatusScheduler orderStatusScheduler;
+
+    @Mock
+    private UBSManagementServiceImpl ubsManagementService;
+
+    @Test
+    void autoChangeOrderStatusOnTheDayOfExportTest() {
+        orderStatusScheduler.autoUpdateOrderStatus();
+        log.info("Update order status from actual status to expected status by the day of export");
+        verify(ubsManagementService, times(1)).updateOrderStatusToExpected();
+    }
+
+}

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -51,6 +51,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 import javax.persistence.EntityNotFoundException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -2273,5 +2274,13 @@ class UBSManagementServiceImplTest {
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
         assertEquals(true, ubsManagementService.checkEmployeeForOrder(order.getId(), "test@gmail.com"));
+    }
+
+    @Test
+    void updateOrderStatusToExpected() {
+        ubsManagementService.updateOrderStatusToExpected();
+        verify(orderRepository).updateOrderStatusToExpected(OrderStatus.CONFIRMED.name(),
+            OrderStatus.ON_THE_ROUTE.name(),
+            LocalDate.now());
     }
 }


### PR DESCRIPTION
dev
## Border

* [Main border ticket](https://github.com/ita-social-projects/GreenCity/issues/5034)


## Code reviewers

- [ ] @ABbondar 
- [ ] @juseti 
- [ ] @JJJazl 
- [ ] @NKorzhik 
- [ ] @LiliaMokhnatska 

## Summary of issue

The order status from "**Підтверджено**" to "**На маршруті**" is not changed and is not set automatically at **00:00** on the day of order fulfillment

1) add new method  in OrderRepository to update order status.

2) implement method in UBSManagementServiceImpl

3) add test for method in UBSManagementServiceImplTest

4) creat OrderStatusScheduler with a method to automatically update the order status at 00:00 at night, where the order status = "CONFIRMED" and date of export = current date

5) add test for OrderStatusScheduler

## Summary of change

1) added new method "updateOrderStatusToExpected" in OrderRepository to update order status.

2) added method "updateOrderStatusToExpected" in UBSManagementService, because checkstyle test did not pass.

3) method implementation in UBSManagementServiceImpl

4) added test for "updateOrderStatusToExpected" method in UBSManagementServiceImplTest

5) created OrderStatusScheduler with a method to automatically update the order status at 00:00 at night, where the order status = "CONFIRMED" and date of export = current date

6) added test for OrderStatusScheduler

## Testing approach

Has been tested on local database several times, for several time periods

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions