### PR TITLE
UBS addCertificate  check if the certificate exists and change validations 

### DIFF
--- a/dao/src/main/java/greencity/repository/CertificateRepository.java
+++ b/dao/src/main/java/greencity/repository/CertificateRepository.java
@@ -51,4 +51,13 @@ public interface CertificateRepository extends JpaRepository<Certificate, String
      * @return set of {@link Certificate}
      */
     Set<Certificate> findAllByCodeAndCertificateStatus(List<String> code, CertificateStatus status);
+
+    /**
+     * Method to check if certificate is already exist by code.
+     *
+     * @param code - certificate code.
+     * @return return true if certificate exists and false if not.
+     * @author Lilia Mokhnatska
+     */
+    boolean existsCertificateByCode(String code);
 }

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -1,6 +1,7 @@
 package greencity.constant;
 
 public final class ErrorMessage {
+    public static final String CERTIFICATE_EXIST = "Certificate with this code is already exist";
     public static final String CERTIFICATE_NOT_FOUND_BY_CODE = "Certificate does not exist by this code: ";
     public static final String CERTIFICATE_EXPIRED = "Certificate expired by this code: ";
     public static final String CERTIFICATE_STATUS = "Certificate has status 'EXPIRED' or 'USED'";

--- a/service-api/src/main/java/greencity/dto/certificate/CertificateDtoForAdding.java
+++ b/service-api/src/main/java/greencity/dto/certificate/CertificateDtoForAdding.java
@@ -22,7 +22,7 @@ public class CertificateDtoForAdding {
     private int monthCount;
 
     @NotNull
-    @Min(1)
+    @Min(0)
     @Max(9999)
     private int points;
 

--- a/service/src/main/java/greencity/service/ubs/CertificateServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/CertificateServiceImpl.java
@@ -30,9 +30,13 @@ public class CertificateServiceImpl implements CertificateService {
 
     @Override
     public void addCertificate(CertificateDtoForAdding add) {
-        add.setPoints(add.getInitialPointsValue());
-        Certificate certificate = modelMapper.map(add, Certificate.class);
-        certificateRepository.save(certificate);
+        if (certificateRepository.existsCertificateByCode(add.getCode())) {
+            throw new BadRequestException(CERTIFICATE_EXIST);
+        } else {
+            add.setPoints(add.getInitialPointsValue());
+            Certificate certificate = modelMapper.map(add, Certificate.class);
+            certificateRepository.save(certificate);
+        }
     }
 
     @Override

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -884,7 +884,8 @@ public class ModelUtils {
         return CertificateDtoForAdding.builder()
             .code("1111-1234")
             .monthCount(0)
-            .points(10)
+            .initialPointsValue(10)
+            .points(0)
             .build();
     }
 

--- a/service/src/test/java/greencity/service/ubs/CertificateServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/CertificateServiceImplTest.java
@@ -1,5 +1,6 @@
 package greencity.service.ubs;
 
+import greencity.ModelUtils;
 import greencity.dto.certificate.CertificateDtoForAdding;
 import greencity.enums.CertificateStatus;
 import greencity.entity.order.Certificate;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,6 +52,18 @@ class CertificateServiceImplTest {
         when(modelMapper.map(certificateDtoForAdding, Certificate.class)).thenReturn(certificate);
         certificateService.addCertificate(certificateDtoForAdding);
         verify(certificateRepository, times(1)).save(certificate);
+    }
+
+    @Test
+    void addCertificateBadRequestException() {
+        CertificateDtoForAdding certificate = ModelUtils.getCertificateDtoForAdding();
+        when(certificateRepository.existsCertificateByCode("1111-1234")).thenReturn(true);
+
+        assertThrows(BadRequestException.class,
+            () -> certificateService.addCertificate(certificate));
+
+        verify(certificateRepository).existsCertificateByCode("1111-1234");
+        verify(certificateRepository, never()).save(any(Certificate.class));
     }
 
     @Test


### PR DESCRIPTION

## Summary Of Issue :
The 400 response code occurs when Admin tries to add a certificate

  Expected result
Admin can add certificates with a sum from 1 to 9999.00 UAH

When add certificate from swagger with code that already exist it be overwrited 
  Expected result 
It is not allowed to add a certificate with an existing code


## Issue Link :
https://github.com/ita-social-projects/GreenCity/issues/5144

## Summary Of Changes :
1. Change min value of point variable in CertificateDtoForAdding
2. Add method existsCertificateByCode in CertificateRepository 
3. Add CERTIFICATE_EXIST message 
4. Change method addCertificate in CertificateServiceImpl
5. Add test for new code


## How to test :
Steps to reproduce
1. Click on the 'Add certificate' bttn
6. Fill up all necessary fields on the pop-up "Add certificate" and set the sum of a certificate that (1 UAH, 9 999 UAH)
7. Click on the 'Add' bttns





## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-#5144: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers