### PR TITLE
[UBS] - create endpoint to switch tariff activation status #5291

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -1,6 +1,5 @@
 package greencity.configuration;
 
-import greencity.client.UserRemoteClient;
 import greencity.security.JwtTool;
 import greencity.security.filters.AccessTokenAuthenticationFilter;
 import greencity.security.providers.JwtAuthenticationProvider;
@@ -142,7 +141,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 SUPER_ADMIN_LINK + "/**")
             .hasAnyRole(ADMIN, UBS_EMPLOYEE)
             .antMatchers(HttpMethod.PATCH,
-                SUPER_ADMIN_LINK + "/deactivateCourier/{id}")
+                SUPER_ADMIN_LINK + "/deactivateCourier/{id}",
+                SUPER_ADMIN_LINK + "/switchTariffStatus/{tariffId}")
             .hasAnyRole(ADMIN, UBS_EMPLOYEE)
             .antMatchers(HttpMethod.PATCH,
                 UBS_MANAG_LINK + "/update-order-page-admin-info/{id}",

--- a/core/src/main/java/greencity/controller/SuperAdminController.java
+++ b/core/src/main/java/greencity/controller/SuperAdminController.java
@@ -12,6 +12,7 @@ import greencity.dto.tariff.ChangeTariffLocationStatusDto;
 import greencity.dto.service.GetTariffServiceDto;
 import greencity.dto.tariff.GetTariffsInfoDto;
 import greencity.dto.tariff.SetTariffLimitsDto;
+import greencity.enums.LocationStatus;
 import greencity.exceptions.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -601,21 +602,27 @@ class SuperAdminController {
     }
 
     /**
-     * Controller for deactivation of TariffsInfo.
+     * Controller for switching tariff activation status.
      *
-     * @author Yurii Fedorko
+     * @param tariffId     {@link Long} tariff id
+     * @param tariffStatus {@link LocationStatus} tariff activation status
+     *
+     * @author Julia Seti
      */
-    @ApiOperation(value = "Deactivate tariff")
+    @ApiOperation(value = "Switch tariff activation status by tariff id")
+    @PreAuthorize("@preAuthorizer.hasAuthority('EDIT_PRICING_CARD', authentication)")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK),
         @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
         @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN)
