### PR TITLE
[UBS] Fix bug with bag and tariff ids initial values

### DIFF
--- a/dao/src/main/resources/db/changelog/logs/ch-insert-into-bags-and-bags-translations-Makitra.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-insert-into-bags-and-bags-translations-Makitra.xml
@@ -5,7 +5,6 @@
 
     <changeSet id="Makitra-15" author="Makitra Vadym">
         <insert tableName="bag">
-            <column name="id">1</column>
             <column name="capacity">120</column>
             <column name="price">230</column>
             <column name="commission">50</column>
@@ -14,7 +13,6 @@
             <column name="min_amount_of_bags">INCLUDE</column>
         </insert>
         <insert tableName="bag">
-            <column name="id">2</column>
             <column name="capacity">20</column>
             <column name="price">110</column>
             <column name="commission">0</column>
@@ -23,7 +21,6 @@
             <column name="min_amount_of_bags">EXCLUDE</column>
         </insert>
         <insert tableName="bag">
-            <column name="id">3</column>
             <column name="capacity">60</column>
             <column name="price">220</column>
             <column name="commission">0</column>
@@ -32,7 +29,6 @@
             <column name="min_amount_of_bags">EXCLUDE</column>
         </insert>
         <insert tableName="bag">
-            <column name="id">4</column>
             <column name="capacity">120</column>
             <column name="price">230</column>
             <column name="commission">50</column>
@@ -41,7 +37,6 @@
             <column name="min_amount_of_bags">INCLUDE</column>
         </insert>
         <insert tableName="bag">
-            <column name="id">5</column>
             <column name="capacity">20</column>
             <column name="price">110</column>
             <column name="commission">0</column>
@@ -50,7 +45,6 @@
             <column name="min_amount_of_bags">EXCLUDE</column>
         </insert>
         <insert tableName="bag">
-            <column name="id">6</column>
             <column name="capacity">60</column>
             <column name="price">220</column>
             <column name="commission">0</column>

--- a/dao/src/main/resources/db/changelog/logs/ch-insert-into-employee-Korzh.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-insert-into-employee-Korzh.xml
@@ -7,7 +7,7 @@
             <column name="first_name">UBS</column>
             <column name="last_name">ADMIN</column>
             <column name="phone_number">+380675554433</column>
-            <column name="email">green.city.ubs@gmail.coml</column>
+            <column name="email">green.city.ubs@gmail.com</column>
             <column name="status">ACTIVE</column>
             <column name="uuid">d0840b34-3f17-4820-a375-305b855dff8b</column>
         </insert>

--- a/dao/src/main/resources/db/changelog/logs/ch-insert-into-receiving-stations-Makitra.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-insert-into-receiving-stations-Makitra.xml
@@ -9,6 +9,7 @@
             <column name="id">1</column>
             <column name="name">Саперно-Слобідська</column>
             <column name ="created_by_id">1</column>
+            <column name="create_date">2023-02-26</column>
             <column name ="station_status">ACTIVE</column>
         </insert>
     </changeSet>

--- a/dao/src/main/resources/db/changelog/logs/ch-insert-into-regions-Fedorko.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-insert-into-regions-Fedorko.xml
@@ -25,9 +25,9 @@
         </update>
 
         <insert tableName="tariffs_info">
-            <column name="id">1</column>
             <column name="courier_id">1</column>
             <column name="creator_id">1</column>
+            <column name="created_at">2023-02-26</column>
             <column name="courier_limits">LIMIT_BY_AMOUNT_OF_BAG</column>
             <column name="location_status">ACTIVE</column>
             <column name="min_amount_of_big_bags">2</column>
@@ -35,9 +35,9 @@
         </insert>
 
         <insert tableName="tariffs_info">
-            <column name="id">2</column>
             <column name="courier_id">1</column>
             <column name="creator_id">1</column>
+            <column name="created_at">2023-02-26</column>
             <column name="courier_limits">LIMIT_BY_AMOUNT_OF_BAG</column>
             <column name="location_status">ACTIVE</column>
             <column name="min_amount_of_big_bags">20</column>

--- a/dao/src/main/resources/db/changelog/logs/liquibase-outputChangeLog.xml
+++ b/dao/src/main/resources/db/changelog/logs/liquibase-outputChangeLog.xml
@@ -51,7 +51,7 @@
     </changeSet>
     <changeSet author="User (generated)" id="1614595847330-9">
         <createTable tableName="bag">
-            <column autoIncrement="true" name="id" type="SERIAL">
+            <column autoIncrement="true" name="id" type="SERIAL" startWith="7">
                 <constraints primaryKey="true" primaryKeyName="bag_pkey"/>
             </column>
             <column name="capacity" type="INT">

--- a/dao/src/main/resources/db/changelog/logs/liquibase-outputChangeLog.xml
+++ b/dao/src/main/resources/db/changelog/logs/liquibase-outputChangeLog.xml
@@ -51,7 +51,7 @@
     </changeSet>
     <changeSet author="User (generated)" id="1614595847330-9">
         <createTable tableName="bag">
-            <column autoIncrement="true" name="id" type="SERIAL" startWith="7">
+            <column autoIncrement="true" name="id" type="SERIAL">
                 <constraints primaryKey="true" primaryKeyName="bag_pkey"/>
             </column>
             <column name="capacity" type="INT">


### PR DESCRIPTION
## Link to issue

https://github.com/ita-social-projects/GreenCity/issues/5336

## Summary of change

Bags and tariffs ids values removed ​​from changelogs with inserted bags and tariffs data to bag and tariff_infos tables.
The admin's email corrected to green.city.ubs@gmail.com.

## Testing approach

Checked data in the respective tables.