### PR TITLE
[UBS] - refactoring methods and endpoints to include/exclude limits for bag #5217

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -145,8 +145,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 SUPER_ADMIN_LINK + "/setLimitsBySumOfOrder/{tariffId}",
                 SUPER_ADMIN_LINK + "/setTariffLimits/{tariffId}",
                 SUPER_ADMIN_LINK + "/deactivateCourier/{id}",
-                SUPER_ADMIN_LINK + "/excludeBag/{id}",
-                SUPER_ADMIN_LINK + "/includeBag/{id}")
+                SUPER_ADMIN_LINK + "/includeLimit/{bagId}",
+                SUPER_ADMIN_LINK + "/excludeLimit/{bagId}")
             .hasAnyRole(ADMIN, UBS_EMPLOYEE)
             .antMatchers(HttpMethod.PATCH,
                 UBS_MANAG_LINK + "/update-order-page-admin-info/{id}",

--- a/core/src/main/java/greencity/controller/SuperAdminController.java
+++ b/core/src/main/java/greencity/controller/SuperAdminController.java
@@ -447,10 +447,11 @@ class SuperAdminController {
     /**
      * Controller for include Bag.
      *
-     * @return {@link GetTariffServiceDto}
+     * @param id {@link Integer} - bag id
+     * @return {@link GetTariffServiceDto} - tariff service dto
      * @author Vadym Makitra
      */
-    @ApiOperation(value = "Include bag")
+    @ApiOperation(value = "Include limit for bag")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK, response = GetTariffServiceDto.class),
         @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
@@ -458,19 +459,20 @@ class SuperAdminController {
         @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
         @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
-    @PatchMapping("/includeBag/{id}")
+    @PatchMapping("/includeLimit/{id}")
     public ResponseEntity<GetTariffServiceDto> includeBag(
         @PathVariable Integer id) {
-        return ResponseEntity.status(HttpStatus.OK).body(superAdminService.includeBag(id));
+        return ResponseEntity.status(HttpStatus.OK).body(superAdminService.includeLimit(id));
     }
 
     /**
      * Controller for include Bag.
      *
-     * @return {@link GetTariffServiceDto}
+     * @param id {@link Integer} - bag id
+     * @return {@link GetTariffServiceDto} - tariff service dto
      * @author Vadym Makitra
      */
-    @ApiOperation(value = "Exclude bag")
+    @ApiOperation(value = "Exclude limit for bag")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK, response = GetTariffServiceDto.class),
         @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
@@ -478,10 +480,10 @@ class SuperAdminController {
         @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
         @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
-    @PatchMapping("/excludeBag/{id}")
+    @PatchMapping("/excludeLimit/{id}")
     public ResponseEntity<GetTariffServiceDto> excludeBag(
         @PathVariable Integer id) {
-        return ResponseEntity.status(HttpStatus.OK).body(superAdminService.excludeBag(id));
+        return ResponseEntity.status(HttpStatus.OK).body(superAdminService.excludeLimit(id));
     }
 
     /**

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -383,6 +383,7 @@ public class ModelUtils {
             .price(120)
             .commission(50)
             .description("Description")
+            .limitIncluded(true)
             .build();
     }
 

--- a/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
+++ b/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
@@ -775,26 +775,26 @@ class SuperAdminControllerTest {
     }
 
     @Test
-    void includeBag() throws Exception {
+    void includeLimit() throws Exception {
         GetTariffServiceDto dto = ModelUtils.getGetTariffServiceDto();
 
-        when(superAdminService.includeBag(1)).thenReturn(dto);
+        when(superAdminService.includeLimit(1)).thenReturn(dto);
 
-        mockMvc.perform(patch(ubsLink + "/includeBag/{id}", 1L)
+        mockMvc.perform(patch(ubsLink + "/includeLimit/{id}", 1L)
             .principal(principal)
             .param("id", "1"))
             .andExpect(status().isOk())
             .andReturn();
 
-        verify(superAdminService).includeBag(1);
+        verify(superAdminService).includeLimit(1);
     }
 
     @Test
-    void includeBagThrowNotFoundException() throws Exception {
-        when(superAdminService.includeBag(1))
+    void includeLimitThrowNotFoundException() throws Exception {
+        when(superAdminService.includeLimit(1))
             .thenThrow(new NotFoundException(ErrorMessage.BAG_NOT_FOUND));
 
-        mockMvc.perform(patch(ubsLink + "/includeBag/{id}", 1L)
+        mockMvc.perform(patch(ubsLink + "/includeLimit/{id}", 1L)
             .principal(principal)
             .param("id", "1"))
             .andExpect(status().isNotFound())
@@ -802,15 +802,15 @@ class SuperAdminControllerTest {
             .andExpect(result -> assertEquals(ErrorMessage.BAG_NOT_FOUND,
                 Objects.requireNonNull(result.getResolvedException()).getMessage()));
 
-        verify(superAdminService).includeBag(1);
+        verify(superAdminService).includeLimit(1);
     }
 
     @Test
-    void includeBagThrowBadRequestException() throws Exception {
-        when(superAdminService.includeBag(1))
+    void includeLimitThrowBadRequestException() throws Exception {
+        when(superAdminService.includeLimit(1))
             .thenThrow(new BadRequestException(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET));
 
-        mockMvc.perform(patch(ubsLink + "/includeBag/{id}", 1L)
+        mockMvc.perform(patch(ubsLink + "/includeLimit/{id}", 1L)
             .principal(principal)
             .param("id", "1"))
             .andExpect(status().isBadRequest())
@@ -818,30 +818,31 @@ class SuperAdminControllerTest {
             .andExpect(result -> assertEquals(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET,
                 Objects.requireNonNull(result.getResolvedException()).getMessage()));
 
-        verify(superAdminService).includeBag(1);
+        verify(superAdminService).includeLimit(1);
     }
 
     @Test
-    void excludeBag() throws Exception {
+    void excludeLimit() throws Exception {
         GetTariffServiceDto dto = ModelUtils.getGetTariffServiceDto();
+        dto.setLimitIncluded(false);
 
-        when(superAdminService.excludeBag(1)).thenReturn(dto);
+        when(superAdminService.excludeLimit(1)).thenReturn(dto);
 
-        mockMvc.perform(patch(ubsLink + "/excludeBag/{id}", 1L)
+        mockMvc.perform(patch(ubsLink + "/excludeLimit/{id}", 1L)
             .principal(principal)
             .param("id", "1"))
             .andExpect(status().isOk())
             .andReturn();
 
-        verify(superAdminService).excludeBag(1);
+        verify(superAdminService).excludeLimit(1);
     }
 
     @Test
-    void excludeBagThrowNotFoundException() throws Exception {
-        when(superAdminService.excludeBag(1))
+    void excludeLimitThrowNotFoundException() throws Exception {
+        when(superAdminService.excludeLimit(1))
             .thenThrow(new NotFoundException(ErrorMessage.BAG_NOT_FOUND));
 
-        mockMvc.perform(patch(ubsLink + "/excludeBag/{id}", 1L)
+        mockMvc.perform(patch(ubsLink + "/excludeLimit/{id}", 1L)
             .principal(principal)
             .param("id", "1"))
             .andExpect(status().isNotFound())
@@ -849,15 +850,15 @@ class SuperAdminControllerTest {
             .andExpect(result -> assertEquals(ErrorMessage.BAG_NOT_FOUND,
                 Objects.requireNonNull(result.getResolvedException()).getMessage()));
 
-        verify(superAdminService).excludeBag(1);
+        verify(superAdminService).excludeLimit(1);
     }
 
     @Test
-    void excludeBagThrowBadRequestException() throws Exception {
-        when(superAdminService.excludeBag(1))
+    void excludeLimitThrowBadRequestException() throws Exception {
+        when(superAdminService.excludeLimit(1))
             .thenThrow(new BadRequestException(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET));
 
-        mockMvc.perform(patch(ubsLink + "/excludeBag/{id}", 1L)
+        mockMvc.perform(patch(ubsLink + "/excludeLimit/{id}", 1L)
             .principal(principal)
             .param("id", "1"))
             .andExpect(status().isBadRequest())
@@ -865,7 +866,7 @@ class SuperAdminControllerTest {
             .andExpect(result -> assertEquals(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET,
                 Objects.requireNonNull(result.getResolvedException()).getMessage()));
 
-        verify(superAdminService).excludeBag(1);
+        verify(superAdminService).excludeLimit(1);
     }
 
     @Test

--- a/service-api/src/main/java/greencity/service/SuperAdminService.java
+++ b/service-api/src/main/java/greencity/service/SuperAdminService.java
@@ -184,22 +184,24 @@ public interface SuperAdminService {
     GetTariffsInfoDto setLimitDescription(Long courierId, String limitDescription);
 
     /**
-     * Method for include bag into minimum set of package.
+     * Method for include limit for bag.
      *
-     * @param id - if of bag.
+     * @param id - bag id.
      * @return {@link GetTariffServiceDto}
      * @author Vadym Makitra
+     * @author Julia Seti
      */
-    GetTariffServiceDto includeBag(Integer id);
+    GetTariffServiceDto includeLimit(Integer id);
 
     /**
-     * Method for exclude bag from minimum set of package.
+     * Method for exclude limit for bag.
      *
-     * @param id - if of bag.
+     * @param id - bag id.
      * @return {@link GetTariffServiceDto}
      * @author Vadym Makitra
+     * @author Julia Seti
      */
-    GetTariffServiceDto excludeBag(Integer id);
+    GetTariffServiceDto excludeLimit(Integer id);
 
     /**
      * Method for change status courier and tariffs to deactivate.

--- a/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
@@ -392,23 +392,23 @@ public class SuperAdminServiceImpl implements SuperAdminService {
     }
 
     @Override
-    public GetTariffServiceDto includeBag(Integer id) {
+    public GetTariffServiceDto includeLimit(Integer id) {
         Bag bag = getBagById(id);
-        if (bag.getMinAmountOfBags().equals(MinAmountOfBag.INCLUDE)) {
+        if (bag.getLimitIncluded()) {
             throw new BadRequestException(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET);
         }
-        bag.setMinAmountOfBags(MinAmountOfBag.INCLUDE);
+        bag.setLimitIncluded(true);
         bagRepository.save(bag);
         return modelMapper.map(bag, GetTariffServiceDto.class);
     }
 
     @Override
-    public GetTariffServiceDto excludeBag(Integer id) {
+    public GetTariffServiceDto excludeLimit(Integer id) {
         Bag bag = getBagById(id);
-        if (MinAmountOfBag.EXCLUDE.equals(bag.getMinAmountOfBags())) {
+        if (!bag.getLimitIncluded()) {
             throw new BadRequestException(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET);
         }
-        bag.setMinAmountOfBags(MinAmountOfBag.EXCLUDE);
+        bag.setLimitIncluded(false);
         bagRepository.save(bag);
         return modelMapper.map(bag, GetTariffServiceDto.class);
     }

--- a/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
@@ -394,7 +394,8 @@ public class SuperAdminServiceImpl implements SuperAdminService {
     @Override
     public GetTariffServiceDto includeLimit(Integer id) {
         Bag bag = getBagById(id);
-        if (bag.getLimitIncluded()) {
+        boolean limitIncluded = bag.getLimitIncluded();
+        if (limitIncluded) {
             throw new BadRequestException(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET);
         }
         bag.setLimitIncluded(true);
@@ -405,7 +406,8 @@ public class SuperAdminServiceImpl implements SuperAdminService {
     @Override
     public GetTariffServiceDto excludeLimit(Integer id) {
         Bag bag = getBagById(id);
-        if (!bag.getLimitIncluded()) {
+        boolean limitIncluded = bag.getLimitIncluded();
+        if (!limitIncluded) {
             throw new BadRequestException(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET);
         }
         bag.setLimitIncluded(false);

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2230,6 +2230,7 @@ public class ModelUtils {
             .description("Description")
             .descriptionEng("DescriptionEng")
             .minAmountOfBags(MinAmountOfBag.INCLUDE)
+            .limitIncluded(false)
             .build());
     }
 
@@ -2766,19 +2767,13 @@ public class ModelUtils {
         return Bag.builder()
             .id(1)
             .minAmountOfBags(MinAmountOfBag.INCLUDE)
+            .limitIncluded(false)
             .description("Description")
             .descriptionEng("DescriptionEng")
             .name("Test")
             .nameEng("a")
             .createdBy(getEmployee())
             .editedBy(getEmployee())
-            .build();
-    }
-
-    public static Bag bagDto2() {
-        return Bag.builder()
-            .id(1)
-            .minAmountOfBags(MinAmountOfBag.EXCLUDE)
             .build();
     }
 

--- a/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
@@ -622,15 +622,16 @@ class SuperAdminServiceImplTest {
     }
 
     @Test
-    void excludeBagTest() {
-        Bag bag = ModelUtils.bagDto();
+    void excludeLimitTest() {
+        Bag bag = ModelUtils.getBag().get();
+        bag.setLimitIncluded(true);
         GetTariffServiceDto dto = ModelUtils.getGetTariffServiceDto();
 
         when(bagRepository.findById(1)).thenReturn(Optional.of(bag));
         when(bagRepository.save(bag)).thenReturn(bag);
         when(modelMapper.map(bag, GetTariffServiceDto.class)).thenReturn(dto);
 
-        superAdminService.excludeBag(1);
+        superAdminService.excludeLimit(1);
 
         verify(bagRepository).findById(1);
         verify(bagRepository).save(bag);
@@ -638,34 +639,34 @@ class SuperAdminServiceImplTest {
     }
 
     @Test
-    void excludeBagThrowNotFoundException() {
+    void excludeLimitThrowNotFoundException() {
         when(bagRepository.findById(1)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class,
-            () -> superAdminService.excludeBag(1));
+            () -> superAdminService.excludeLimit(1));
 
         verify(bagRepository).findById(1);
         verify(bagRepository, never()).save(any(Bag.class));
     }
 
     @Test
-    void excludeBagThrowBadRequestException() {
-        Optional<Bag> bag = Optional.ofNullable(ModelUtils.bagDto2());
+    void excludeLimitThrowBadRequestException() {
+        Optional<Bag> bag = ModelUtils.getBag();
         when(bagRepository.findById(1)).thenReturn(bag);
-        assertThrows(BadRequestException.class, () -> superAdminService.excludeBag(1));
+        assertThrows(BadRequestException.class, () -> superAdminService.excludeLimit(1));
     }
 
     @Test
-    void includeBagTest() {
-        Bag bag = ModelUtils.bagDto();
+    void includeLimitTest() {
+        Bag bag = ModelUtils.getBag().get();
         GetTariffServiceDto dto = ModelUtils.getGetTariffServiceDto();
-        bag.setMinAmountOfBags(MinAmountOfBag.EXCLUDE);
+        dto.setLimitIncluded(true);
 
         when(bagRepository.findById(10)).thenReturn(Optional.of(bag));
         when(bagRepository.save(bag)).thenReturn(bag);
         when(modelMapper.map(bag, GetTariffServiceDto.class)).thenReturn(dto);
 
-        superAdminService.includeBag(10);
+        superAdminService.includeLimit(10);
 
         verify(bagRepository).findById(10);
         verify(bagRepository).save(bag);
@@ -673,21 +674,22 @@ class SuperAdminServiceImplTest {
     }
 
     @Test
-    void includeBagThrowNotFoundException() {
+    void includeLimitThrowNotFoundException() {
         when(bagRepository.findById(1)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class,
-            () -> superAdminService.includeBag(1));
+            () -> superAdminService.includeLimit(1));
 
         verify(bagRepository).findById(1);
         verify(bagRepository, never()).save(any(Bag.class));
     }
 
     @Test
-    void includeBagThrowBadRequestException() {
-        Optional<Bag> bag = Optional.ofNullable(ModelUtils.bagDto());
-        when(bagRepository.findById(1)).thenReturn(bag);
-        assertThrows(BadRequestException.class, () -> superAdminService.includeBag(1));
+    void includeLimitThrowBadRequestException() {
+        Bag bag = ModelUtils.bagDto();
+        bag.setLimitIncluded(true);
+        when(bagRepository.findById(1)).thenReturn(Optional.of(bag));
+        assertThrows(BadRequestException.class, () -> superAdminService.includeLimit(1));
     }
 
     @Test


### PR DESCRIPTION
## Link to issue

https://github.com/ita-social-projects/GreenCity/issues/5217

## Summary of change

- Endpoints /excludeBag/{id} and /includeBag/{id} renamed to /excludeLimit/{id} and /includeLimit/{id} respectively in  SuperAdminController.class.
- Fixed antMatchers endpoints /excludeLimit/{id} and /includeLimit/{id} in SecurityConfig.class.
- The excludeBag() and includeBag() methods have been renamed to includeLimit() and excludeLimit(), and their implementation in SuperAdminServiceImpl.class has been changed.
- Tests changed.

## Testing approach

Checked testing cases by endpoints /excludeLimit/{id} and /includeLimit/{id} in swagger.