### PR TITLE
[UBS] - change the request method from patch to put on endpoints for include and exclude bag limit #5247

### DIFF
--- a/core/src/main/java/greencity/controller/SuperAdminController.java
+++ b/core/src/main/java/greencity/controller/SuperAdminController.java
@@ -454,12 +454,11 @@ class SuperAdminController {
     @ApiOperation(value = "Include limit for bag")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK, response = GetTariffServiceDto.class),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
         @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
         @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
         @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
-    @PatchMapping("/includeLimit/{id}")
+    @PutMapping("/includeLimit/{id}")
     public ResponseEntity<GetTariffServiceDto> includeBag(
         @PathVariable Integer id) {
         return ResponseEntity.status(HttpStatus.OK).body(superAdminService.includeLimit(id));
@@ -475,12 +474,11 @@ class SuperAdminController {
     @ApiOperation(value = "Exclude limit for bag")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK, response = GetTariffServiceDto.class),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
         @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
         @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
         @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
-    @PatchMapping("/excludeLimit/{id}")
+    @PutMapping("/excludeLimit/{id}")
     public ResponseEntity<GetTariffServiceDto> excludeBag(
         @PathVariable Integer id) {
         return ResponseEntity.status(HttpStatus.OK).body(superAdminService.excludeLimit(id));

--- a/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
+++ b/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
@@ -780,7 +780,7 @@ class SuperAdminControllerTest {
 
         when(superAdminService.includeLimit(1)).thenReturn(dto);
 
-        mockMvc.perform(patch(ubsLink + "/includeLimit/{id}", 1L)
+        mockMvc.perform(put(ubsLink + "/includeLimit/{id}", 1L)
             .principal(principal)
             .param("id", "1"))
             .andExpect(status().isOk())
@@ -794,28 +794,12 @@ class SuperAdminControllerTest {
         when(superAdminService.includeLimit(1))
             .thenThrow(new NotFoundException(ErrorMessage.BAG_NOT_FOUND));
 
-        mockMvc.perform(patch(ubsLink + "/includeLimit/{id}", 1L)
+        mockMvc.perform(put(ubsLink + "/includeLimit/{id}", 1L)
             .principal(principal)
             .param("id", "1"))
             .andExpect(status().isNotFound())
             .andExpect(result -> assertTrue(result.getResolvedException() instanceof NotFoundException))
             .andExpect(result -> assertEquals(ErrorMessage.BAG_NOT_FOUND,
-                Objects.requireNonNull(result.getResolvedException()).getMessage()));
-
-        verify(superAdminService).includeLimit(1);
-    }
-
-    @Test
-    void includeLimitThrowBadRequestException() throws Exception {
-        when(superAdminService.includeLimit(1))
-            .thenThrow(new BadRequestException(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET));
-
-        mockMvc.perform(patch(ubsLink + "/includeLimit/{id}", 1L)
-            .principal(principal)
-            .param("id", "1"))
-            .andExpect(status().isBadRequest())
-            .andExpect(result -> assertTrue(result.getResolvedException() instanceof BadRequestException))
-            .andExpect(result -> assertEquals(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET,
                 Objects.requireNonNull(result.getResolvedException()).getMessage()));
 
         verify(superAdminService).includeLimit(1);
@@ -828,7 +812,7 @@ class SuperAdminControllerTest {
 
         when(superAdminService.excludeLimit(1)).thenReturn(dto);
 
-        mockMvc.perform(patch(ubsLink + "/excludeLimit/{id}", 1L)
+        mockMvc.perform(put(ubsLink + "/excludeLimit/{id}", 1L)
             .principal(principal)
             .param("id", "1"))
             .andExpect(status().isOk())
@@ -842,28 +826,12 @@ class SuperAdminControllerTest {
         when(superAdminService.excludeLimit(1))
             .thenThrow(new NotFoundException(ErrorMessage.BAG_NOT_FOUND));
 
-        mockMvc.perform(patch(ubsLink + "/excludeLimit/{id}", 1L)
+        mockMvc.perform(put(ubsLink + "/excludeLimit/{id}", 1L)
             .principal(principal)
             .param("id", "1"))
             .andExpect(status().isNotFound())
             .andExpect(result -> assertTrue(result.getResolvedException() instanceof NotFoundException))
             .andExpect(result -> assertEquals(ErrorMessage.BAG_NOT_FOUND,
-                Objects.requireNonNull(result.getResolvedException()).getMessage()));
-
-        verify(superAdminService).excludeLimit(1);
-    }
-
-    @Test
-    void excludeLimitThrowBadRequestException() throws Exception {
-        when(superAdminService.excludeLimit(1))
-            .thenThrow(new BadRequestException(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET));
-
-        mockMvc.perform(patch(ubsLink + "/excludeLimit/{id}", 1L)
-            .principal(principal)
-            .param("id", "1"))
-            .andExpect(status().isBadRequest())
-            .andExpect(result -> assertTrue(result.getResolvedException() instanceof BadRequestException))
-            .andExpect(result -> assertEquals(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET,
                 Objects.requireNonNull(result.getResolvedException()).getMessage()));
 
         verify(superAdminService).excludeLimit(1);

--- a/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
@@ -394,10 +394,6 @@ public class SuperAdminServiceImpl implements SuperAdminService {
     @Override
     public GetTariffServiceDto includeLimit(Integer id) {
         Bag bag = getBagById(id);
-        boolean limitIncluded = bag.getLimitIncluded();
-        if (limitIncluded) {
-            throw new BadRequestException(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET);
-        }
         bag.setLimitIncluded(true);
         bagRepository.save(bag);
         return modelMapper.map(bag, GetTariffServiceDto.class);
@@ -406,10 +402,6 @@ public class SuperAdminServiceImpl implements SuperAdminService {
     @Override
     public GetTariffServiceDto excludeLimit(Integer id) {
         Bag bag = getBagById(id);
-        boolean limitIncluded = bag.getLimitIncluded();
-        if (!limitIncluded) {
-            throw new BadRequestException(ErrorMessage.BAG_WITH_THIS_STATUS_ALREADY_SET);
-        }
         bag.setLimitIncluded(false);
         bagRepository.save(bag);
         return modelMapper.map(bag, GetTariffServiceDto.class);

--- a/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
@@ -650,13 +650,6 @@ class SuperAdminServiceImplTest {
     }
 
     @Test
-    void excludeLimitThrowBadRequestException() {
-        Optional<Bag> bag = ModelUtils.getBag();
-        when(bagRepository.findById(1)).thenReturn(bag);
-        assertThrows(BadRequestException.class, () -> superAdminService.excludeLimit(1));
-    }
-
-    @Test
     void includeLimitTest() {
         Bag bag = ModelUtils.getBag().get();
         GetTariffServiceDto dto = ModelUtils.getGetTariffServiceDto();
@@ -682,14 +675,6 @@ class SuperAdminServiceImplTest {
 
         verify(bagRepository).findById(1);
         verify(bagRepository, never()).save(any(Bag.class));
-    }
-
-    @Test
-    void includeLimitThrowBadRequestException() {
-        Bag bag = ModelUtils.bagDto();
-        bag.setLimitIncluded(true);
-        when(bagRepository.findById(1)).thenReturn(Optional.of(bag));
-        assertThrows(BadRequestException.class, () -> superAdminService.includeLimit(1));
     }
 
     @Test


### PR DESCRIPTION
## Link to issue

https://github.com/ita-social-projects/GreenCity/issues/5247

## Summary of change

Request method on endpoints /excludeLimit/{id} and /includeLimit/{id} changed from Patch to Put.
Removed throwing an BadRequestException in the includeLimit() and excludeLimit() methods if the value of the limitIncluded field has not changed.
Tests changed.

## Testing approach

Checked testing cases by endpoints /excludeLimit/{id} and /includeLimit/{id} in swagger.