### PR TITLE
Bug fix 400 error when admin trying add comment to order

### DIFF
--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -522,7 +522,7 @@ public class ModelUtils {
 
     public static RequestToChangeOrdersDataDto getRequestToChangeOrdersDataDTO() {
         return RequestToChangeOrdersDataDto.builder()
-            .orderId(List.of(1L))
+            .orderIdsList(List.of(1L))
             .columnName("name")
             .newValue("1")
             .build();

--- a/dao/src/main/java/greencity/repository/OrderRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderRepository.java
@@ -211,6 +211,17 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     void updateCancelingComment(Long orderId, String cancellationComment);
 
     /**
+     * Method sets admin comment for order by order id.
+     * 
+     * @param orderId      - order's ID
+     * @param adminComment - admin comment to set
+     */
+    @Modifying
+    @Transactional
+    @Query(value = "UPDATE Order o SET o.adminComment =:adminComment WHERE o.id =:orderId")
+    void updateAdminComment(Long orderId, String adminComment);
+
+    /**
      * Method sets order cancellation reason by order's id.
      *
      * @param orderId            - order's ID

--- a/service-api/src/main/java/greencity/dto/order/RequestToChangeOrdersDataDto.java
+++ b/service-api/src/main/java/greencity/dto/order/RequestToChangeOrdersDataDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 @EqualsAndHashCode
 @Builder
 public class RequestToChangeOrdersDataDto {
-    private List<Long> orderId;
+    private List<Long> orderIdsList;
     private String columnName;
     private String newValue;
 }

--- a/service/src/main/java/greencity/service/ubs/OrdersAdminsPageServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/OrdersAdminsPageServiceImpl.java
@@ -426,15 +426,14 @@ public class OrdersAdminsPageServiceImpl implements OrdersAdminsPageService {
         return unresolvedGoals;
     }
 
-    private List<Long> addCommentToOrder(List<Long> ordersId, String value, Employee employee,
-        String orderHistoryMessage) {
+    private List<Long> cancellationCommentForDevelopStage(List<Long> ordersId, String value, Employee employee) {
         List<Long> unresolvedGoals = new ArrayList<>();
         for (Long orderId : ordersId) {
             try {
                 Order existedOrder = orderRepository.findById(orderId)
                     .orElseThrow(() -> new EntityNotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST));
-                orderRepository.updateAdminComment(orderId, value);
-                eventService.saveEvent(orderHistoryMessage + "  " + value, employee.getEmail(),
+                orderRepository.updateCancelingComment(orderId, value);
+                eventService.saveEvent(OrderHistory.ORDER_CANCELLED + "  " + value, employee.getEmail(),
                     existedOrder);
             } catch (Exception e) {
                 unresolvedGoals.add(orderId);
@@ -443,12 +442,20 @@ public class OrdersAdminsPageServiceImpl implements OrdersAdminsPageService {
         return unresolvedGoals;
     }
 
-    private List<Long> cancellationCommentForDevelopStage(List<Long> ordersId, String value, Employee employee) {
-        return addCommentToOrder(ordersId, value, employee, OrderHistory.ORDER_CANCELLED);
-    }
-
     private List<Long> adminCommentForDevelopStage(List<Long> ordersId, String value, Employee employee) {
-        return addCommentToOrder(ordersId, value, employee, OrderHistory.ADD_ADMIN_COMMENT);
+        List<Long> unresolvedGoals = new ArrayList<>();
+        for (Long orderId : ordersId) {
+            try {
+                Order existedOrder = orderRepository.findById(orderId)
+                    .orElseThrow(() -> new EntityNotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST));
+                orderRepository.updateAdminComment(orderId, value);
+                eventService.saveEvent(OrderHistory.ADD_ADMIN_COMMENT + "  " + value, employee.getEmail(),
+                    existedOrder);
+            } catch (Exception e) {
+                unresolvedGoals.add(orderId);
+            }
+        }
+        return unresolvedGoals;
     }
 
     @Override

--- a/service/src/main/java/greencity/service/ubs/OrdersAdminsPageServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/OrdersAdminsPageServiceImpl.java
@@ -187,7 +187,7 @@ public class OrdersAdminsPageServiceImpl implements OrdersAdminsPageService {
         String value = requestToChangeOrdersDataDTO.getNewValue();
         List<Long> ordersId = requestToChangeOrdersDataDTO.getOrderIdsList();
         Employee employee = employeeRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException(EMPLOYEE_NOT_FOUND));
+            .orElseThrow(() -> new EntityNotFoundException(EMPLOYEE_NOT_FOUND));
         switch (columnName) {
             case ORDER_STATUS:
                 return createReturnForSwitchChangeOrder(orderStatusForDevelopStage(ordersId, value, employee.getId()));
@@ -196,7 +196,8 @@ public class OrdersAdminsPageServiceImpl implements OrdersAdminsPageService {
             case TIME_OF_EXPORT:
                 return createReturnForSwitchChangeOrder(timeOfExportForDevelopStage(ordersId, value, employee.getId()));
             case RECEIVING:
-                return createReturnForSwitchChangeOrder(receivingStationForDevelopStage(ordersId, value, employee.getId()));
+                return createReturnForSwitchChangeOrder(
+                    receivingStationForDevelopStage(ordersId, value, employee.getId()));
             case CANCELLATION_REASON:
                 return createReturnForSwitchChangeOrder(cancellationReasonForDevelopStage(ordersId, value));
             case CANCELLATION_COMMENT:
@@ -424,27 +425,32 @@ public class OrdersAdminsPageServiceImpl implements OrdersAdminsPageService {
         }
         return unresolvedGoals;
     }
-    private List<Long> addCommentToOrder(List<Long> ordersId, String value, Employee employee, String orderHistoryMessage) {
+
+    private List<Long> addCommentToOrder(List<Long> ordersId, String value, Employee employee,
+        String orderHistoryMessage) {
         List<Long> unresolvedGoals = new ArrayList<>();
         for (Long orderId : ordersId) {
             try {
                 Order existedOrder = orderRepository.findById(orderId)
-                        .orElseThrow(() -> new EntityNotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST));
+                    .orElseThrow(() -> new EntityNotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST));
                 orderRepository.updateAdminComment(orderId, value);
                 eventService.saveEvent(orderHistoryMessage + "  " + value, employee.getEmail(),
-                        existedOrder);
+                    existedOrder);
             } catch (Exception e) {
                 unresolvedGoals.add(orderId);
             }
         }
         return unresolvedGoals;
     }
+
     private List<Long> cancellationCommentForDevelopStage(List<Long> ordersId, String value, Employee employee) {
         return addCommentToOrder(ordersId, value, employee, OrderHistory.ORDER_CANCELLED);
     }
+
     private List<Long> adminCommentForDevelopStage(List<Long> ordersId, String value, Employee employee) {
         return addCommentToOrder(ordersId, value, employee, OrderHistory.ADD_ADMIN_COMMENT);
     }
+
     @Override
     public synchronized List<Long> dateOfExportForDevelopStage(List<Long> ordersId, String value, Long employeeId) {
         LocalDate date = LocalDate.parse(value.substring(0, 10), DateTimeFormatter.ISO_LOCAL_DATE);

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -193,6 +193,7 @@ import static java.util.Collections.singletonList;
 
 public class ModelUtils {
 
+    public static final String TEST_EMAIL = "test@gmail.com";
     public static final Order TEST_ORDER = createOrder();
     public static final Address TEST_ADDRESS = createAddress2();
     public static final OrderAddressDtoResponse TEST_ORDER_ADDRESS_DTO_RESPONSE = createOrderAddressDtoResponse();
@@ -455,7 +456,6 @@ public class ModelUtils {
                         .latitude(49.83)
                         .longitude(23.88)
                         .build())
-                    // .user(User.builder().id(1L).build())
                     .build())
                 .build())
             .user(User.builder()
@@ -3399,9 +3399,16 @@ public class ModelUtils {
     public static RequestToChangeOrdersDataDto getRequestToChangeOrdersDataDTO() {
         return RequestToChangeOrdersDataDto.builder()
             .columnName("orderStatus")
-            .orderId(List.of(1L))
+            .orderIdsList(List.of(1L))
             .newValue("1")
             .build();
+    }
+    public static RequestToChangeOrdersDataDto getRequestToAddAdminCommentForOrder() {
+        return RequestToChangeOrdersDataDto.builder()
+                .columnName("adminComment")
+                .orderIdsList(List.of(1L))
+                .newValue("Admin Comment")
+                .build();
     }
 
     public static List<Bot> botList() {
@@ -3462,7 +3469,6 @@ public class ModelUtils {
                         .latitude(49.83)
                         .longitude(23.88)
                         .build())
-                    // .user(User.builder().id(1L).build())
                     .build())
                 .build())
             .user(User.builder().id(1L).recipientName("Yuriy").recipientSurname("Gerasum").build())

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -3403,12 +3403,13 @@ public class ModelUtils {
             .newValue("1")
             .build();
     }
+
     public static RequestToChangeOrdersDataDto getRequestToAddAdminCommentForOrder() {
         return RequestToChangeOrdersDataDto.builder()
-                .columnName("adminComment")
-                .orderIdsList(List.of(1L))
-                .newValue("Admin Comment")
-                .build();
+            .columnName("adminComment")
+            .orderIdsList(List.of(1L))
+            .newValue("Admin Comment")
+            .build();
     }
 
     public static List<Bot> botList() {

--- a/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
@@ -2,6 +2,7 @@ package greencity.service.ubs;
 
 import greencity.ModelUtils;
 import greencity.client.UserRemoteClient;
+import greencity.constant.ErrorMessage;
 import greencity.dto.courier.ReceivingStationDto;
 import greencity.dto.order.RequestToChangeOrdersDataDto;
 import greencity.enums.OrderStatus;
@@ -198,7 +199,62 @@ class OrdersAdminsPageServiceImplTest {
             .thenReturn(employeeList);
         assertNotNull(ordersAdminsPageService.getParametersForOrdersTable("1"));
     }
+    @Test
+    void chooseOrderDataSwitcherThrowEntityNotFoundExceptionTest() {
+        String email = ModelUtils.TEST_EMAIL;
+        var requestToChangeOrdersDataDto = ModelUtils.getRequestToChangeOrdersDataDTO();
+        var entityNotFoundException = assertThrows(
+                EntityNotFoundException.class,
+                () -> ordersAdminsPageService.chooseOrdersDataSwitcher(email, requestToChangeOrdersDataDto));
 
+        assertEquals(ErrorMessage.EMPLOYEE_NOT_FOUND, entityNotFoundException.getMessage());
+
+        verify(employeeRepository).findByEmail(email);
+    }
+    @Test
+    void addCommentToOrderReturnNotEmptyList(){
+        String email = ModelUtils.TEST_EMAIL;
+        var requestToChangeOrdersDataDto = ModelUtils.getRequestToAddAdminCommentForOrder();
+        var employee = ModelUtils.getEmployee();
+
+        when(employeeRepository.findByEmail(email)).thenReturn(Optional.of(employee));
+
+        var changeOrderResponseDTO = ordersAdminsPageService.chooseOrdersDataSwitcher(
+                email,
+                requestToChangeOrdersDataDto);
+
+        assertEquals(
+                requestToChangeOrdersDataDto.getOrderIdsList().size(),
+                changeOrderResponseDTO.getUnresolvedGoalsOrderId().size());
+
+        int orderRepositoryFindByIdCalls = requestToChangeOrdersDataDto.getOrderIdsList().size();
+
+        verify(employeeRepository).findByEmail(email);
+        verify(orderRepository, times(orderRepositoryFindByIdCalls)).findById(anyLong());
+    }
+    @Test
+    void addCommentToOrderReturnEmptyList() {
+        String email = ModelUtils.TEST_EMAIL;
+        var requestToChangeOrdersDataDto = ModelUtils.getRequestToAddAdminCommentForOrder();
+        var employee = ModelUtils.getEmployee();
+        var order = ModelUtils.getOrder();
+
+        when(employeeRepository.findByEmail(email)).thenReturn(Optional.of(employee));
+        when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
+
+        var changeOrderResponseDto = ordersAdminsPageService.chooseOrdersDataSwitcher(
+                email,
+                requestToChangeOrdersDataDto);
+
+        assertEquals(
+                0,
+                changeOrderResponseDto.getUnresolvedGoalsOrderId().size());
+
+        int orderRepositoryFindByIdCalls = requestToChangeOrdersDataDto.getOrderIdsList().size();
+
+        verify(employeeRepository).findByEmail(email);
+        verify(orderRepository, times(orderRepositoryFindByIdCalls)).findById(anyLong());
+    }
     @ParameterizedTest
     @CsvSource({
         "FORMED, ADJUSTMENT",
@@ -386,7 +442,6 @@ class OrdersAdminsPageServiceImplTest {
 
         when(receivingStationRepository.getOne(1L)).thenReturn(ModelUtils.getReceivingStation());
         when(employeeRepository.findByEmail(email)).thenReturn(employee);
-        when(employeeRepository.findById(1L)).thenReturn(employee);
 
         ordersAdminsPageService.chooseOrdersDataSwitcher(email, dto);
         dto.setColumnName("dateOfExport");

--- a/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
@@ -404,6 +404,8 @@ class OrdersAdminsPageServiceImplTest {
         dto.setColumnName("cancellationComment");
         dto.setNewValue("Comment");
         ordersAdminsPageService.chooseOrdersDataSwitcher(email, dto);
+        dto.setColumnName("adminComment");
+        dto.setNewValue("Admin Comment");
 
         verify(receivingStationRepository, atLeast(1)).getOne(1L);
         verify(employeeRepository, atLeast(1)).findByEmail(email);

--- a/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
@@ -214,7 +214,7 @@ class OrdersAdminsPageServiceImplTest {
     }
 
     @Test
-    void addCommentToOrderReturnNotEmptyList() {
+    void adminCommentForDevelopStageReturnNotEmptyList() {
         String email = ModelUtils.TEST_EMAIL;
         var requestToChangeOrdersDataDto = ModelUtils.getRequestToAddAdminCommentForOrder();
         var employee = ModelUtils.getEmployee();
@@ -236,7 +236,7 @@ class OrdersAdminsPageServiceImplTest {
     }
 
     @Test
-    void addCommentToOrderReturnEmptyList() {
+    void adminCommentForDevelopStageReturnEmptyList() {
         String email = ModelUtils.TEST_EMAIL;
         var requestToChangeOrdersDataDto = ModelUtils.getRequestToAddAdminCommentForOrder();
         var employee = ModelUtils.getEmployee();

--- a/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
@@ -199,20 +199,22 @@ class OrdersAdminsPageServiceImplTest {
             .thenReturn(employeeList);
         assertNotNull(ordersAdminsPageService.getParametersForOrdersTable("1"));
     }
+
     @Test
     void chooseOrderDataSwitcherThrowEntityNotFoundExceptionTest() {
         String email = ModelUtils.TEST_EMAIL;
         var requestToChangeOrdersDataDto = ModelUtils.getRequestToChangeOrdersDataDTO();
         var entityNotFoundException = assertThrows(
-                EntityNotFoundException.class,
-                () -> ordersAdminsPageService.chooseOrdersDataSwitcher(email, requestToChangeOrdersDataDto));
+            EntityNotFoundException.class,
+            () -> ordersAdminsPageService.chooseOrdersDataSwitcher(email, requestToChangeOrdersDataDto));
 
         assertEquals(ErrorMessage.EMPLOYEE_NOT_FOUND, entityNotFoundException.getMessage());
 
         verify(employeeRepository).findByEmail(email);
     }
+
     @Test
-    void addCommentToOrderReturnNotEmptyList(){
+    void addCommentToOrderReturnNotEmptyList() {
         String email = ModelUtils.TEST_EMAIL;
         var requestToChangeOrdersDataDto = ModelUtils.getRequestToAddAdminCommentForOrder();
         var employee = ModelUtils.getEmployee();
@@ -220,18 +222,19 @@ class OrdersAdminsPageServiceImplTest {
         when(employeeRepository.findByEmail(email)).thenReturn(Optional.of(employee));
 
         var changeOrderResponseDTO = ordersAdminsPageService.chooseOrdersDataSwitcher(
-                email,
-                requestToChangeOrdersDataDto);
+            email,
+            requestToChangeOrdersDataDto);
 
         assertEquals(
-                requestToChangeOrdersDataDto.getOrderIdsList().size(),
-                changeOrderResponseDTO.getUnresolvedGoalsOrderId().size());
+            requestToChangeOrdersDataDto.getOrderIdsList().size(),
+            changeOrderResponseDTO.getUnresolvedGoalsOrderId().size());
 
         int orderRepositoryFindByIdCalls = requestToChangeOrdersDataDto.getOrderIdsList().size();
 
         verify(employeeRepository).findByEmail(email);
         verify(orderRepository, times(orderRepositoryFindByIdCalls)).findById(anyLong());
     }
+
     @Test
     void addCommentToOrderReturnEmptyList() {
         String email = ModelUtils.TEST_EMAIL;
@@ -243,18 +246,19 @@ class OrdersAdminsPageServiceImplTest {
         when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
 
         var changeOrderResponseDto = ordersAdminsPageService.chooseOrdersDataSwitcher(
-                email,
-                requestToChangeOrdersDataDto);
+            email,
+            requestToChangeOrdersDataDto);
 
         assertEquals(
-                0,
-                changeOrderResponseDto.getUnresolvedGoalsOrderId().size());
+            0,
+            changeOrderResponseDto.getUnresolvedGoalsOrderId().size());
 
         int orderRepositoryFindByIdCalls = requestToChangeOrdersDataDto.getOrderIdsList().size();
 
         verify(employeeRepository).findByEmail(email);
         verify(orderRepository, times(orderRepositoryFindByIdCalls)).findById(anyLong());
     }
+
     @ParameterizedTest
     @CsvSource({
         "FORMED, ADJUSTMENT",


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @Markiro1 
- [ ] @juseti 
- [ ] @NKorzhik 
- [ ] @ABbondar 
- [ ] @OlegVat 
- [ ] @MaksymGolik 

### Second Level Review

- [ ] @github_username

## Summary of issue

400 error is returned when an administrator tries to add a comment to an order

## Summary of change

1) added method updateAdminComment() in OrderRepository
OrdersAdminsPageServiceImpl class:
2) added ADMIN_COMMENT constant variable
3) added method adminCommentForDevelopStage()
4) added new switch case in chooseOrdersDataSwitcher() method 5) changed test method chooseOrdersDataSwitcherTest() in OrdersAdminsPageServiceImplTest

## Testing approach

1. User is logged in as an administrator.
2. Go to https://www.testgreencity.ga/GreenCityClient/#/ubs-admin/
3. User navigated to UBS > Orders
4. Open order from the list of orders
5. Add a comment to order

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions