### PR TITLE
Fix/#5194/incorrect order history after cancellation

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -931,11 +931,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                 eventService.saveEvent(OrderHistory.ORDER_NOT_TAKEN_OUT + "  " + order.getComment() + "  "
                     + order.getImageReasonNotTakingBags(), email, order);
             } else if (order.getOrderStatus() == OrderStatus.CANCELED) {
-                if (order.getPointsToUse() != 0 || !order.getCertificates().isEmpty()) {
-                    notificationService.notifyBonusesFromCanceledOrder(order);
-                    returnAllPointsFromOrder(order);
-                }
-                order.setCancellationComment(dto.getCancellationComment());
+                setOrderCancellation(order, dto.getCancellationComment());
                 eventService.saveEvent(OrderHistory.ORDER_CANCELLED, email, order);
             } else if (order.getOrderStatus() == OrderStatus.DONE) {
                 eventService.saveEvent(OrderHistory.ORDER_DONE, email, order);
@@ -953,6 +949,14 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         }
 
         return buildStatuses(order, payment.get(0));
+    }
+
+    private void setOrderCancellation(Order order, String cancellationComment) {
+        if (order.getPointsToUse() != 0 || !order.getCertificates().isEmpty()) {
+            notificationService.notifyBonusesFromCanceledOrder(order);
+            returnAllPointsFromOrder(order);
+        }
+        order.setCancellationComment(cancellationComment);
     }
 
     private OrderDetailStatusDto buildStatuses(Order order, Payment payment) {

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -930,13 +930,13 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             } else if (order.getOrderStatus() == OrderStatus.NOT_TAKEN_OUT) {
                 eventService.saveEvent(OrderHistory.ORDER_NOT_TAKEN_OUT + "  " + order.getComment() + "  "
                     + order.getImageReasonNotTakingBags(), email, order);
-            } else if (order.getOrderStatus() == OrderStatus.CANCELED
-                && (order.getPointsToUse() != 0 || !order.getCertificates().isEmpty())) {
-                notificationService.notifyBonusesFromCanceledOrder(order);
-                returnAllPointsFromOrder(order);
+            } else if (order.getOrderStatus() == OrderStatus.CANCELED) {
+                if(order.getPointsToUse() != 0 || !order.getCertificates().isEmpty()){
+                    notificationService.notifyBonusesFromCanceledOrder(order);
+                    returnAllPointsFromOrder(order);
+                }
                 order.setCancellationComment(dto.getCancellationComment());
-                eventService.saveEvent(OrderHistory.ORDER_CANCELLED + "  " + dto.getCancellationComment(), email,
-                    order);
+                eventService.saveEvent(OrderHistory.ORDER_CANCELLED, email, order);
             } else if (order.getOrderStatus() == OrderStatus.DONE) {
                 eventService.saveEvent(OrderHistory.ORDER_DONE, email, order);
             } else if (order.getOrderStatus() == OrderStatus.BROUGHT_IT_HIMSELF) {

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -931,7 +931,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                 eventService.saveEvent(OrderHistory.ORDER_NOT_TAKEN_OUT + "  " + order.getComment() + "  "
                     + order.getImageReasonNotTakingBags(), email, order);
             } else if (order.getOrderStatus() == OrderStatus.CANCELED) {
-                if(order.getPointsToUse() != 0 || !order.getCertificates().isEmpty()){
+                if (order.getPointsToUse() != 0 || !order.getCertificates().isEmpty()) {
                     notificationService.notifyBonusesFromCanceledOrder(order);
                     returnAllPointsFromOrder(order);
                 }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -512,6 +512,15 @@ public class ModelUtils {
             .build();
     }
 
+    public static Order getOrderWithoutPayment() {
+        return Order.builder()
+            .id(1L)
+            .payment(Collections.emptyList())
+            .certificates(Collections.emptySet())
+            .pointsToUse(500)
+            .build();
+    }
+
     public static OrderDto getOrderDto() {
         return OrderDto.builder()
             .firstName("oleh")
@@ -2589,6 +2598,15 @@ public class ModelUtils {
             .build();
     }
 
+    public static PaymentTableInfoDto getPaymentTableInfoDto2() {
+        return PaymentTableInfoDto.builder()
+            .paidAmount(0L)
+            .unPaidAmount(0L)
+            .paymentInfoDtos(Collections.emptyList())
+            .overpayment(400L)
+            .build();
+    }
+
     public static PaymentInfoDto getInfoPayment() {
         return PaymentInfoDto.builder()
             .comment("ddd")
@@ -3215,6 +3233,30 @@ public class ModelUtils {
             .exportedQuantity(new HashMap<>())
             .pointsToUse(100)
             .orderStatus(OrderStatus.DONE)
+            .build();
+    }
+
+    public static Order getOrderWithoutExportedBags() {
+        Map<Integer, Integer> hashMap = new HashMap<>();
+        hashMap.put(1, 1);
+        hashMap.put(2, 1);
+        return Order.builder()
+            .id(1L)
+            .amountOfBagsOrdered(hashMap)
+            .confirmedQuantity(hashMap)
+            .exportedQuantity(new HashMap<>())
+            .pointsToUse(100)
+            .certificates(Collections.emptySet())
+            .orderStatus(OrderStatus.CONFIRMED)
+            .user(User.builder().id(1L).currentPoints(100).build())
+            .payment(Lists.newArrayList(Payment.builder()
+                .paymentId("1L")
+                .amount(20000L)
+                .currency("UAH")
+                .settlementDate("20.02.1990")
+                .comment("avb")
+                .paymentStatus(PaymentStatus.PAID)
+                .build()))
             .build();
     }
 

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -581,6 +581,17 @@ class UBSManagementServiceImplTest {
         assertEquals(expectedObject.getPaymentStatus(), producedObjectDone.getPaymentStatus());
         assertEquals(expectedObject.getDate(), producedObjectDone.getDate());
 
+        order.setPointsToUse(0);
+        testOrderDetail.setOrderStatus(OrderStatus.CANCELED.toString());
+        expectedObject.setOrderStatus(OrderStatus.CANCELED.toString());
+        OrderDetailStatusDto producedObjectCancelled2 = ubsManagementService
+            .updateOrderDetailStatus(order.getId(), testOrderDetail, "test@gmail.com");
+
+        assertEquals(expectedObject.getOrderStatus(), producedObjectCancelled2.getOrderStatus());
+        assertEquals(expectedObject.getPaymentStatus(), producedObjectCancelled2.getPaymentStatus());
+        assertEquals(expectedObject.getDate(), producedObjectCancelled2.getDate());
+        assertEquals(0, order.getPointsToUse());
+
         testOrderDetail.setOrderStatus(OrderStatus.BROUGHT_IT_HIMSELF.toString());
         expectedObject.setOrderStatus(OrderStatus.BROUGHT_IT_HIMSELF.toString());
         OrderDetailStatusDto producedObjectBroughtItHimself = ubsManagementService
@@ -590,13 +601,24 @@ class UBSManagementServiceImplTest {
         assertEquals(expectedObject.getPaymentStatus(), producedObjectBroughtItHimself.getPaymentStatus());
         assertEquals(expectedObject.getDate(), producedObjectBroughtItHimself.getDate());
 
+        order.setCertificates(Set.of(ModelUtils.getCertificate()));
+        testOrderDetail.setOrderStatus(OrderStatus.CANCELED.toString());
+        expectedObject.setOrderStatus(OrderStatus.CANCELED.toString());
+        OrderDetailStatusDto producedObjectCancelled3 = ubsManagementService
+            .updateOrderDetailStatus(order.getId(), testOrderDetail, "test@gmail.com");
+
+        assertEquals(expectedObject.getOrderStatus(), producedObjectCancelled3.getOrderStatus());
+        assertEquals(expectedObject.getPaymentStatus(), producedObjectCancelled3.getPaymentStatus());
+        assertEquals(expectedObject.getDate(), producedObjectCancelled3.getDate());
+        assertEquals(0, order.getPointsToUse());
+
         verify(eventService, times(1))
             .saveEvent("Статус Замовлення - Узгодження",
                 "test@gmail.com", order);
         verify(eventService, times(1))
             .saveEvent("Статус Замовлення - Підтверджено",
                 "test@gmail.com", order);
-        verify(eventService, times(1))
+        verify(eventService, times(3))
             .saveEvent("Статус Замовлення - Скасовано",
                 "test@gmail.com", order);
 

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -596,7 +596,7 @@ class UBSManagementServiceImplTest {
             .saveEvent("Статус Замовлення - Підтверджено",
                 "test@gmail.com", order);
         verify(eventService, times(1))
-            .saveEvent("Статус Замовлення - Скасовано" + "  " + order.getCancellationComment(),
+            .saveEvent("Статус Замовлення - Скасовано",
                 "test@gmail.com", order);
 
     }


### PR DESCRIPTION
dev
## Bag

https://github.com/ita-social-projects/GreenCity/issues/5194

## Summary of issue

Incorrect order history event after cancele order

## Summary of change

UBSManagmentServiceImpl
UBSManagmentServiceImplTest

## Testing approach

Sign in as admin 
Cancel any order

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions