### PR TITLE
Ubs order history

### DIFF
--- a/dao/src/main/java/greencity/repository/OrderDetailRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderDetailRepository.java
@@ -84,9 +84,8 @@ public interface OrderDetailRepository extends JpaRepository<Order, Integer> {
      * @param bagId   bag id {@link Long}
      * @author Orest Mahdziak
      */
-    @Query(value = "SELECT CONFIRMED_QUANTITY FROM ORDER_BAG_MAPPING "
+    @Query(value = "SELECT EXPORTED_QUANTITY FROM ORDER_BAG_MAPPING "
         + "WHERE ORDER_ID = :orderId AND BAG_ID = :bagId", nativeQuery = true)
-
     Long getExporterWaste(Long orderId, Long bagId);
 
     /**

--- a/service-api/src/main/java/greencity/dto/order/OrderResponseDto.java
+++ b/service-api/src/main/java/greencity/dto/order/OrderResponseDto.java
@@ -36,7 +36,7 @@ public class OrderResponseDto implements Serializable {
 
     private Set<@Length(min = 3, max = 10) @Pattern(regexp = "[0-9]+") String> additionalOrders;
 
-    @Length(max = 170)
+    @Length(max = 255)
     private String orderComment;
 
     @Valid

--- a/service-api/src/main/java/greencity/dto/user/PersonalDataDto.java
+++ b/service-api/src/main/java/greencity/dto/user/PersonalDataDto.java
@@ -34,7 +34,7 @@ public class PersonalDataDto implements Serializable {
     private String senderEmail;
     private String senderPhoneNumber;
 
-    @Length(max = 200)
+    @Length(max = 255)
     private String addressComment;
 
     private Long ubsUserId;

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -699,7 +699,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                         countOfChanges++;
                     }
                     values.append(bag.getName()).append(" ").append(capacity).append(" л: ")
-                        .append(exporterWasteWas.orElse(0L))
+                        .append(exporterWasteWas.orElse(confirmWasteWas.orElse(0L)))
                         .append(" шт на ").append(entry.getValue()).append(" шт.");
                 }
             }
@@ -928,7 +928,8 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             } else if (order.getOrderStatus() == OrderStatus.FORMED) {
                 eventService.saveEvent(OrderHistory.ORDER_FORMED, email, order);
             } else if (order.getOrderStatus() == OrderStatus.NOT_TAKEN_OUT) {
-                eventService.saveEvent(OrderHistory.ORDER_NOT_TAKEN_OUT + "  " + order.getReasonNotTakingBagDescription(), email, order);
+                eventService.saveEvent(
+                    OrderHistory.ORDER_NOT_TAKEN_OUT + "  " + order.getReasonNotTakingBagDescription(), email, order);
             } else if (order.getOrderStatus() == OrderStatus.CANCELED) {
                 setOrderCancellation(order, dto.getCancellationComment());
                 eventService.saveEvent(OrderHistory.ORDER_CANCELLED, email, order);

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -684,11 +684,14 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             Optional<Bag> bagOptional = bagRepository.findById(entry.getKey());
             if (bagOptional.isPresent() && checkOrderStatusAboutExportedWaste(order)) {
                 Optional<Long> exporterWasteWas = Optional.empty();
+                Optional<Long> confirmWasteWas = Optional.empty();
                 Bag bag = bagOptional.get();
                 if (Boolean.TRUE.equals(orderDetailRepository.ifRecordExist(orderId, entry.getKey().longValue()) > 0)) {
                     exporterWasteWas =
                         Optional
                             .ofNullable(orderDetailRepository.getExporterWaste(orderId, entry.getKey().longValue()));
+                    confirmWasteWas =
+                        Optional.ofNullable(orderDetailRepository.getConfirmWaste(orderId, entry.getKey().longValue()));
                 }
                 if (entry.getValue().longValue() != exporterWasteWas.orElse(0L)) {
                     if (countOfChanges == 0) {
@@ -707,13 +710,13 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         return order.getOrderStatus() == OrderStatus.ADJUSTMENT
             || order.getOrderStatus() == OrderStatus.CONFIRMED
             || order.getOrderStatus() == OrderStatus.FORMED
-            || order.getOrderStatus() == OrderStatus.NOT_TAKEN_OUT;
+            || order.getOrderStatus() == OrderStatus.NOT_TAKEN_OUT
+            || order.getOrderStatus() == OrderStatus.ON_THE_ROUTE
+            || order.getOrderStatus() == OrderStatus.BROUGHT_IT_HIMSELF;
     }
 
     private boolean checkOrderStatusAboutExportedWaste(Order order) {
-        return order.getOrderStatus() == OrderStatus.ON_THE_ROUTE
-            || order.getOrderStatus() == OrderStatus.BROUGHT_IT_HIMSELF
-            || order.getOrderStatus() == OrderStatus.DONE
+        return order.getOrderStatus() == OrderStatus.DONE
             || order.getOrderStatus() == OrderStatus.CANCELED;
     }
 
@@ -925,8 +928,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             } else if (order.getOrderStatus() == OrderStatus.FORMED) {
                 eventService.saveEvent(OrderHistory.ORDER_FORMED, email, order);
             } else if (order.getOrderStatus() == OrderStatus.NOT_TAKEN_OUT) {
-                eventService.saveEvent(OrderHistory.ORDER_NOT_TAKEN_OUT + "  " + order.getComment() + "  "
-                    + order.getImageReasonNotTakingBags(), email, order);
+                eventService.saveEvent(OrderHistory.ORDER_NOT_TAKEN_OUT + "  " + order.getReasonNotTakingBagDescription(), email, order);
             } else if (order.getOrderStatus() == OrderStatus.CANCELED) {
                 setOrderCancellation(order, dto.getCancellationComment());
                 eventService.saveEvent(OrderHistory.ORDER_CANCELLED, email, order);

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -988,6 +988,28 @@ class UBSManagementServiceImplTest {
     }
 
     @Test
+    void testSetOrderDetailWithExportedWaste() {
+        when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusDoneDto()));
+        when(bagRepository.findCapacityById(1)).thenReturn(1);
+        doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+        when(orderRepository.getOrderDetails(anyLong()))
+            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+        when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
+        when(orderDetailRepository.ifRecordExist(any(), any())).thenReturn(1L);
+        ubsManagementService.setOrderDetail(1L,
+            UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsConfirmed(),
+            UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(),
+            "test@gmail.com");
+        verify(orderRepository, times(2)).findById(1L);
+        verify(bagRepository, times(2)).findCapacityById(1);
+        verify(bagRepository, times(2)).findById(1);
+        verify(orderDetailRepository, times(3)).ifRecordExist(any(), any());
+        verify(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+    }
+
+    @Test
     void testSetOrderDetailFormed() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);


### PR DESCRIPTION
# Green City UBS  bug in writing order history PR


## Summary Of Issue :
1)
 **Steps to reproduce**
Click on the Order's number in the Order table (with status "На маршруті")
Go to the block 'Деталі замовлення'
Click on the picker in order to change the number of ordered packages for one or several services (e.g. from 2 to 4 ) and click on "Зберегти" bttn
Scroll to the block 'Історія замовлення' on the order details page and check the info about changing

**Actual result**
The title of the change event 'Змінено деталі вивезення' is displayed instead 'Змінено деталі замовлення. [service name] [package size]: [previous quantity of packages]шт. на [current quantity of packages] шт.' in the History log

**Expected result**
The initial quantity of packages is displayed according to the initial order from the client on the pop-up window of the change event (Змінено деталі замовлення. [service name] [package size]: [previous quantity of packages]шт. на [current quantity of packages] шт.)
[e.g. Змінено деталі замовлення. Безпечні відходи 120 л: 2 шт на 3 шт. Текстильні відходи 120 л: 1 шт на 0 шт.]

2) 
**Steps to reproduce**
Click on the Order's number in the Order table (with status "На маршруті")
Go to the block 'Деталі замовлення'
Click on the picker in order to change the number of ordered packages for one or several services (e.g. from 2 to 4 ), change order status from "На маршруті" to "Не вивезли" and click on "Зберегти" bttn
Scroll to the block 'Історія замовлення' on the order details page and check the info about changing
**Actual result**
'Статус Замовлення - Не вивезли []' is displayed instead 'Статус Замовлення - Не вивезли' and 'Змінено деталі вивезення' is additionally logged in the Order History

**Expected result**
When Admin changes order status from "На маршруті" to "Не вивезли", changes the number of packages, and saves these changes it should be displayed in Order History as 'Статус Замовлення - Не вивезли' and 'Змінено деталі замовлення. [service name] [package size]: [previous quantity of packages]шт. на [current quantity of packages] шт.'. There is no change event named 'Змінено деталі вивезення' after changing order status.

3) 
**Steps to reproduce**
Click on the Order's number in the Order table (with status "Не вивезли")
Go to the block 'Деталі замовлення'
Click on the picker in order to change the number of ordered packages for one or several services (e.g. from 2 to 4 ), change order status from "Не вивезли" to "Привезе сам" and click on "Зберегти" bttn
Scroll to the block 'Історія замовлення' on the order details page and check the info about changing
Actual result
The title of the change event Змінено деталі замовлення. [service name] [package size]: [previous quantity of packages]шт. на [current quantity of packages] шт.' is not logged in the History log after changing the order status from "Не вивезли" to "Привезе сам" , changing the quantity of packages and clicking on "Зберегти" bttn

Expected result
The title of the change event Змінено деталі замовлення. [service name] [package size]: [previous quantity of packages]шт. на [current quantity of packages] шт.' is logged every time in the History log after changing the quantity of packages




## Issue Link :
https://github.com/ita-social-projects/GreenCity/issues/5188
https://github.com/ita-social-projects/GreenCity/issues/5189
https://github.com/ita-social-projects/GreenCity/issues/5190


## Summary Of Changes :

1. change  method getExporterWaste in OrderDetailRepository
2. change  method  checkOrderStatusAboutConfirmWaste in  UBSManagementServiceImpl
3. change  method checkOrderStatusAboutExportedWaste  in  UBSManagementServiceImpl
4. change  method  collectEventAboutExportedWaste in UBSManagementServiceImpl
5. change method updateOrderDetailStatus in  UBSManagementServiceImpl
6. change the value of the permissible value orderComment in OrderResponseDto
7. change the value of the permissible value  ddressComment in PersonalDataDto 
8. add test for new lines of code








## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [ ] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [ ] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