+        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
-    @PreAuthorize("@preAuthorizer.hasAuthority('EDIT_PRICING_CARD', authentication)")
-    @PutMapping("/deactivateTariff/{tariffId}")
-    public ResponseEntity<HttpStatus> deactivateTariff(@PathVariable Long tariffId) {
-        superAdminService.deactivateTariffCard(tariffId);
+    @PatchMapping("/switchTariffStatus/{tariffId}")
+    public ResponseEntity<HttpStatus> switchTariffStatus(
+        @PathVariable Long tariffId,
+        @Valid @RequestBody LocationStatus tariffStatus) {
+        superAdminService.switchTariffStatus(tariffId, tariffStatus);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 

--- a/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
+++ b/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
@@ -20,6 +20,7 @@ import greencity.dto.service.GetTariffServiceDto;
 import greencity.dto.service.TariffServiceDto;
 import greencity.dto.tariff.GetTariffsInfoDto;
 import greencity.dto.tariff.SetTariffLimitsDto;
+import greencity.enums.LocationStatus;
 import greencity.exception.handler.CustomExceptionHandler;
 import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
@@ -785,11 +786,58 @@ class SuperAdminControllerTest {
 
     @Test
     @SneakyThrows
-    void deactivateTariffTest() {
-        mockMvc.perform(put(ubsLink + "/deactivateTariff/{tariffId}", 1L)
+    void switchTariffStatus() {
+        String requestJSON = new ObjectMapper().writeValueAsString(LocationStatus.ACTIVE);
+        mockMvc.perform(patch(ubsLink + "/switchTariffStatus/{tariffId}", 1L)
             .principal(principal)
+            .content(requestJSON)
+            .param("tariffId", "1L")
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
+
+        verify(superAdminService).switchTariffStatus(1L, LocationStatus.ACTIVE);
+    }
+
+    @Test
+    @SneakyThrows
+    void switchTariffStatusThrowNotFoundException() {
+        String requestJSON = new ObjectMapper().writeValueAsString(LocationStatus.ACTIVE);
+
+        doThrow(new NotFoundException(ErrorMessage.TARIFF_NOT_FOUND + 1L))
+            .when(superAdminService).switchTariffStatus(1L, LocationStatus.ACTIVE);
+
+        mockMvc.perform(patch(ubsLink + "/switchTariffStatus/{tariffId}", 1L)
+            .principal(principal)
+            .content(requestJSON)
+            .param("tariffId", "1L")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(result -> assertTrue(result.getResolvedException() instanceof NotFoundException))
+            .andExpect(result -> assertEquals(ErrorMessage.TARIFF_NOT_FOUND + 1L,
+                Objects.requireNonNull(result.getResolvedException()).getMessage()));
+
+        verify(superAdminService).switchTariffStatus(1L, LocationStatus.ACTIVE);
+    }
+
+    @Test
+    @SneakyThrows
+    void switchTariffStatusThrowBadRequestException() {
+        String requestJSON = new ObjectMapper().writeValueAsString(LocationStatus.ACTIVE);
+
+        doThrow(new BadRequestException(ErrorMessage.TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_BAGS))
+            .when(superAdminService).switchTariffStatus(1L, LocationStatus.ACTIVE);
+
+        mockMvc.perform(patch(ubsLink + "/switchTariffStatus/{tariffId}", 1L)
+            .principal(principal)
+            .content(requestJSON)
+            .param("tariffId", "1L")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(result -> assertTrue(result.getResolvedException() instanceof BadRequestException))
+            .andExpect(result -> assertEquals(ErrorMessage.TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_BAGS,
+                Objects.requireNonNull(result.getResolvedException()).getMessage()));
+
+        verify(superAdminService).switchTariffStatus(1L, LocationStatus.ACTIVE);
     }
 
     @Test

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -74,7 +74,6 @@ public final class ErrorMessage {
         "Current location already has status that's you wanna chose";
     public static final String COURIER_IS_NOT_FOUND_BY_ID = "Couldn't found courier by id: ";
     public static final String CANNOT_DEACTIVATE_COURIER = "Courier is already deactivated with id: ";
-    public static final String BAG_WITH_THIS_STATUS_ALREADY_SET = "Bag with this status already set.";
     public static final String LIQPAY_PAYMENT_WITH_SELECTED_ID_NOT_FOUND =
         "Payment with selected id does not belong LiqPay.";
     public static final String ORDER_WITH_CURRENT_ID_NOT_FOUND = "Couldn't find order with id that you chose";
@@ -124,6 +123,13 @@ public final class ErrorMessage {
     public static final String EMPLOYEE_WITH_CURRENT_UUID_WAS_NOT_DEACTIVATED = "Employee with current uuid was not "
         + "deactivated.";
     public static final String BAG_FOR_TARIFF_NOT_EXIST = "Could not find bag with id %d for tariff with id %d";
+    public static final String TARIFF_ALREADY_HAS_THIS_STATUS = "Tariff with id %d already has status: %s";
+    public static final String TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_SERVICE =
+        "Tariff has not been activated. Please add service for tariff.";
+    public static final String TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_LIMITS =
+        "Tariff has not been activated. Please set limits for tariff.";
+    public static final String TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_BAGS =
+        "Tariff has not been activated. Please add package for tariff.";
 
     /**
      * Constructor.

--- a/service-api/src/main/java/greencity/service/SuperAdminService.java
+++ b/service-api/src/main/java/greencity/service/SuperAdminService.java
@@ -19,6 +19,7 @@ import greencity.dto.service.GetTariffServiceDto;
 import greencity.dto.tariff.GetTariffsInfoDto;
 import greencity.dto.tariff.SetTariffLimitsDto;
 import greencity.entity.order.Courier;
+import greencity.enums.LocationStatus;
 import greencity.filters.TariffsInfoFilterCriteria;
 
 import java.util.List;
@@ -241,13 +242,14 @@ public interface SuperAdminService {
     void setTariffLimits(Long tariffId, SetTariffLimitsDto setTariffLimits);
 
     /**
-     * Method for deactivation or deleting Tariff depends on orders were made by
-     * this tariff.
+     * Method to switch the tariff status to active or deactivated.
      *
-     * @param tariffId - id of tariff
+     * @param tariffId     {@link Long} tariff id
+     * @param tariffStatus {@link LocationStatus} tariff status
      *
+     * @author Julia Seti
      */
-    void deactivateTariffCard(Long tariffId);
+    void switchTariffStatus(Long tariffId, LocationStatus tariffStatus);
 
     /**
      * Method for editing Locations.

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -992,20 +992,6 @@ public class ModelUtils {
             .build();
     }
 
-    public static TariffsInfoDto getTariffsInfoDto() {
-        return TariffsInfoDto.builder()
-            .id(1L)
-            .max(20L)
-            .min(2L)
-            .courierLimit(CourierLimit.LIMIT_BY_SUM_OF_ORDER)
-            .tariffLocations(Set.of(TariffLocation.builder()
-                .location(getLocation())
-                .build()))
-            .receivingStations(List.of(getReceivingStationDto()))
-            .courier(getCourierDto())
-            .build();
-    }
-
     public static GetTariffInfoForEmployeeDto getTariffInfoForEmployeeDto() {
         return GetTariffInfoForEmployeeDto
             .builder()
@@ -3559,6 +3545,40 @@ public class ModelUtils {
             .receivingStationList(Set.of(getReceivingStation()))
             .courier(getCourier())
             .service(getService())
+            .build();
+    }
+
+    public static TariffsInfo getTariffsInfoActive() {
+        return TariffsInfo.builder()
+            .id(1L)
+            .locationStatus(LocationStatus.ACTIVE)
+            .courierLimit(CourierLimit.LIMIT_BY_AMOUNT_OF_BAG)
+            .max(20L)
+            .min(2L)
+            .tariffLocations(Set.of(TariffLocation.builder()
+                .location(getLocation())
+                .build()))
+            .receivingStationList(Set.of(getReceivingStation()))
+            .courier(getCourier())
+            .service(getService())
+            .bags(getBag4list())
+            .build();
+    }
+
+    public static TariffsInfo getTariffsInfoDeactivated() {
+        return TariffsInfo.builder()
+            .id(1L)
+            .locationStatus(LocationStatus.DEACTIVATED)
+            .courierLimit(CourierLimit.LIMIT_BY_AMOUNT_OF_BAG)
+            .max(20L)
+            .min(2L)
+            .tariffLocations(Set.of(TariffLocation.builder()
+                .location(getLocation())
+                .build()))
+            .receivingStationList(Set.of(getReceivingStation()))
+            .courier(getCourier())
+            .service(getService())
+            .bags(getBag4list())
             .build();
     }
 

--- a/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
@@ -1225,6 +1225,34 @@ class SuperAdminServiceImplTest {
     }
 
     @Test
+    void switchTariffStatusToActiveWithMaxIsNull() {
+        TariffsInfo tariffInfo = ModelUtils.getTariffsInfoDeactivated();
+        tariffInfo.setMax(null);
+
+        when(tariffsInfoRepository.findById(1L)).thenReturn(Optional.of(tariffInfo));
+        when(tariffsInfoRepository.save(tariffInfo)).thenReturn(tariffInfo);
+
+        superAdminService.switchTariffStatus(1L, LocationStatus.ACTIVE);
+
+        verify(tariffsInfoRepository).findById(1L);
+        verify(tariffsInfoRepository).save(tariffInfo);
+    }
+
+    @Test
+    void switchTariffStatusToActiveWithMinIsNull() {
+        TariffsInfo tariffInfo = ModelUtils.getTariffsInfoDeactivated();
+        tariffInfo.setMin(null);
+
+        when(tariffsInfoRepository.findById(1L)).thenReturn(Optional.of(tariffInfo));
+        when(tariffsInfoRepository.save(tariffInfo)).thenReturn(tariffInfo);
+
+        superAdminService.switchTariffStatus(1L, LocationStatus.ACTIVE);
+
+        verify(tariffsInfoRepository).findById(1L);
+        verify(tariffsInfoRepository).save(tariffInfo);
+    }
+
+    @Test
     void switchTariffStatusThrowNotFoundException() {
         when(tariffsInfoRepository.findById(1L)).thenReturn(Optional.empty());
 
@@ -1243,8 +1271,8 @@ class SuperAdminServiceImplTest {
 
         Throwable t = assertThrows(BadRequestException.class,
             () -> superAdminService.switchTariffStatus(1L, LocationStatus.ACTIVE));
-        assertEquals(t.getMessage(),
-            String.format(ErrorMessage.TARIFF_ALREADY_HAS_THIS_STATUS, 1L, LocationStatus.ACTIVE));
+        assertEquals(String.format(ErrorMessage.TARIFF_ALREADY_HAS_THIS_STATUS, 1L, LocationStatus.ACTIVE),
+            t.getMessage());
 
         verify(tariffsInfoRepository).findById(1L);
         verify(tariffsInfoRepository, never()).save(tariffInfo);
@@ -1259,14 +1287,15 @@ class SuperAdminServiceImplTest {
 
         Throwable t = assertThrows(BadRequestException.class,
             () -> superAdminService.switchTariffStatus(1L, LocationStatus.ACTIVE));
-        assertEquals(t.getMessage(), ErrorMessage.TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_BAGS);
+        assertEquals(ErrorMessage.TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_BAGS,
+            t.getMessage());
 
         verify(tariffsInfoRepository).findById(1L);
         verify(tariffsInfoRepository, never()).save(tariffInfo);
     }
 
     @Test
-    void switchTariffStatusToActiveWithoutLimitsThrowBadRequestException() {
+    void switchTariffStatusToActiveWithMinAndMaxNullThrowBadRequestException() {
         TariffsInfo tariffInfo = ModelUtils.getTariffsInfoDeactivated();
         tariffInfo.setMax(null);
         tariffInfo.setMin(null);
@@ -1275,7 +1304,8 @@ class SuperAdminServiceImplTest {
 
         Throwable t = assertThrows(BadRequestException.class,
             () -> superAdminService.switchTariffStatus(1L, LocationStatus.ACTIVE));
-        assertEquals(t.getMessage(), ErrorMessage.TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_LIMITS);
+        assertEquals(ErrorMessage.TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_LIMITS,
+            t.getMessage());
 
         verify(tariffsInfoRepository).findById(1L);
         verify(tariffsInfoRepository, never()).save(tariffInfo);
@@ -1290,7 +1320,8 @@ class SuperAdminServiceImplTest {
 
         Throwable t = assertThrows(BadRequestException.class,
             () -> superAdminService.switchTariffStatus(1L, LocationStatus.ACTIVE));
-        assertEquals(t.getMessage(), ErrorMessage.TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_SERVICE);
+        assertEquals(ErrorMessage.TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_SERVICE,
+            t.getMessage());
 
         verify(tariffsInfoRepository).findById(1L);
         verify(tariffsInfoRepository, never()).save(tariffInfo);


### PR DESCRIPTION
## Link to issue

https://github.com/ita-social-projects/GreenCity/issues/5291

## Summary of change

**Created/Added:**

- endpoint /ubs/superAdmin/switchTariffStatus/{tariffId} to SuperAdminController.class.
- method switchTariffStatus() and its implementation in SuperAdminService.class and SuperAdminServiceImpl.class respectively.
- messages to ErrorMessage.class.
- test methods in SuperAdminControllerTest.class and SuperAdminServiceImplTest.class.
- methods in ModelUtils.class

**Changed:**

- added endpoint /ubs/superAdmin/switchTariffStatus/{tariffId} to antMatchers in SecurityConfig.class.

**Deleted:**

- endpoint /ubs/superAdmin/deactivateTariff/{tariffId} from SuperAdminController.class.
- method deactivateTariffCard from SuperAdminService.class and SuperAdminServiceImpl.class.
- test method deactivateTariffTest() from SuperAdminControllerTest.class.
- test methods deactivateTariff() and deactivateTariffTestThrows() from SuperAdminServiceImplTest.class.

## Testing approach

Runing tests with different params by endpoint /ubs/superAdmin/switchTariffStatus/{tariffId} in swagger.