### PR TITLE
deleted receiving_station colomn in order table and order_employee table

### DIFF
--- a/dao/src/main/java/greencity/entity/order/Order.java
+++ b/dao/src/main/java/greencity/entity/order/Order.java
@@ -121,9 +121,6 @@ public class Order {
     @Column(name = "date_of_export")
     private LocalDate dateOfExport;
 
-    @ManyToMany(mappedBy = "attachedOrders")
-    private Set<Employee> attachedEmployees;
-
     @ElementCollection
     @CollectionTable(name = "order_additional",
         joinColumns = @JoinColumn(name = "orders_id", referencedColumnName = "id"))

--- a/dao/src/main/java/greencity/entity/user/employee/Employee.java
+++ b/dao/src/main/java/greencity/entity/user/employee/Employee.java
@@ -56,13 +56,6 @@ public class Employee {
 
     @ManyToMany
     @JoinTable(
-        name = "order_employee",
-        joinColumns = {@JoinColumn(name = "employee_id")},
-        inverseJoinColumns = {@JoinColumn(name = "order_id")})
-    private Set<Order> attachedOrders;
-
-    @ManyToMany
-    @JoinTable(
         name = "tariff_infos_receiving_employee_mapping",
         joinColumns = {@JoinColumn(name = "employee_id")},
         inverseJoinColumns = {@JoinColumn(name = "tariffs_info_id")})

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -178,4 +178,6 @@
     <include file="db/changelog/logs/ch-update-bag-table-limit_included-value-Bondar.xml"/>
     <include file="db/changelog/logs/ch-drop-column-min-amount-of-bags-in-table-bag-Seti.xml"/>
     <include file="db/changelog/logs/ch-insert-info-into-table-service-Seti.xml"/>
+    <include file="db/changelog/logs/ch-drop-column-receiving-station-Kharchenko.xml"/>
+    <include file="db/changelog/logs/ch-drop-table-order-employee-Kharchenko.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-drop-column-receiving-station-Kharchenko.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-drop-column-receiving-station-Kharchenko.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="Kharchenko-1" author="Volodymyr Kharchenko">
+        <dropColumn tableName="orders" columnName="receiving_station"/>
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-drop-table-order-employee-Kharchenko.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-drop-table-order-employee-Kharchenko.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="Kharchenko-2" author="Volodymyr Kharchenko">
+        <dropTable tableName="order_employee"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
dev

https://github.com/ita-social-projects/GreenCity/issues/5351

## Summary of issue

receiving_station column in order table, delete order_employee table is not used

## Summary of change

Changed
- Employee
- Order
- db.changelog-master

Added
- ch-drop-column-receiving-station-Kharchenko
- ch-drop-table-order-employee-Kharchenko.xml

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions