### PR TITLE
Fix#5246 duplicate bags from order details endpoint

### DIFF
--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -59,7 +59,7 @@ public class OrderController {
      * {@link UserVO}.
      *
      * @param userUuid {@link UserVO} id.
-     * @param orderId  {@link UserVO} id of order.
+     * @param optionalOrderId  {@link UserVO} id of order.
      * @return {@link UserPointsAndAllBagsDto}.
      * @author Oleh Bilonizhka
      */
@@ -73,9 +73,9 @@ public class OrderController {
     @GetMapping("/order-details")
     public ResponseEntity<UserPointsAndAllBagsDto> getCurrentUserPoints(
         @ApiIgnore @CurrentUserUuid String userUuid,
-        @RequestParam Long orderId) {
+        @RequestParam(required = false) Optional<Long> optionalOrderId) {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(ubsClientService.getFirstPageData(userUuid, orderId));
+            .body(ubsClientService.getFirstPageData(userUuid, optionalOrderId));
     }
 
     /**

--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -58,12 +58,12 @@ public class OrderController {
      * Controller returns all available bags and bonus points of current user.
      * {@link UserVO}.
      *
-     * @param userUuid   {@link UserVO} id.
-     * @param locationId {@link UserVO} id of location to filter by.
+     * @param userUuid {@link UserVO} id.
+     * @param orderId  {@link UserVO} id of order.
      * @return {@link UserPointsAndAllBagsDto}.
      * @author Oleh Bilonizhka
      */
-    @ApiOperation(value = "Get current user points and filtered by location bags list.")
+    @ApiOperation(value = "Get current user points by order id.")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK, response = UserPointsAndAllBagsDto.class),
         @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
@@ -73,9 +73,9 @@ public class OrderController {
     @GetMapping("/order-details")
     public ResponseEntity<UserPointsAndAllBagsDto> getCurrentUserPoints(
         @ApiIgnore @CurrentUserUuid String userUuid,
-        @RequestParam(required = false) Optional<Long> locationId) {
+        @RequestParam Long orderId) {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(ubsClientService.getFirstPageData(userUuid, locationId));
+            .body(ubsClientService.getFirstPageData(userUuid, orderId));
     }
 
     /**

--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -58,8 +58,8 @@ public class OrderController {
      * Controller returns all available bags and bonus points of current user.
      * {@link UserVO}.
      *
-     * @param userUuid {@link UserVO} id.
-     * @param optionalOrderId  {@link UserVO} id of order.
+     * @param userUuid        {@link UserVO} id.
+     * @param optionalOrderId {@link UserVO} id of order.
      * @return {@link UserPointsAndAllBagsDto}.
      * @author Oleh Bilonizhka
      */

--- a/core/src/test/java/greencity/controller/OrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/OrderControllerTest.java
@@ -99,14 +99,17 @@ class OrderControllerTest {
 
     @Test
     void getCurrentUserPoints() throws Exception {
-        when(userRemoteClient.findUuidByEmail((anyString()))).thenReturn("35467585763t4sfgchjfuyetf");
+        when(userRemoteClient.findUuidByEmail((anyString())))
+            .thenReturn("35467585763t4sfgchjfuyetf");
 
         mockMvc.perform(get(ubsLink + "/order-details")
-            .principal(principal))
+            .principal(principal)
+            .param("orderId", "1")
+            .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
 
         verify(userRemoteClient).findUuidByEmail("test@gmail.com");
-        verify(ubsClientService).getFirstPageData("35467585763t4sfgchjfuyetf", Optional.empty());
+        verify(ubsClientService).getFirstPageData("35467585763t4sfgchjfuyetf", 1L);
     }
 
     @Test

--- a/core/src/test/java/greencity/controller/OrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/OrderControllerTest.java
@@ -98,18 +98,32 @@ class OrderControllerTest {
     }
 
     @Test
-    void getCurrentUserPoints() throws Exception {
+    void getCurrentUserPointsWithOrderId() throws Exception {
         when(userRemoteClient.findUuidByEmail((anyString())))
             .thenReturn("35467585763t4sfgchjfuyetf");
 
         mockMvc.perform(get(ubsLink + "/order-details")
             .principal(principal)
-            .param("orderId", "1")
+            .param("optionalOrderId", "1")
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
 
         verify(userRemoteClient).findUuidByEmail("test@gmail.com");
-        verify(ubsClientService).getFirstPageData("35467585763t4sfgchjfuyetf", 1L);
+        verify(ubsClientService).getFirstPageData("35467585763t4sfgchjfuyetf", Optional.of(1L));
+    }
+
+    @Test
+    void getCurrentUserPointsWithoutOrderId() throws Exception {
+        when(userRemoteClient.findUuidByEmail((anyString())))
+            .thenReturn("35467585763t4sfgchjfuyetf");
+
+        mockMvc.perform(get(ubsLink + "/order-details").principal(principal)
+            .param("optionalOrderId", "")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+
+        verify(userRemoteClient).findUuidByEmail("test@gmail.com");
+        verify(ubsClientService).getFirstPageData("35467585763t4sfgchjfuyetf", Optional.empty());
     }
 
     @Test

--- a/dao/src/main/java/greencity/repository/BagRepository.java
+++ b/dao/src/main/java/greencity/repository/BagRepository.java
@@ -86,7 +86,7 @@ public interface BagRepository extends JpaRepository<Bag, Integer> {
      * @return {@link List} of {@link Bag} by tariffInfoId.
      * @author Safarov Renat
      */
-    @Query(value = "SELECT b FROM Bag as b where b.tariffsInfo.id =:tariffInfoId")
+    @Query(value = "SELECT b FROM Bag AS b WHERE b.tariffsInfo.id =:tariffInfoId")
     List<Bag> findBagsByTariffInfoId(@Param("tariffInfoId") Long tariffInfoId);
 
     /**
@@ -107,18 +107,4 @@ public interface BagRepository extends JpaRepository<Bag, Integer> {
      * @author Julia Seti
      */
     List<Bag> getAllByTariffsInfoId(Long tariffId);
-
-    /**
-     * method, that returns {@link List} of {@link Bag} by location id.
-     *
-     * @param locationId {@link Long} location id.
-     * @return {@link List} of {@link Bag} by location id.
-     * @author Julia Seti
-     */
-    @Query(nativeQuery = true,
-        value = "SELECT * FROM bag b "
-            + "JOIN tariffs_info ti on ti.id = b.tariffs_info_id "
-            + "JOIN tariffs_locations tl on ti.id = tl.tariffs_info_id "
-            + "WHERE tl.location_id =:locationId and ti.location_status = 'ACTIVE'")
-    List<Bag> findBagsByLocationIdAndLocationStatusIsActive(@Param("locationId") Long locationId);
 }

--- a/service-api/src/main/java/greencity/service/ubs/UBSClientService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSClientService.java
@@ -34,11 +34,12 @@ public interface UBSClientService {
     /**
      * Methods returns all available for order bags and current user's bonus points.
      *
-     * @param uuid current {@link User}'s uuid.
+     * @param uuid    current {@link User}'s uuid.
+     * @param orderId {@link Long} order id
      * @return {@link UserPointsAndAllBagsDto}.
      * @author Oleh Bilonizhka
      */
-    UserPointsAndAllBagsDto getFirstPageData(String uuid, Optional<Long> locationId);
+    UserPointsAndAllBagsDto getFirstPageData(String uuid, Long orderId);
 
     /**
      * Methods returns all saved user data.

--- a/service-api/src/main/java/greencity/service/ubs/UBSClientService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSClientService.java
@@ -35,11 +35,11 @@ public interface UBSClientService {
      * Methods returns all available for order bags and current user's bonus points.
      *
      * @param uuid    current {@link User}'s uuid.
-     * @param orderId {@link Long} order id
+     * @param orderId {@link Optional<Long>} order id
      * @return {@link UserPointsAndAllBagsDto}.
      * @author Oleh Bilonizhka
      */
-    UserPointsAndAllBagsDto getFirstPageData(String uuid, Long orderId);
+    UserPointsAndAllBagsDto getFirstPageData(String uuid, Optional<Long> orderId);
 
     /**
      * Methods returns all saved user data.

--- a/service-api/src/main/java/greencity/service/ubs/UBSClientService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSClientService.java
@@ -35,7 +35,7 @@ public interface UBSClientService {
      * Methods returns all available for order bags and current user's bonus points.
      *
      * @param uuid    current {@link User}'s uuid.
-     * @param orderId {@link Optional<Long>} order id
+     * @param orderId {@link Optional} order id.
      * @return {@link UserPointsAndAllBagsDto}.
      * @author Oleh Bilonizhka
      */

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -275,8 +275,8 @@ public class UBSClientServiceImpl implements UBSClientService {
     private List<Bag> getBagsByOrderId(Long orderId) {
         if (orderId != null) {
             var order = getOrderByIdOrThrowNotFoundException(
-                    orderId,
-                    ORDER_WITH_CURRENT_ID_NOT_FOUND);
+                orderId,
+                ORDER_WITH_CURRENT_ID_NOT_FOUND);
             var tariffId = order.getTariffsInfo().getId();
 
             return bagRepository.findBagsByTariffInfoId(tariffId);
@@ -287,7 +287,7 @@ public class UBSClientServiceImpl implements UBSClientService {
 
     private Order getOrderByIdOrThrowNotFoundException(Long orderId, String exceptionMessage) {
         return orderRepository.findById(orderId)
-                .orElseThrow(() -> new NotFoundException(exceptionMessage + orderId));
+            .orElseThrow(() -> new NotFoundException(exceptionMessage + orderId));
     }
 
     /**

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -150,6 +150,7 @@ import greencity.util.OrderUtils;
 
 import static greencity.constant.ErrorMessage.*;
 import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.*;
 import static java.util.stream.Collectors.joining;
 
 /**
@@ -259,30 +260,20 @@ public class UBSClientServiceImpl implements UBSClientService {
      * {@inheritDoc}
      */
     @Override
-    public UserPointsAndAllBagsDto getFirstPageData(String uuid, Optional<Long> optionalLocationId) {
+    public UserPointsAndAllBagsDto getFirstPageData(String uuid, Long orderId) {
         User user = userRepository.findUserByUuid(uuid).orElseThrow(
             () -> new NotFoundException(ErrorMessage.USER_WITH_CURRENT_UUID_DOES_NOT_EXIST));
-        List<BagTranslationDto> btdList = getBagList(optionalLocationId.orElse(null))
-            .stream()
+
+        Order order = orderRepository.findById(orderId)
+            .orElseThrow(() -> new NotFoundException(ORDER_WITH_CURRENT_ID_NOT_FOUND));
+
+        var tariffId = order.getTariffsInfo().getId();
+
+        var bagTranslationDtoList = bagRepository.findBagsByTariffInfoId(tariffId).stream()
             .map(bag -> modelMapper.map(bag, BagTranslationDto.class))
-            .collect(Collectors.toList());
-        return new UserPointsAndAllBagsDto(btdList, user.getCurrentPoints());
-    }
+            .collect(toList());
 
-    private List<Bag> getBagList(Long locationId) {
-        return locationId != null
-            ? bagRepository
-                .findBagsByLocationIdAndLocationStatusIsActive(
-                    checkAndGetLocationId(locationId))
-            : bagRepository
-                .findAll();
-    }
-
-    private long checkAndGetLocationId(Long locationId) {
-        if (locationRepository.existsById(locationId)) {
-            return locationId;
-        }
-        throw new NotFoundException(ErrorMessage.LOCATION_DOESNT_FOUND_BY_ID + locationId);
+        return new UserPointsAndAllBagsDto(bagTranslationDtoList, user.getCurrentPoints());
     }
 
     /**
@@ -445,7 +436,7 @@ public class UBSClientServiceImpl implements UBSClientService {
             .stream()
             .sorted(Comparator.comparing(Address::getId))
             .map(u -> modelMapper.map(u, AddressDto.class))
-            .collect(Collectors.toList());
+            .collect(toList());
         return new OrderWithAddressesResponseDto(addressDtoList);
     }
 
@@ -670,7 +661,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         return orderRepository.getAllOrdersOfUser(uuid).stream()
             .sorted(Comparator.comparing(Order::getOrderDate))
             .map(order -> modelMapper.map(order, OrderClientDto.class))
-            .collect(Collectors.toList());
+            .collect(toList());
     }
 
     /**
@@ -743,7 +734,7 @@ public class UBSClientServiceImpl implements UBSClientService {
 
         List<CertificateDto> certificateDtos = order.getCertificates().stream()
             .map(certificate -> modelMapper.map(certificate, CertificateDto.class))
-            .collect(Collectors.toList());
+            .collect(toList());
 
         Double amountBeforePayment =
             fullPrice - order.getPointsToUse() - countPaidAmount(payments) - countCertificatesBonuses(certificateDtos);
@@ -820,7 +811,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         return bagsForOrder.stream()
             .filter(bag -> actualBagAmounts.containsKey(bag.getId()))
             .map(bag -> buildBagForUserDto(bag, actualBagAmounts.get(bag.getId())))
-            .collect(Collectors.toList());
+            .collect(toList());
     }
 
     private Map<Integer, Integer> getActualBagAmountsForOrder(Order order) {
@@ -1172,7 +1163,7 @@ public class UBSClientServiceImpl implements UBSClientService {
             bonusForUbsUser = changeOfPointsList.stream()
                 .sorted(Comparator.comparing(ChangeOfPoints::getDate).reversed())
                 .map(m -> modelMapper.map(m, PointsForUbsUserDto.class))
-                .collect(Collectors.toList());
+                .collect(toList());
         }
         AllPointsUserDto allBonusesForUserDto = new AllPointsUserDto();
         allBonusesForUserDto.setUserBonuses(userBonuses);
@@ -1196,7 +1187,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         return orderEvents
             .stream()
             .map(event -> modelMapper.map(event, EventDto.class))
-            .collect(Collectors.toList());
+            .collect(toList());
     }
 
     /**
@@ -1209,7 +1200,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         setUserData(user, userProfileUpdateDto);
         List<Address> addressList =
             userProfileUpdateDto.getAddressDto().stream().map(a -> modelMapper.map(a, Address.class))
-                .collect(Collectors.toList());
+                .collect(toList());
 
         for (Address address : addressList) {
             address.setUser(user);
@@ -1217,7 +1208,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         user.setAddresses(addressList);
         User savedUser = userRepository.save(user);
         List<AddressDto> mapperAddressDto =
-            addressList.stream().map(a -> modelMapper.map(a, AddressDto.class)).collect(Collectors.toList());
+            addressList.stream().map(a -> modelMapper.map(a, AddressDto.class)).collect(toList());
         UserProfileUpdateDto mappedUserProfileDto = modelMapper.map(savedUser, UserProfileUpdateDto.class);
         UserProfileUpdateDto.builder().addressDto(mapperAddressDto).build();
         return mappedUserProfileDto;
@@ -1233,7 +1224,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         List<AddressDto> addressDto =
             allAddress.stream()
                 .map(a -> modelMapper.map(a, AddressDto.class))
-                .collect(Collectors.toList());
+                .collect(toList());
         userProfileDto.setAddressDto(addressDto);
         userProfileDto.setBotList(botList);
         userProfileDto.setHasPassword(userRemoteClient.getPasswordStatus().isHasPassword());
@@ -1553,7 +1544,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         List<Payment> payments = order.getPayment();
         List<CertificateDto> certificateDtos = order.getCertificates().stream()
             .map(certificate -> modelMapper.map(certificate, CertificateDto.class))
-            .collect(Collectors.toList());
+            .collect(toList());
 
         sumToPay =
             sumToPay - order.getPointsToUse() - countPaidAmount(payments).intValue()
@@ -1862,7 +1853,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         return EnumSet.allOf(BotType.class)
             .stream()
             .map(type -> new Bot(type.name(), createLink(type, uuid)))
-            .collect(Collectors.toList());
+            .collect(toList());
     }
 
     private String createLink(BotType type, String uuid) {
@@ -1881,11 +1872,11 @@ public class UBSClientServiceImpl implements UBSClientService {
     private List<AllActiveLocationsDto> getAllActiveLocations() {
         List<Location> locations = locationRepository.findAllActive();
         Map<RegionDto, List<LocationsDtos>> map = locations.stream()
-            .collect(Collectors.toMap(x -> modelMapper.map(x, RegionDto.class),
+            .collect(toMap(x -> modelMapper.map(x, RegionDto.class),
                 x -> new ArrayList<>(List.of(modelMapper.map(x, LocationsDtos.class))),
                 (x, y) -> {
                     x.addAll(y);
-                    return new ArrayList<>(x).stream().distinct().collect(Collectors.toList());
+                    return new ArrayList<>(x).stream().distinct().collect(toList());
                 }));
 
         return map.entrySet().stream()
@@ -1895,7 +1886,7 @@ public class UBSClientServiceImpl implements UBSClientService {
                 .nameUk(x.getKey().getNameUk())
                 .locations(x.getValue())
                 .build())
-            .collect(Collectors.toList());
+            .collect(toList());
     }
 
     @Override
@@ -1962,6 +1953,6 @@ public class UBSClientServiceImpl implements UBSClientService {
     public List<LocationSummaryDto> getLocationSummary() {
         return regionRepository.findAll().stream()
             .map(location -> modelMapper.map(location, LocationSummaryDto.class))
-            .collect(Collectors.toList());
+            .collect(toList());
     }
 }

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
@@ -69,7 +68,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
 
 import com.google.maps.model.AddressComponentType;

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1589,7 +1589,6 @@ public class ModelUtils {
                         .latitude(49.83)
                         .longitude(23.88)
                         .build())
-                    // .user(User.builder().id(1L).build())
                     .build())
                 .build())
             .certificates(Collections.emptySet())

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -284,8 +284,8 @@ class UBSClientServiceImplTest {
                 .getMessage();
 
         assertEquals(
-                ErrorMessage.ORDER_WITH_CURRENT_ID_NOT_FOUND + optionalOrderId.get(),
-                message);
+            ErrorMessage.ORDER_WITH_CURRENT_ID_NOT_FOUND + optionalOrderId.get(),
+            message);
 
         verify(userRepository).findUserByUuid(anyString());
         verify(orderRepository).findById(anyLong());

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -273,12 +273,13 @@ class UBSClientServiceImplTest {
     void getFirstPageDataOrderNotFoundException() {
         User user = getUserWithLastLocation();
         Long orderId = 1L;
+        String uuid = "35467585763t4sfgchjfuyetf";
 
         when(userRepository.findUserByUuid(anyString())).thenReturn(Optional.of(user));
         when(orderRepository.findById(anyLong())).thenReturn(Optional.empty());
 
         var message = assertThrows(NotFoundException.class,
-            () -> ubsService.getFirstPageData(anyString(), orderId))
+            () -> ubsService.getFirstPageData(uuid, orderId))
                 .getMessage();
 
         assertEquals(ErrorMessage.ORDER_WITH_CURRENT_ID_NOT_FOUND, message);
@@ -291,11 +292,15 @@ class UBSClientServiceImplTest {
     @Test
     void getFirstPageDataUserNotFoundException() {
         Long orderId = 1L;
+        String uuid = "35467585763t4sfgchjfuyetf";
 
         when(userRepository.findUserByUuid(anyString())).thenReturn(Optional.empty());
 
-        assertThrows(NotFoundException.class,
-            () -> ubsService.getFirstPageData(anyString(), orderId));
+        var message = assertThrows(NotFoundException.class,
+            () -> ubsService.getFirstPageData(uuid, orderId))
+                .getMessage();
+
+        assertEquals(ErrorMessage.USER_WITH_CURRENT_UUID_DOES_NOT_EXIST, message);
 
         verify(userRepository).findUserByUuid(anyString());
         verify(orderRepository, never()).findById(anyLong());

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -114,6 +114,7 @@ import greencity.exceptions.user.UserNotFoundException;
 import greencity.util.Bot;
 import greencity.util.EncryptionUtil;
 
+import static greencity.ModelUtils.*;
 import static greencity.ModelUtils.TEST_BAG_LIST;
 import static greencity.ModelUtils.TEST_ORDER_ADDRESS_DTO_REQUEST;
 import static greencity.ModelUtils.TEST_PAYMENT_LIST;
@@ -235,87 +236,75 @@ class UBSClientServiceImplTest {
 
     @Test
     void getFirstPageData() {
-        Long locationId = 1L;
-        UserPointsAndAllBagsDto userPointsAndAllBagsDtoExpected = ModelUtils.getUserPointsAndAllBagsDto();
-        List<Bag> bagList = ModelUtils.getBag1list();
-        User user = ModelUtils.getUserWithLastLocation();
-        BagTranslationDto dto = ModelUtils.getBagTranslationDto();
+        Long orderId = 1L;
+
+        UserPointsAndAllBagsDto userPointsAndAllBagsDtoExpected = getUserPointsAndAllBagsDto();
+
+        User user = getUserWithLastLocation();
         user.setCurrentPoints(600);
-        when(locationRepository.existsById(locationId)).thenReturn(true);
-        when(userRepository.findUserByUuid("35467585763t4sfgchjfuyetf")).thenReturn(Optional.of(user));
-        when(bagRepository.findBagsByLocationIdAndLocationStatusIsActive(locationId)).thenReturn(bagList);
+
+        Order order = getOrder();
+        order.setTariffsInfo(getTariffsInfo());
+
+        List<Bag> bagList = getBag1list();
+
+        BagTranslationDto dto = getBagTranslationDto();
+
+        when(userRepository.findUserByUuid(anyString())).thenReturn(Optional.of(user));
+        when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
+        when(bagRepository.findBagsByTariffInfoId(anyLong())).thenReturn(bagList);
         when(modelMapper.map(bagList.get(0), BagTranslationDto.class)).thenReturn(dto);
 
         UserPointsAndAllBagsDto userPointsAndAllBagsDtoActual =
-            ubsService.getFirstPageData("35467585763t4sfgchjfuyetf", Optional.of(locationId));
+            ubsService.getFirstPageData(anyString(), orderId);
 
         assertEquals(userPointsAndAllBagsDtoExpected.getBags(), userPointsAndAllBagsDtoActual.getBags());
         assertEquals(userPointsAndAllBagsDtoExpected.getPoints(), userPointsAndAllBagsDtoActual.getPoints());
         assertEquals(userPointsAndAllBagsDtoExpected.getBags().get(0).getId(),
             userPointsAndAllBagsDtoActual.getBags().get(0).getId());
 
-        verify(locationRepository).existsById(locationId);
-        verify(userRepository).findUserByUuid("35467585763t4sfgchjfuyetf");
-        verify(bagRepository).findBagsByLocationIdAndLocationStatusIsActive(locationId);
+        verify(userRepository).findUserByUuid(anyString());
+        verify(orderRepository).findById(anyLong());
+        verify(bagRepository).findBagsByTariffInfoId(anyLong());
         verify(modelMapper).map(bagList.get(0), BagTranslationDto.class);
     }
 
     @Test
-    void getFirstPageDataWithoutLocationId() {
-        Optional<Long> locationId = Optional.empty();
-        UserPointsAndAllBagsDto userPointsAndAllBagsDtoExpected = ModelUtils.getUserPointsAndAllBagsDto();
-        List<Bag> bagList = ModelUtils.getBag1list();
-        User user = ModelUtils.getUserWithLastLocation();
-        BagTranslationDto dto = ModelUtils.getBagTranslationDto();
-        user.setCurrentPoints(600);
-        when(userRepository.findUserByUuid("35467585763t4sfgchjfuyetf")).thenReturn(Optional.of(user));
-        when(bagRepository.findAll()).thenReturn(bagList);
-        when(modelMapper.map(bagList.get(0), BagTranslationDto.class)).thenReturn(dto);
+    void getFirstPageDataOrderNotFoundException() {
+        User user = getUserWithLastLocation();
+        Long orderId = 1L;
 
-        UserPointsAndAllBagsDto userPointsAndAllBagsDtoActual =
-            ubsService.getFirstPageData("35467585763t4sfgchjfuyetf", locationId);
+        when(userRepository.findUserByUuid(anyString())).thenReturn(Optional.of(user));
+        when(orderRepository.findById(anyLong())).thenReturn(Optional.empty());
 
-        assertEquals(userPointsAndAllBagsDtoExpected.getBags(), userPointsAndAllBagsDtoActual.getBags());
-        assertEquals(userPointsAndAllBagsDtoExpected.getPoints(), userPointsAndAllBagsDtoActual.getPoints());
-        assertEquals(userPointsAndAllBagsDtoExpected.getBags().get(0).getId(),
-            userPointsAndAllBagsDtoActual.getBags().get(0).getId());
+        var message = assertThrows(NotFoundException.class,
+            () -> ubsService.getFirstPageData(anyString(), orderId))
+                .getMessage();
 
-        verify(userRepository).findUserByUuid("35467585763t4sfgchjfuyetf");
-        verify(bagRepository).findAll();
-        verify(modelMapper).map(bagList.get(0), BagTranslationDto.class);
-    }
+        assertEquals(ErrorMessage.ORDER_WITH_CURRENT_ID_NOT_FOUND, message);
 
-    @Test
-    void getFirstPageDataLocationNotFoundException() {
-        Optional<Long> locationId = Optional.of(1L);
-        User user = ModelUtils.getUserWithLastLocation();
-        when(userRepository.findUserByUuid("35467585763t4sfgchjfuyetf")).thenReturn(Optional.of(user));
-        when(locationRepository.existsById(1L)).thenReturn(false);
-
-        assertThrows(NotFoundException.class,
-            () -> ubsService.getFirstPageData("35467585763t4sfgchjfuyetf", locationId));
-
-        verify(locationRepository).existsById(1L);
-        verify(userRepository).findUserByUuid("35467585763t4sfgchjfuyetf");
-        verify(bagRepository, never()).findBagsByLocationIdAndLocationStatusIsActive(anyLong());
+        verify(userRepository).findUserByUuid(anyString());
+        verify(orderRepository).findById(anyLong());
+        verify(bagRepository, never()).findBagsByTariffInfoId(anyLong());
     }
 
     @Test
     void getFirstPageDataUserNotFoundException() {
-        Optional<Long> locationId = Optional.of(1L);
-        when(userRepository.findUserByUuid("35467585763t4sfgchjfuyetf")).thenReturn(Optional.empty());
+        Long orderId = 1L;
+
+        when(userRepository.findUserByUuid(anyString())).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class,
-            () -> ubsService.getFirstPageData("35467585763t4sfgchjfuyetf", locationId));
+            () -> ubsService.getFirstPageData(anyString(), orderId));
 
-        verify(userRepository).findUserByUuid("35467585763t4sfgchjfuyetf");
-        verify(locationRepository, never()).existsById(1L);
-        verify(bagRepository, never()).findBagsByLocationIdAndLocationStatusIsActive(anyLong());
+        verify(userRepository).findUserByUuid(anyString());
+        verify(orderRepository, never()).findById(anyLong());
+        verify(bagRepository, never()).findBagsByTariffInfoId(anyLong());
     }
 
     @Test
     void testSaveToDB() throws IllegalAccessException {
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setAlternateEmail("test@mail.com");
         user.setCurrentPoints(900);
 
@@ -351,7 +340,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfo()));
+            .thenReturn(Optional.of(getTariffInfo()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
         when(ubsUserRepository.findById(1L)).thenReturn(Optional.of(ubSuser));
         when(modelMapper.map(dto, Order.class)).thenReturn(order);
@@ -367,7 +356,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void testSaveToDBWShouldThrowBadRequestException() throws IllegalAccessException {
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setAlternateEmail("test@mail.com");
         user.setCurrentPoints(900);
 
@@ -395,7 +384,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfoWithLimitOfBagsAndMaxLessThanCountOfBigBag()));
+            .thenReturn(Optional.of(getTariffInfoWithLimitOfBagsAndMaxLessThanCountOfBigBag()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
 
         assertThrows(BadRequestException.class,
@@ -408,7 +397,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void testSaveToDBWithoutOrderUnpaid() throws IllegalAccessException {
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setAlternateEmail("test@mail.com");
         user.setCurrentPoints(900);
 
@@ -436,7 +425,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfo()));
+            .thenReturn(Optional.of(getTariffInfo()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
         when(ubsUserRepository.findById(1L)).thenReturn(Optional.of(ubSuser));
         when(modelMapper.map(dto.getPersonalData(), UBSuser.class)).thenReturn(ubSuser);
@@ -455,7 +444,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void saveToDBFailPaidOrder() {
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setCurrentPoints(1000);
         OrderResponseDto dto = getOrderResponseDto();
         dto.getBags().get(0).setAmount(5);
@@ -467,7 +456,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfo()));
+            .thenReturn(Optional.of(getTariffInfo()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
         when(orderRepository.findById(any())).thenReturn(Optional.of(order));
 
@@ -477,7 +466,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void testSaveToDBThrowsException() throws IllegalAccessException {
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setCurrentPoints(900);
 
         OrderResponseDto dto = getOrderResponseDto();
@@ -512,7 +501,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfoWithLimitOfBags()));
+            .thenReturn(Optional.of(getTariffInfoWithLimitOfBags()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
         Assertions.assertThrows(BadRequestException.class,
             () -> ubsService.saveFullOrderToDB(dto, "35467585763t4sfgchjfuyetf", null));
@@ -521,14 +510,14 @@ class UBSClientServiceImplTest {
     @Test
     void getSecondPageData() {
         String uuid = "35467585763t4sfgchjfuyetf";
-        PersonalDataDto expected = ModelUtils.getOrderResponseDto().getPersonalData();
+        PersonalDataDto expected = getOrderResponseDto().getPersonalData();
 
-        User user = ModelUtils.getTestUser()
+        User user = getTestUser()
             .setUuid(uuid)
             .setRecipientEmail("mail@mail.ua")
             .setRecipientPhone("067894522")
             .setAlternateEmail("my@email.com");
-        List<UBSuser> ubsUser = Arrays.asList(ModelUtils.getUBSuser());
+        List<UBSuser> ubsUser = Arrays.asList(getUBSuser());
         when(userRepository.findByUuid(uuid)).thenReturn(user);
         when(ubsUserRepository.findUBSuserByUser(user)).thenReturn(ubsUser);
         when(modelMapper.map(user, PersonalDataDto.class)).thenReturn(expected);
@@ -552,14 +541,14 @@ class UBSClientServiceImplTest {
     void getSecondPageDataWithUserFounded() {
 
         String uuid = "35467585763t4sfgchjfuyetf";
-        PersonalDataDto expected = ModelUtils.getOrderResponseDto().getPersonalData();
+        PersonalDataDto expected = getOrderResponseDto().getPersonalData();
 
-        User user = ModelUtils.getTestUser()
+        User user = getTestUser()
             .setUuid(uuid)
             .setRecipientEmail("mail@mail.ua")
             .setRecipientPhone("067894522")
             .setAlternateEmail("my@email.com");
-        List<UBSuser> ubsUser = Arrays.asList(ModelUtils.getUBSuser());
+        List<UBSuser> ubsUser = Arrays.asList(getUBSuser());
         when(userRepository.findByUuid(uuid)).thenReturn(null);
         when(ubsUserRepository.findUBSuserByUser(user)).thenReturn(ubsUser);
         when(userRemoteClient.findByUuid(anyString())).thenReturn(Optional.ofNullable(getUbsCustomersDto()));
@@ -578,7 +567,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void checkCertificate() {
-        Certificate certificate = ModelUtils.getCertificate();
+        Certificate certificate = getCertificate();
         when(certificateRepository.findById("1111-1234")).thenReturn(Optional.of(certificate));
         when(modelMapper.map(certificate, CertificateDto.class)).thenReturn(CertificateDto.builder()
             .code("1111-1234")
@@ -593,7 +582,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void checkCertificateUSED() {
-        Certificate certificate = ModelUtils.getCertificate();
+        Certificate certificate = getCertificate();
         certificate.setCertificateStatus(CertificateStatus.USED);
         when(certificateRepository.findById("1111-1234")).thenReturn(Optional.of(certificate));
         when(modelMapper.map(certificate, CertificateDto.class)).thenReturn(CertificateDto.builder()
@@ -653,7 +642,7 @@ class UBSClientServiceImplTest {
         Order order = getOrderDoneByUser();
         order.setAmountOfBagsOrdered(Collections.singletonMap(1, 1));
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
-        when(bagRepository.findAllByOrder(dto.getOrderId())).thenReturn(ModelUtils.getBag4list());
+        when(bagRepository.findAllByOrder(dto.getOrderId())).thenReturn(getBag4list());
         MakeOrderAgainDto result = ubsService.makeOrderAgain(new Locale("en"), 1L);
 
         assertEquals(dto, result);
@@ -684,7 +673,7 @@ class UBSClientServiceImplTest {
     @Test
     void findUserByUuid() {
         String uuid = "87df9ad5-6393-441f-8423-8b2e770b01a8";
-        when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.of(ModelUtils.getUser()));
+        when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.of(getUser()));
         ubsService.findAllCurrentPointsForUser(uuid);
         verify(userRepository).findUserByUuid(uuid);
     }
@@ -705,7 +694,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void markUserAsDeactivatedById() {
-        User user = ModelUtils.getUser();
+        User user = getUser();
         when(userRepository.findById(1L)).thenReturn(Optional.ofNullable(user));
         ubsService.markUserAsDeactivated(1L);
         verify(userRepository).findById(1L);
@@ -714,7 +703,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void getsUserAndUserUbsAndViolationsInfoByOrderId() {
-        UserInfoDto expectedResult = ModelUtils.getUserInfoDto();
+        UserInfoDto expectedResult = getUserInfoDto();
         expectedResult.setRecipientId(1L);
         when(orderRepository.findById(1L)).thenReturn(Optional.of(getOrderDetails()));
         when(userRepository.findByUuid(anyString())).thenReturn(getOrderDetails().getUser());
@@ -732,10 +721,10 @@ class UBSClientServiceImplTest {
 
     @Test
     void getsUserAndUserUbsAndViolationsInfoByOrderIdWithoutSender() {
-        UserInfoDto expectedResult = ModelUtils.getUserInfoDto();
+        UserInfoDto expectedResult = getUserInfoDto();
         expectedResult.setRecipientId(1L);
-        when(orderRepository.findById(1L)).thenReturn(Optional.of(ModelUtils.getOrderDetailsWithoutSender()));
-        when(userRepository.findByUuid(anyString())).thenReturn(ModelUtils.getOrderDetailsWithoutSender().getUser());
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(getOrderDetailsWithoutSender()));
+        when(userRepository.findByUuid(anyString())).thenReturn(getOrderDetailsWithoutSender().getUser());
         when(userRepository.countTotalUsersViolations(1L)).thenReturn(expectedResult.getTotalUserViolations());
         when(userRepository.checkIfUserHasViolationForCurrentOrder(1L, 1L))
             .thenReturn(expectedResult.getUserViolationForCurrentOrder());
@@ -769,7 +758,7 @@ class UBSClientServiceImplTest {
             .recipientId(1L)
             .build();
 
-        Optional<UBSuser> user = Optional.of(ModelUtils.getUBSuser());
+        Optional<UBSuser> user = Optional.of(getUBSuser());
         when(ubsUserRepository.findById(1L)).thenReturn(user);
         when(ubsUserRepository.save(user.get())).thenReturn(user.get());
 
@@ -806,7 +795,7 @@ class UBSClientServiceImplTest {
             .recipientEmail("anatolii.andr@gmail.com")
             .recipientPhoneNumber("095123456").build();
 
-        Optional<UBSuser> user = Optional.of(ModelUtils.getUBSuser());
+        Optional<UBSuser> user = Optional.of(getUBSuser());
         when(ubsUserRepository.findById(1L)).thenReturn(user);
         when(ubsUserRepository.save(user.get())).thenReturn(user.get());
 
@@ -822,13 +811,13 @@ class UBSClientServiceImplTest {
 
     @Test
     void saveProfileData() {
-        User user = ModelUtils.getUser();
+        User user = getUser();
 
         when(userRepository.findByUuid("87df9ad5-6393-441f-8423-8b2e770b01a8")).thenReturn(user);
 
-        List<AddressDto> addressDto = ModelUtils.addressDtoList();
-        List<Address> address = ModelUtils.addressList();
-        List<Bot> botList = ModelUtils.botList();
+        List<AddressDto> addressDto = addressDtoList();
+        List<Address> address = addressList();
+        List<Bot> botList = botList();
 
         UserProfileUpdateDto userProfileUpdateDto =
             UserProfileUpdateDto.builder().addressDto(addressDto)
@@ -854,13 +843,13 @@ class UBSClientServiceImplTest {
 
     @Test
     void getProfileData() {
-        User user = ModelUtils.getUser();
+        User user = getUser();
         when(userRepository.findByUuid(user.getUuid())).thenReturn(user);
         UserProfileDto userProfileDto = new UserProfileDto();
-        List<AddressDto> addressDto = ModelUtils.addressDtoList();
+        List<AddressDto> addressDto = addressDtoList();
         userProfileDto.setAddressDto(addressDto);
-        List<Address> address = ModelUtils.addressList();
-        List<Bot> botList = ModelUtils.botList();
+        List<Address> address = addressList();
+        List<Bot> botList = botList();
         userProfileDto.setBotList(botList);
         when(modelMapper.map(user, UserProfileDto.class)).thenReturn(userProfileDto);
         when(userRemoteClient.getPasswordStatus()).thenReturn(new PasswordStatusDto(true));
@@ -926,57 +915,57 @@ class UBSClientServiceImplTest {
 
     @Test
     void testSaveCurrentAddressForOrder() {
-        User user = ModelUtils.getUserForCreate();
+        User user = getUserForCreate();
         List<Address> addresses = user.getAddresses();
         String uuid = user.getUuid();
-        OrderAddressDtoRequest dtoRequest = ModelUtils.getTestOrderAddressLocationDto(true);
+        OrderAddressDtoRequest dtoRequest = getTestOrderAddressLocationDto(true);
 
         when(userRepository.findByUuid(user.getUuid())).thenReturn(user);
         when(addressRepository.findAllNonDeletedAddressesByUserId(user.getId())).thenReturn(addresses);
         when(googleApiService.getResultFromGeoCode(eq("fake street name, 13, fake street, 02000"), anyInt()))
-            .thenReturn(ModelUtils.getGeocodingResult());
+            .thenReturn(getGeocodingResult());
         when(modelMapper.map(any(),
             eq(OrderAddressDtoRequest.class)))
                 .thenReturn(TEST_ORDER_ADDRESS_DTO_REQUEST);
 
         addresses.get(0).setActual(false);
 
-        CreateAddressRequestDto createAddressRequestDto = ModelUtils.getAddressRequestDto();
+        CreateAddressRequestDto createAddressRequestDto = getAddressRequestDto();
 
         when(addressRepository.save(addresses.get(0))).thenReturn(addresses.get(0));
         when(modelMapper.map(dtoRequest,
             Address.class)).thenReturn(new Address());
         when(modelMapper.map(addresses.get(0),
             AddressDto.class))
-                .thenReturn(ModelUtils.addressDto());
+                .thenReturn(addressDto());
 
         addresses.get(0).setAddressStatus(AddressStatus.NEW);
 
         OrderWithAddressesResponseDto actualWithSearchAddress =
             ubsService.saveCurrentAddressForOrder(createAddressRequestDto, uuid);
 
-        Assertions.assertEquals(ModelUtils.getAddressDtoResponse(), actualWithSearchAddress);
+        Assertions.assertEquals(getAddressDtoResponse(), actualWithSearchAddress);
         verify(addressRepository, times(1)).save(addresses.get(0));
     }
 
     @Test
     void testSaveCurrentAddressForOrderAlreadyExistException() {
-        User user = ModelUtils.getUserForCreate();
+        User user = getUserForCreate();
         List<Address> addresses = user.getAddresses();
         String uuid = user.getUuid();
-        OrderAddressDtoRequest dtoRequest = ModelUtils.getTestOrderAddressLocationDto();
+        OrderAddressDtoRequest dtoRequest = getTestOrderAddressLocationDto();
 
         when(userRepository.findByUuid(user.getUuid())).thenReturn(user);
         when(addressRepository.findAllNonDeletedAddressesByUserId(user.getId())).thenReturn(addresses);
         when(googleApiService.getResultFromGeoCode(eq("fake street name, 13, fake street, 02000"), anyInt()))
-            .thenReturn(ModelUtils.getGeocodingResult());
+            .thenReturn(getGeocodingResult());
         when(modelMapper.map(any(),
             eq(OrderAddressDtoRequest.class)))
                 .thenReturn(dtoRequest);
 
         addresses.get(0).setActual(false);
 
-        CreateAddressRequestDto createAddressRequestDto = ModelUtils.getAddressRequestDto();
+        CreateAddressRequestDto createAddressRequestDto = getAddressRequestDto();
 
         addresses.get(0).setAddressStatus(AddressStatus.NEW);
 
@@ -986,14 +975,14 @@ class UBSClientServiceImplTest {
 
     @Test
     void testSaveCurrentAddressForMaximumNumbersOfOrdersAddressesException() {
-        User user = ModelUtils.getUserForCreate();
+        User user = getUserForCreate();
         List<Address> addresses = getMaximumAmountOfAddresses();
         String uuid = user.getUuid();
 
         when(userRepository.findByUuid(user.getUuid())).thenReturn(user);
         when(addressRepository.findAllNonDeletedAddressesByUserId(user.getId())).thenReturn(addresses);
 
-        CreateAddressRequestDto createAddressRequestDto = ModelUtils.getAddressRequestDto();
+        CreateAddressRequestDto createAddressRequestDto = getAddressRequestDto();
 
         assertThrows(BadRequestException.class,
             () -> ubsService.saveCurrentAddressForOrder(createAddressRequestDto, uuid));
@@ -1001,12 +990,12 @@ class UBSClientServiceImplTest {
 
     @Test
     void testUpdateCurrentAddressForOrder() {
-        User user = ModelUtils.getUserForCreate();
+        User user = getUserForCreate();
         List<Address> addresses = user.getAddresses();
         String uuid = user.getUuid();
-        OrderAddressDtoRequest dtoRequest = ModelUtils.getTestOrderAddressLocationDto();
+        OrderAddressDtoRequest dtoRequest = getTestOrderAddressLocationDto();
         dtoRequest.setId(1L);
-        OrderAddressDtoRequest updateAddressRequestDto = ModelUtils.getTestOrderAddressDtoRequest();
+        OrderAddressDtoRequest updateAddressRequestDto = getTestOrderAddressDtoRequest();
         updateAddressRequestDto.setId(1L);
         addresses.get(0).setActual(false);
         addresses.get(0).setAddressStatus(AddressStatus.IN_ORDER);
@@ -1015,7 +1004,7 @@ class UBSClientServiceImplTest {
         when(userRepository.findByUuid(user.getUuid())).thenReturn(user);
         when(addressRepository.findAllNonDeletedAddressesByUserId(user.getId())).thenReturn(addresses);
         when(googleApiService.getResultFromGeoCode(eq("fake street name, 13, fake street, 02000"), anyInt()))
-            .thenReturn(ModelUtils.getGeocodingResult());
+            .thenReturn(getGeocodingResult());
         when(modelMapper.map(any(),
             eq(OrderAddressDtoRequest.class)))
                 .thenReturn(TEST_ORDER_ADDRESS_DTO_REQUEST);
@@ -1026,31 +1015,31 @@ class UBSClientServiceImplTest {
         when(addressRepository.save(addresses.get(0))).thenReturn(addresses.get(0));
         when(modelMapper.map(addresses.get(0),
             AddressDto.class))
-                .thenReturn(ModelUtils.addressDto());
+                .thenReturn(addressDto());
 
         OrderWithAddressesResponseDto actualWithSearchAddress =
             ubsService.updateCurrentAddressForOrder(updateAddressRequestDto, uuid);
 
         Assertions.assertNotNull(updateAddressRequestDto.getSearchAddress());
         Assertions.assertNull(dtoRequest.getSearchAddress());
-        Assertions.assertEquals(ModelUtils.getAddressDtoResponse(), actualWithSearchAddress);
+        Assertions.assertEquals(getAddressDtoResponse(), actualWithSearchAddress);
         verify(googleApiService, times(2)).getResultFromGeoCode(eq("fake street name, 13, fake street, 02000"),
             anyInt());
         updateAddressRequestDto.setSearchAddress(null);
         OrderWithAddressesResponseDto actualWithoutSearchAddress =
             ubsService.updateCurrentAddressForOrder(updateAddressRequestDto, uuid);
-        Assertions.assertEquals(ModelUtils.getAddressDtoResponse(), actualWithoutSearchAddress);
+        Assertions.assertEquals(getAddressDtoResponse(), actualWithoutSearchAddress);
         verify(addressRepository, times(2)).save(addresses.get(0));
     }
 
     @Test
     void testUpdateCurrentAddressForOrderWithNoAddress() {
-        User user = ModelUtils.getUserForCreate(AddressStatus.DELETED);
+        User user = getUserForCreate(AddressStatus.DELETED);
         List<Address> addresses = user.getAddresses();
         String uuid = user.getUuid();
-        OrderAddressDtoRequest dtoRequest = ModelUtils.getTestOrderAddressLocationDto();
+        OrderAddressDtoRequest dtoRequest = getTestOrderAddressLocationDto();
         dtoRequest.setId(1L);
-        OrderAddressDtoRequest updateAddressRequestDto = ModelUtils.getTestOrderAddressDtoRequest();
+        OrderAddressDtoRequest updateAddressRequestDto = getTestOrderAddressDtoRequest();
         updateAddressRequestDto.setId(1L);
         addresses.get(0).setActual(false);
         addresses.get(0).setUser(user);
@@ -1058,7 +1047,7 @@ class UBSClientServiceImplTest {
         when(userRepository.findByUuid(user.getUuid())).thenReturn(user);
         when(addressRepository.findById(user.getId())).thenReturn(Optional.ofNullable(addresses.get(0)));
         when(googleApiService.getResultFromGeoCode(eq("fake street name, 13, fake street, 02000"), anyInt()))
-            .thenReturn(ModelUtils.getGeocodingResult());
+            .thenReturn(getGeocodingResult());
 
         when(addressRepository.findById(user.getId())).thenReturn(Optional.ofNullable(addresses.get(0)));
         when(modelMapper.map(dtoRequest,
@@ -1083,12 +1072,12 @@ class UBSClientServiceImplTest {
 
     @Test
     void testUpdateCurrentAddressForOrderAlreadyExistException() {
-        User user = ModelUtils.getUserForCreate();
+        User user = getUserForCreate();
         List<Address> addresses = user.getAddresses();
         String uuid = user.getUuid();
-        OrderAddressDtoRequest dtoRequest = ModelUtils.getTestOrderAddressLocationDto();
+        OrderAddressDtoRequest dtoRequest = getTestOrderAddressLocationDto();
         dtoRequest.setId(1L);
-        OrderAddressDtoRequest updateAddressRequestDto = ModelUtils.getTestOrderAddressDtoRequest();
+        OrderAddressDtoRequest updateAddressRequestDto = getTestOrderAddressDtoRequest();
         updateAddressRequestDto.setId(1L);
         addresses.get(0).setActual(false);
         addresses.get(0).setAddressStatus(AddressStatus.IN_ORDER);
@@ -1097,7 +1086,7 @@ class UBSClientServiceImplTest {
         when(userRepository.findByUuid(user.getUuid())).thenReturn(user);
         when(addressRepository.findAllNonDeletedAddressesByUserId(user.getId())).thenReturn(addresses);
         when(googleApiService.getResultFromGeoCode(eq("fake street name, 13, fake street, 02000"), anyInt()))
-            .thenReturn(ModelUtils.getGeocodingResult());
+            .thenReturn(getGeocodingResult());
 
         when(modelMapper.map(any(),
             eq(OrderAddressDtoRequest.class)))
@@ -1109,12 +1098,12 @@ class UBSClientServiceImplTest {
 
     @Test
     void testUpdateCurrentAddressForOrderNotFoundOrderAddressException() {
-        User user = ModelUtils.getUserForCreate();
+        User user = getUserForCreate();
         List<Address> addresses = user.getAddresses();
         String uuid = user.getUuid();
-        OrderAddressDtoRequest dtoRequest = ModelUtils.getTestOrderAddressLocationDto();
+        OrderAddressDtoRequest dtoRequest = getTestOrderAddressLocationDto();
         dtoRequest.setId(1L);
-        OrderAddressDtoRequest updateAddressRequestDto = ModelUtils.getTestOrderAddressDtoRequest();
+        OrderAddressDtoRequest updateAddressRequestDto = getTestOrderAddressDtoRequest();
         updateAddressRequestDto.setId(1L);
         addresses.get(0).setActual(false);
         addresses.get(0).setAddressStatus(AddressStatus.IN_ORDER);
@@ -1123,7 +1112,7 @@ class UBSClientServiceImplTest {
         when(userRepository.findByUuid(user.getUuid())).thenReturn(user);
         when(addressRepository.findAllNonDeletedAddressesByUserId(user.getId())).thenReturn(addresses);
         when(googleApiService.getResultFromGeoCode(eq("fake street name, 13, fake street, 02000"), anyInt()))
-            .thenReturn(ModelUtils.getGeocodingResult());
+            .thenReturn(getGeocodingResult());
 
         when(modelMapper.map(any(),
             eq(OrderAddressDtoRequest.class)))
@@ -1205,8 +1194,8 @@ class UBSClientServiceImplTest {
 
     @Test
     void testGetOrderCancellationReason() {
-        OrderCancellationReasonDto dto = ModelUtils.getCancellationDto();
-        Order orderDto = ModelUtils.getOrderTest();
+        OrderCancellationReasonDto dto = getCancellationDto();
+        Order orderDto = getOrderTest();
         when(orderRepository.findById(anyLong())).thenReturn(Optional.ofNullable(orderDto));
         assert orderDto != null;
         when(userRepository.findByUuid(anyString())).thenReturn(orderDto.getUser());
@@ -1233,8 +1222,8 @@ class UBSClientServiceImplTest {
 
     @Test
     void testUpdateOrderCancellationReason() {
-        OrderCancellationReasonDto dto = ModelUtils.getCancellationDto();
-        Order orderDto = ModelUtils.getOrderTest();
+        OrderCancellationReasonDto dto = getCancellationDto();
+        Order orderDto = getOrderTest();
         when(orderRepository.findById(anyLong())).thenReturn(Optional.ofNullable(orderDto));
         assert orderDto != null;
         when(userRepository.findByUuid(anyString())).thenReturn(orderDto.getUser());
@@ -1266,8 +1255,8 @@ class UBSClientServiceImplTest {
 
     @Test
     void testGelAllEventsFromOrderByOrderId() {
-        List<Event> orderEvents = ModelUtils.getListOfEvents();
-        when(orderRepository.findById(1L)).thenReturn(ModelUtils.getOrderWithEvents());
+        List<Event> orderEvents = getListOfEvents();
+        when(orderRepository.findById(1L)).thenReturn(getOrderWithEvents());
         when(eventRepository.findAllEventsByOrderId(1L)).thenReturn(orderEvents);
         List<EventDto> eventDTOS = orderEvents.stream()
             .map(event -> modelMapper.map(event, EventDto.class))
@@ -1284,7 +1273,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void testGelAllEventsFromOrderByOrderIdWithThrowingEventsNotFoundException() {
-        when(orderRepository.findById(1L)).thenReturn(ModelUtils.getOrderWithEvents());
+        when(orderRepository.findById(1L)).thenReturn(getOrderWithEvents());
         when(eventRepository.findAllEventsByOrderId(1L)).thenReturn(Collections.emptyList());
         assertThrows(NotFoundException.class,
             () -> ubsService.getAllEventsForOrder(1L, "abc"));
@@ -1319,7 +1308,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfo()));
+            .thenReturn(Optional.of(getTariffInfo()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
         when(ubsUserRepository.findById(1L)).thenReturn(Optional.of(ubSuser));
         when(modelMapper.map(dto, Order.class)).thenReturn(order);
@@ -1339,7 +1328,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void saveFullOrderFromLiqPayFailPaidOrder() {
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setCurrentPoints(1000);
         OrderResponseDto dto = getOrderResponseDto();
         dto.getBags().get(0).setAmount(5);
@@ -1351,7 +1340,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfo()));
+            .thenReturn(Optional.of(getTariffInfo()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
         when(orderRepository.findById(any())).thenReturn(Optional.of(order));
 
@@ -1361,7 +1350,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void testSaveFullOrderFromLiqPayThrowsException() {
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setCurrentPoints(900);
         OrderResponseDto dto = getOrderResponseDto();
         dto.getBags().get(0).setAmount(2);
@@ -1382,7 +1371,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfoWithLimitOfBags()));
+            .thenReturn(Optional.of(getTariffInfoWithLimitOfBags()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
         assertThrows(BadRequestException.class,
             () -> ubsService.saveFullOrderToDBFromLiqPay(dto, "35467585763t4sfgchjfuyetf", null));
@@ -1400,7 +1389,7 @@ class UBSClientServiceImplTest {
         user.getOrders().add(order);
         user.setChangeOfPointsList(new ArrayList<>());
 
-        Optional<Bag> bag = ModelUtils.getBag();
+        Optional<Bag> bag = getBag();
 
         UBSuser ubSuser = getUBSuser();
         ubSuser.setId(null);
@@ -1416,7 +1405,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfo()));
+            .thenReturn(Optional.of(getTariffInfo()));
         when(bagRepository.findById(3)).thenReturn(bag);
         when(ubsUserRepository.findById(1L)).thenReturn(Optional.of(ubSuser));
         when(modelMapper.map(dto, Order.class)).thenReturn(order);
@@ -1430,7 +1419,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void validateLiqPayPayment() {
-        PaymentResponseDtoLiqPay dto = ModelUtils.getPaymentResponceDto();
+        PaymentResponseDtoLiqPay dto = getPaymentResponceDto();
 
         when(encryptionUtil.formingResponseSignatureLiqPay(dto.getData(), null)).thenReturn("Test Signature");
 
@@ -1440,7 +1429,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void validateNotValidLiqPayPayment() {
-        PaymentResponseDtoLiqPay dto = ModelUtils.getPaymentResponceDto();
+        PaymentResponseDtoLiqPay dto = getPaymentResponceDto();
 
         when(encryptionUtil.formingResponseSignatureLiqPay(dto.getData(), null)).thenReturn("fdf");
 
@@ -1449,7 +1438,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void deleteOrder() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         when(ordersForUserRepository.getAllByUserUuidAndId(order.getUser().getUuid(), order.getId()))
             .thenReturn(order);
 
@@ -1460,7 +1449,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void deleteOrderFail() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         when(ordersForUserRepository.getAllByUserUuidAndId(order.getUser().getUuid(), order.getId()))
             .thenReturn(null);
 
@@ -1471,7 +1460,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void processOrderFondyClient() throws Exception {
-        Order order = ModelUtils.getOrderCount();
+        Order order = getOrderCount();
         HashMap<Integer, Integer> value = new HashMap<>();
         value.put(1, 22);
         order.setAmountOfBagsOrdered(value);
@@ -1479,12 +1468,12 @@ class UBSClientServiceImplTest {
         order.setSumTotalAmountWithoutDiscounts(1000L);
         order.setCertificates(Set.of(getCertificate()));
         order.setPayment(TEST_PAYMENT_LIST);
-        User user = ModelUtils.getUser();
+        User user = getUser();
         user.setCurrentPoints(100);
         user.setChangeOfPointsList(new ArrayList<>());
         order.setUser(user);
 
-        OrderFondyClientDto dto = ModelUtils.getOrderFondyClientDto();
+        OrderFondyClientDto dto = getOrderFondyClientDto();
         Field[] fields = UBSClientServiceImpl.class.getDeclaredFields();
         for (Field f : fields) {
             if (f.getName().equals("merchantId")) {
@@ -1493,8 +1482,8 @@ class UBSClientServiceImplTest {
             }
         }
 
-        Certificate certificate = ModelUtils.getCertificate();
-        CertificateDto certificateDto = ModelUtils.createCertificateDto();
+        Certificate certificate = getCertificate();
+        CertificateDto certificateDto = createCertificateDto();
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(userRepository.findUserByUuid("uuid")).thenReturn(Optional.of(user));
@@ -1513,21 +1502,21 @@ class UBSClientServiceImplTest {
 
     @Test
     void processOrderFondyClientFailPaidOrder() {
-        Order order = ModelUtils.getOrderCountWithPaymentStatusPaid();
-        OrderFondyClientDto dto = ModelUtils.getOrderFondyClientDto();
+        Order order = getOrderCountWithPaymentStatusPaid();
+        OrderFondyClientDto dto = getOrderFondyClientDto();
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(order));
         Assertions.assertThrows(BadRequestException.class, () -> ubsService.processOrderFondyClient(dto, "uuid"));
     }
 
     @Test
     void proccessOrderLiqpayClient() {
-        Order order = ModelUtils.getOrderCount();
+        Order order = getOrderCount();
         HashMap<Integer, Integer> value = new HashMap<>();
         value.put(1, 22);
         order.setAmountOfBagsOrdered(value);
         OrderFondyClientDto dto = getOrderFondyClientDto();
-        Bag bag = ModelUtils.bagDtoClient();
-        User user = ModelUtils.getUser();
+        Bag bag = bagDtoClient();
+        User user = getUser();
         user.setCurrentPoints(100);
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
@@ -1542,15 +1531,15 @@ class UBSClientServiceImplTest {
 
     @Test
     void proccessOrderLiqpayClientFailPaidOrder() {
-        Order order = ModelUtils.getOrderCountWithPaymentStatusPaid();
-        OrderFondyClientDto dto = ModelUtils.getOrderFondyClientDto();
+        Order order = getOrderCountWithPaymentStatusPaid();
+        OrderFondyClientDto dto = getOrderFondyClientDto();
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(order));
         Assertions.assertThrows(BadRequestException.class, () -> ubsService.proccessOrderLiqpayClient(dto, "uuid"));
     }
 
     @Test
     void saveFullOrderToDBForIF() throws IllegalAccessException {
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setCurrentPoints(900);
 
         OrderResponseDto dto = getOrderResponseDto();
@@ -1586,11 +1575,11 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfo()));
+            .thenReturn(Optional.of(getTariffInfo()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
         when(ubsUserRepository.findById(1L)).thenReturn(Optional.of(ubSuser));
         when(modelMapper.map(dto, Order.class)).thenReturn(order);
-        when(certificateRepository.findById("1111-1234")).thenReturn(Optional.of(ModelUtils.getCertificate()));
+        when(certificateRepository.findById("1111-1234")).thenReturn(Optional.of(getCertificate()));
         when(modelMapper.map(dto.getPersonalData(), UBSuser.class)).thenReturn(ubSuser);
         when(orderRepository.findById(any())).thenReturn(Optional.of(order1));
         when(encryptionUtil.formRequestSignature(any(), eq(null), eq("1"))).thenReturn("TestValue");
@@ -1602,9 +1591,9 @@ class UBSClientServiceImplTest {
 
     @Test
     void saveFullOrderToDBWhenSumToPayeqNull() throws IllegalAccessException {
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setCurrentPoints(9000);
-        user.setUbsUsers(ModelUtils.getUbsUsers());
+        user.setUbsUsers(getUbsUsers());
 
         OrderResponseDto dto = getOrderResponseDto();
         dto.setAddressId(1L);
@@ -1639,7 +1628,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfo()));
+            .thenReturn(Optional.of(getTariffInfo()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
         when(ubsUserRepository.findById(1L)).thenReturn(Optional.of(ubSuser));
         when(addressRepository.findById(any())).thenReturn(Optional.of(address));
@@ -1653,7 +1642,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void testSaveToDBfromIForIFThrowsException() throws IllegalAccessException {
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setCurrentPoints(900);
 
         OrderResponseDto dto = getOrderResponseDto();
@@ -1687,7 +1676,7 @@ class UBSClientServiceImplTest {
         }
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfoWithLimitOfBags()));
+            .thenReturn(Optional.of(getTariffInfoWithLimitOfBags()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
         Assertions.assertThrows(BadRequestException.class, () -> {
             ubsService.saveFullOrderToDB(dto, "35467585763t4sfgchjfuyetf", null);
@@ -1696,7 +1685,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void testCheckSumIfCourierLimitBySumOfOrderForIF1() throws IllegalAccessException {
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setCurrentPoints(9000);
 
         OrderResponseDto dto = getOrderResponseDto();
@@ -1727,7 +1716,7 @@ class UBSClientServiceImplTest {
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
             .thenReturn(Optional.of(
-                ModelUtils.getTariffInfoWithLimitOfBags()
+                getTariffInfoWithLimitOfBags()
                     .setCourierLimit(CourierLimit.LIMIT_BY_SUM_OF_ORDER)
                     .setMin(50000L)));
 
@@ -1741,7 +1730,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void testCheckSumIfCourierLimitBySumOfOrderForIF2() throws InvocationTargetException, IllegalAccessException {
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setCurrentPoints(9000);
 
         OrderResponseDto dto = getOrderResponseDto();
@@ -1772,7 +1761,7 @@ class UBSClientServiceImplTest {
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
             .thenReturn(Optional.of(
-                ModelUtils.getTariffInfoWithLimitOfBags()
+                getTariffInfoWithLimitOfBags()
                     .setCourierLimit(CourierLimit.LIMIT_BY_SUM_OF_ORDER)
                     .setMax(500L)));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
@@ -1811,7 +1800,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfo()));
+            .thenReturn(Optional.of(getTariffInfo()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
         when(ubsUserRepository.findById(1L)).thenReturn(Optional.of(ubSuser));
         when(modelMapper.map(dto, Order.class)).thenReturn(order);
@@ -1832,9 +1821,9 @@ class UBSClientServiceImplTest {
     @Test
     void validatePaymentClientTest() {
 
-        PaymentResponseDto dto = ModelUtils.getPaymentResponseDto();
+        PaymentResponseDto dto = getPaymentResponseDto();
 
-        when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersDto()));
+        when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(getOrdersDto()));
         when(encryptionUtil.checkIfResponseSignatureIsValid(dto, null)).thenReturn(true);
 
         ubsService.validatePaymentClient(dto);
@@ -1846,10 +1835,10 @@ class UBSClientServiceImplTest {
 
     @Test
     void validatePaymentClientExceptionTest() {
-        PaymentResponseDto dto = ModelUtils.getPaymentResponseDto();
+        PaymentResponseDto dto = getPaymentResponseDto();
 
         when(orderRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersDto()));
+            .thenReturn(Optional.ofNullable(getOrdersDto()));
 
         assertThrows(BadRequestException.class, () -> ubsService.validatePaymentClient(dto));
     }
@@ -1865,7 +1854,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void findAllCurrentPointsForUser() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setCurrentPoints(100);
         user.getChangeOfPointsList().get(0).setAmount(100);
 
@@ -1885,7 +1874,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void getPaymentResponseFromFondy() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         FondyPaymentResponse expected = FondyPaymentResponse.builder()
             .paymentStatus(order.getPayment().get(0).getResponseStatus())
             .build();
@@ -1919,10 +1908,10 @@ class UBSClientServiceImplTest {
 
     @Test
     void getPaymentResponseFromFondyAccessDeniedException() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
-        when(userRepository.findByUuid(anyString())).thenReturn(ModelUtils.getTestUser());
+        when(userRepository.findByUuid(anyString())).thenReturn(getTestUser());
 
         assertThrows(AccessDeniedException.class, () -> {
             ubsService.getPaymentResponseFromFondy(1L, "abc");
@@ -1931,12 +1920,12 @@ class UBSClientServiceImplTest {
 
     @Test
     void getOrderForUserTest() {
-        OrderStatusTranslation orderStatusTranslation = ModelUtils.getOrderStatusTranslation();
-        OrderPaymentStatusTranslation orderPaymentStatusTranslation = ModelUtils.getOrderPaymentStatusTranslation();
-        OrdersDataForUserDto ordersDataForUserDto = ModelUtils.getOrderStatusDto();
-        Order order = ModelUtils.getOrderTest();
-        User user = ModelUtils.getTestUser();
-        Bag bag = ModelUtils.bagDto();
+        OrderStatusTranslation orderStatusTranslation = getOrderStatusTranslation();
+        OrderPaymentStatusTranslation orderPaymentStatusTranslation = getOrderPaymentStatusTranslation();
+        OrdersDataForUserDto ordersDataForUserDto = getOrderStatusDto();
+        Order order = getOrderTest();
+        User user = getTestUser();
+        Bag bag = bagDto();
 
         List<Bag> bags = new ArrayList<>();
         List<Order> orderList = new ArrayList<>();
@@ -1974,8 +1963,8 @@ class UBSClientServiceImplTest {
 
     @Test
     void getOrderForUserFail() {
-        Order order = ModelUtils.getOrderTest();
-        User user = ModelUtils.getTestUser();
+        Order order = getOrderTest();
+        User user = getTestUser();
 
         when(ordersForUserRepository.getAllByUserUuidAndId("UUID", order.getId()))
             .thenReturn(null);
@@ -1987,12 +1976,12 @@ class UBSClientServiceImplTest {
 
     @Test
     void getOrdersForUserTest() {
-        OrderStatusTranslation orderStatusTranslation = ModelUtils.getOrderStatusTranslation();
-        OrderPaymentStatusTranslation orderPaymentStatusTranslation = ModelUtils.getOrderPaymentStatusTranslation();
-        OrdersDataForUserDto ordersDataForUserDto = ModelUtils.getOrderStatusDto();
-        Order order = ModelUtils.getOrderTest();
-        User user = ModelUtils.getTestUser();
-        Bag bag = ModelUtils.bagDto();
+        OrderStatusTranslation orderStatusTranslation = getOrderStatusTranslation();
+        OrderPaymentStatusTranslation orderPaymentStatusTranslation = getOrderPaymentStatusTranslation();
+        OrdersDataForUserDto ordersDataForUserDto = getOrderStatusDto();
+        Order order = getOrderTest();
+        User user = getTestUser();
+        Bag bag = bagDto();
 
         List<Bag> bags = new ArrayList<>();
         List<Order> orderList = new ArrayList<>();
@@ -2036,12 +2025,12 @@ class UBSClientServiceImplTest {
 
     @Test
     void testOrdersForUserWithExportedQuantity() {
-        OrderStatusTranslation orderStatusTranslation = ModelUtils.getOrderStatusTranslation();
-        OrderPaymentStatusTranslation orderPaymentStatusTranslation = ModelUtils.getOrderPaymentStatusTranslation();
-        OrdersDataForUserDto ordersDataForUserDto = ModelUtils.getOrderStatusDto();
-        Order order = ModelUtils.getOrderTest();
-        User user = ModelUtils.getTestUser();
-        Bag bag = ModelUtils.bagDto();
+        OrderStatusTranslation orderStatusTranslation = getOrderStatusTranslation();
+        OrderPaymentStatusTranslation orderPaymentStatusTranslation = getOrderPaymentStatusTranslation();
+        OrdersDataForUserDto ordersDataForUserDto = getOrderStatusDto();
+        Order order = getOrderTest();
+        User user = getTestUser();
+        Bag bag = bagDto();
 
         List<Bag> bags = new ArrayList<>();
         List<Order> orderList = new ArrayList<>();
@@ -2085,12 +2074,12 @@ class UBSClientServiceImplTest {
 
     @Test
     void testOrdersForUserWithConfirmedQuantity() {
-        OrderStatusTranslation orderStatusTranslation = ModelUtils.getOrderStatusTranslation();
-        OrderPaymentStatusTranslation orderPaymentStatusTranslation = ModelUtils.getOrderPaymentStatusTranslation();
-        OrdersDataForUserDto ordersDataForUserDto = ModelUtils.getOrderStatusDto();
-        Order order = ModelUtils.getOrderTest();
-        User user = ModelUtils.getTestUser();
-        Bag bag = ModelUtils.bagDto();
+        OrderStatusTranslation orderStatusTranslation = getOrderStatusTranslation();
+        OrderPaymentStatusTranslation orderPaymentStatusTranslation = getOrderPaymentStatusTranslation();
+        OrdersDataForUserDto ordersDataForUserDto = getOrderStatusDto();
+        Order order = getOrderTest();
+        User user = getTestUser();
+        Bag bag = bagDto();
 
         List<Bag> bags = new ArrayList<>();
         List<Order> orderList = new ArrayList<>();
@@ -2134,11 +2123,11 @@ class UBSClientServiceImplTest {
 
     @Test
     void senderInfoDtoBuilderTest() {
-        OrderStatusTranslation orderStatusTranslation = ModelUtils.getOrderStatusTranslation();
-        OrderPaymentStatusTranslation orderPaymentStatusTranslation = ModelUtils.getOrderPaymentStatusTranslation();
-        UBSuser ubsuser = ModelUtils.getUBSuserWithoutSender();
-        Order order = ModelUtils.getOrderTest().setUbsUser(ubsuser);
-        User user = ModelUtils.getTestUser();
+        OrderStatusTranslation orderStatusTranslation = getOrderStatusTranslation();
+        OrderPaymentStatusTranslation orderPaymentStatusTranslation = getOrderPaymentStatusTranslation();
+        UBSuser ubsuser = getUBSuserWithoutSender();
+        Order order = getOrderTest().setUbsUser(ubsuser);
+        User user = getTestUser();
         List<Order> orderList = new ArrayList<>();
         order.setAmountOfBagsOrdered(Map.of(1, 10));
         order.setUser(user);
@@ -2163,7 +2152,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void getTariffInfoForLocationTest() {
-        var tariff = ModelUtils.getTariffInfo();
+        var tariff = getTariffInfo();
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
             .thenReturn(Optional.of(tariff));
         OrderCourierPopUpDto dto = ubsService.getTariffInfoForLocation(1L);
@@ -2173,9 +2162,9 @@ class UBSClientServiceImplTest {
 
     @Test
     void getInfoForCourierOrderingTest() {
-        var tariff = ModelUtils.getTariffInfo();
+        var tariff = getTariffInfo();
         when(orderRepository.getLastOrderOfUserByUUIDIfExists(anyString()))
-            .thenReturn(Optional.of(ModelUtils.getOrder()));
+            .thenReturn(Optional.of(getOrder()));
         when(tariffsInfoRepository.findTariffsInfoByOrdersId(anyLong())).thenReturn(tariff);
         OrderCourierPopUpDto dto = ubsService.getInfoForCourierOrdering("35467585763t4sfgchjfuyetf", Optional.empty());
         verify(modelMapper).map(tariff, TariffsForLocationDto.class);
@@ -2184,7 +2173,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void getInfoForCourierOrderingTest2() {
-        List<Location> list = ModelUtils.getLocationList();
+        List<Location> list = getLocationList();
         when(locationRepository.findAllActive()).thenReturn(list);
         when(modelMapper.map(list.get(0), RegionDto.class))
             .thenReturn(RegionDto.builder().regionId(1L).nameUk("Київська область ").nameEn("Kyiv region").build());
@@ -2199,7 +2188,7 @@ class UBSClientServiceImplTest {
     @Test
     void checkIfAddressHasBeenDeletedTest() throws IllegalAccessException {
 
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setCurrentPoints(900);
 
         OrderResponseDto dto = getOrderResponseDto();
@@ -2228,7 +2217,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfo()));
+            .thenReturn(Optional.of(getTariffInfo()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
         when(ubsUserRepository.findById(1L)).thenReturn(Optional.of(ubSuser));
         when(modelMapper.map(dto, Order.class)).thenReturn(order);
@@ -2243,10 +2232,10 @@ class UBSClientServiceImplTest {
     @Test
     void checkAddressUserTest() throws IllegalAccessException {
 
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setCurrentPoints(900);
 
-        User user1 = ModelUtils.getUser();
+        User user1 = getUser();
 
         OrderResponseDto dto = getOrderResponseDto();
         dto.getBags().get(0).setAmount(15);
@@ -2274,7 +2263,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfo()));
+            .thenReturn(Optional.of(getTariffInfo()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
         when(ubsUserRepository.findById(1L)).thenReturn(Optional.of(ubSuser));
         when(modelMapper.map(dto, Order.class)).thenReturn(order);
@@ -2288,7 +2277,7 @@ class UBSClientServiceImplTest {
     @Test
     void checkIfUserHaveEnoughPointsTest() throws IllegalAccessException {
 
-        User user = ModelUtils.getUserWithLastLocation();
+        User user = getUserWithLastLocation();
         user.setCurrentPoints(100);
 
         OrderResponseDto dto = getOrderResponseDto();
@@ -2312,7 +2301,7 @@ class UBSClientServiceImplTest {
 
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(anyLong(), anyLong()))
-            .thenReturn(Optional.of(ModelUtils.getTariffInfo()));
+            .thenReturn(Optional.of(getTariffInfo()));
         when(bagRepository.findById(3)).thenReturn(Optional.of(bag));
 
         Assertions.assertThrows(BadRequestException.class,
@@ -2321,7 +2310,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void getLiqPayStatusTest() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         User user = order.getUser();
 
         StatusRequestDtoLiqPay dto = StatusRequestDtoLiqPay.builder()
@@ -2369,10 +2358,10 @@ class UBSClientServiceImplTest {
 
     @Test
     void getTariffForOrderTest() {
-        TariffsInfo tariffsInfo = ModelUtils.getTariffInfo();
+        TariffsInfo tariffsInfo = getTariffInfo();
         when(tariffsInfoRepository.findByOrdersId(anyLong())).thenReturn(Optional.of(tariffsInfo));
         when(modelMapper.map(tariffsInfo, TariffsForLocationDto.class))
-            .thenReturn(ModelUtils.getTariffsForLocationDto());
+            .thenReturn(getTariffsForLocationDto());
         var dto = ubsService.getTariffForOrder(1L);
         verify(tariffsInfoRepository, times(1)).findByOrdersId(anyLong());
         verify(modelMapper).map(tariffsInfo, TariffsForLocationDto.class);
@@ -2394,7 +2383,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void updateEmployeesAuthorities() {
-        UserEmployeeAuthorityDto dto = ModelUtils.getUserEmployeeAuthorityDto();
+        UserEmployeeAuthorityDto dto = getUserEmployeeAuthorityDto();
         userRemoteClient.updateEmployeesAuthorities(dto, "test@mail.com");
         verify(userRemoteClient, times(1)).updateEmployeesAuthorities(
             dto, "test@mail.com");
@@ -2416,9 +2405,9 @@ class UBSClientServiceImplTest {
 
     @Test
     void updateEmployeesAuthoritiesService() {
-        UserEmployeeAuthorityDto dto = ModelUtils.getUserEmployeeAuthorityDto();
+        UserEmployeeAuthorityDto dto = getUserEmployeeAuthorityDto();
 
-        when(employeeRepository.findByEmail(dto.getEmployeeEmail())).thenReturn(Optional.of(ModelUtils.getEmployee()));
+        when(employeeRepository.findByEmail(dto.getEmployeeEmail())).thenReturn(Optional.of(getEmployee()));
 
         ubsService.updateEmployeesAuthorities(dto, dto.getEmployeeEmail());
 
@@ -2429,11 +2418,11 @@ class UBSClientServiceImplTest {
 
     @Test
     void testOrdersForUserWithQuantity() {
-        OrderStatusTranslation orderStatusTranslation = ModelUtils.getOrderStatusTranslation();
-        OrderPaymentStatusTranslation orderPaymentStatusTranslation = ModelUtils.getOrderPaymentStatusTranslation();
-        Order order = ModelUtils.getOrderTest();
-        User user = ModelUtils.getTestUser();
-        Bag bag = ModelUtils.bagDto();
+        OrderStatusTranslation orderStatusTranslation = getOrderStatusTranslation();
+        OrderPaymentStatusTranslation orderPaymentStatusTranslation = getOrderPaymentStatusTranslation();
+        Order order = getOrderTest();
+        User user = getTestUser();
+        Bag bag = bagDto();
 
         List<Bag> bags = new ArrayList<>();
         List<Order> orderList = new ArrayList<>();

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -271,6 +271,36 @@ class UBSClientServiceImplTest {
     }
 
     @Test
+    void getFirstPageDataWithoutOrderId() {
+        var user = getUserWithLastLocation();
+        user.setCurrentPoints(600);
+
+        var bagList = getBag1list();
+        var bagTranslationDto = getBagTranslationDto();
+
+        var userPointsAndAllBagsDtoExpected = getUserPointsAndAllBagsDto();
+
+        when(userRepository.findUserByUuid(anyString())).thenReturn(Optional.of(user));
+        when(bagRepository.findAll()).thenReturn(bagList);
+        when(modelMapper.map(bagList.get(0), BagTranslationDto.class)).thenReturn(bagTranslationDto);
+
+        var userPointsAndAllBagsDtoActual =
+            ubsService.getFirstPageData(anyString(), Optional.empty());
+
+        assertEquals(userPointsAndAllBagsDtoExpected.getBags(), userPointsAndAllBagsDtoActual.getBags());
+        assertEquals(userPointsAndAllBagsDtoExpected.getPoints(), userPointsAndAllBagsDtoActual.getPoints());
+        assertEquals(
+            userPointsAndAllBagsDtoExpected.getBags().get(0).getId(),
+            userPointsAndAllBagsDtoActual.getBags().get(0).getId());
+
+        verify(userRepository).findUserByUuid(anyString());
+        verify(bagRepository).findAll();
+        verify(modelMapper).map(any(), any());
+
+        verify(bagRepository, never()).findBagsByTariffInfoId(anyLong());
+    }
+
+    @Test
     void getFirstPageDataOrderNotFoundException() {
         User user = getUserWithLastLocation();
         Optional<Long> optionalOrderId = Optional.of(1L);


### PR DESCRIPTION
## JIRA

* [Main JIRA ticket](https://github.com/ita-social-projects/GreenCity/issues/5246)


## Code reviewers

- [x] @NKorzhik 
- [x] @KharchenkoV 
- [x] @MaksymGolik 
- [x] @LiliaMokhnatska 
- [ ] @Markiro1 
- [x] @juseti 
- [ ] @OlegVat 
- [ ] @sergoliarnik 
- [ ] @ABbondar 

## Summary of issue

All existing bags are displayed on the order page

1) changed request parameter for "/order-details" endpoint of OrderController class to (Optional<Long> optionalOrderId)

2) changed parameter for method getFirstPageData() of UBSClientService interface from Optional locationId to Optional orderId

3) changed functionality of getFirstPageData() method and removed methods getBagList(), checkAndGetLocationId() for work with locationId. Added methods() getBagsByOrderId() and getOrderByIdOrThrowNotFoundException() instead

4) removed method findBagsByLocationIdAndLocationStatusIsActive() in BagRepository

5) removed extra comment in ModelUtils

6) changed test methods in OrderController and UBSClientServiceImplTest

ToDo

1. Go to https://www.testgreencity.ga/#/ubs
2. Sign in as a User
3. Go to UBS-User
4. Click on the 'Pay' button in Order's card
5. Pay attention to the order page
6. Only tariffs related to this order are displayed on the page

ToDo

## CHECK LIST
- [x]  СI passed
- [ ]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions