### PR TITLE
[UBS] - create endpoint to edit tariff info #5357

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -131,6 +131,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 SUPER_ADMIN_LINK + "/editTariffService/{id}",
                 SUPER_ADMIN_LINK + "/editService/{id}",
                 SUPER_ADMIN_LINK + "/setTariffLimits/{tariffId}",
+                SUPER_ADMIN_LINK + "/editTariffInfo/{id}",
                 SUPER_ADMIN_LINK + "/**")
             .hasAnyRole(ADMIN, UBS_EMPLOYEE)
             .antMatchers(HttpMethod.DELETE,
@@ -146,8 +147,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .hasAnyRole(ADMIN, UBS_EMPLOYEE)
             .antMatchers(HttpMethod.PATCH,
                 UBS_MANAG_LINK + "/update-order-page-admin-info/{id}",
-                SUPER_ADMIN_LINK + "/activeLocations/{id}",
-                SUPER_ADMIN_LINK + "/editInfoAboutTariff")
+                SUPER_ADMIN_LINK + "/activeLocations/{id}")
             .hasAnyRole(UBS_EMPLOYEE)
             .antMatchers(HttpMethod.POST,
                 UBS_MANAG_LINK + "/**",

--- a/core/src/main/java/greencity/controller/SuperAdminController.java
+++ b/core/src/main/java/greencity/controller/SuperAdminController.java
@@ -10,6 +10,7 @@ import greencity.dto.service.GetServiceDto;
 import greencity.dto.service.GetTariffServiceDto;
 import greencity.dto.tariff.AddNewTariffResponseDto;
 import greencity.dto.tariff.ChangeTariffLocationStatusDto;
+import greencity.dto.tariff.EditTariffDto;
 import greencity.dto.tariff.GetTariffLimitsDto;
 import greencity.dto.tariff.GetTariffsInfoDto;
 import greencity.dto.tariff.SetTariffLimitsDto;
@@ -574,6 +575,31 @@ class SuperAdminController {
     public ResponseEntity<Boolean> checkIfTariffExists(
         @RequestBody @Valid AddNewTariffDto addNewTariffDto) {
         return ResponseEntity.status(HttpStatus.OK).body(superAdminService.checkIfTariffExists(addNewTariffDto));
+    }
+
+    /**
+     * Controller for editing tariff info.
+     *
+     * @param id  {@link Long} tariff id.
+     * @param dto {@link EditTariffDto} edited tariff dto.
+     *
+     * @author Julia Seti
+     */
+    @ApiOperation(value = "Edit tariff info")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = HttpStatuses.OK),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND),
+        @ApiResponse(code = 409, message = HttpStatuses.CONFLICT)
+    })
+    @PreAuthorize("@preAuthorizer.hasAuthority('EDIT_PRICING_CARD', authentication)")
+    @PutMapping("/editTariffInfo/{id}")
+    public ResponseEntity<HttpStatus> editTariff(
+        @Valid @PathVariable Long id, @Valid @RequestBody EditTariffDto dto) {
+        superAdminService.editTariff(id, dto);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     /**

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -40,6 +40,7 @@ import greencity.dto.service.ServiceDto;
 import greencity.dto.service.GetServiceDto;
 import greencity.dto.service.GetTariffServiceDto;
 import greencity.dto.service.TariffServiceDto;
+import greencity.dto.tariff.EditTariffDto;
 import greencity.dto.tariff.GetTariffsInfoDto;
 import greencity.dto.tariff.SetTariffLimitsDto;
 import greencity.dto.user.AddBonusesToUserDto;
@@ -490,6 +491,13 @@ public class ModelUtils {
             .courierId(1L)
             .locationIdList(List.of(1L))
             .receivingStationsIdList(List.of(1L))
+            .build();
+    }
+
+    public static EditTariffDto getEditTariffDto() {
+        return EditTariffDto.builder()
+            .locationIds(List.of(1L))
+            .receivingStationIds(List.of(1L))
             .build();
     }
 

--- a/dao/src/main/java/greencity/repository/TariffLocationRepository.java
+++ b/dao/src/main/java/greencity/repository/TariffLocationRepository.java
@@ -51,4 +51,13 @@ public interface TariffLocationRepository extends JpaRepository<TariffLocation, 
      * @author - Safarov Renat
      */
     Optional<TariffLocation> findTariffLocationByTariffsInfoAndLocation(TariffsInfo tariffsInfo, Location location);
+
+    /**
+     * Method for finding TariffLocations by tariffsInfo.
+     *
+     * @param tariffsInfo {@link Long} - tariffsInfo
+     * @return {@link List} of {@link TariffLocation}
+     * @author - Julia Seti
+     */
+    List<TariffLocation> findAllByTariffsInfo(TariffsInfo tariffsInfo);
 }

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -54,6 +54,8 @@ public final class ErrorMessage {
     public static final String ADDRESS_NOT_FOUND = "Address not found";
     public static final String LOCATION_DOESNT_FOUND = "Location does not found";
     public static final String LOCATION_DOESNT_FOUND_BY_ID = "Location does not exist by id: ";
+    public static final String LOCATIONS_BELONG_TO_DIFFERENT_REGIONS =
+        "The locations belong to different regions. Please choose locations from the same region";
     public static final String INTERRUPTED_EXCEPTION = "Interrupted exception thrown ";
     public static final String ORDER_ALREADY_HAS_VIOLATION = "Current order already has violation";
     public static final String ORDER_ALREADY_PAID = "Current order is already paid";

--- a/service-api/src/main/java/greencity/dto/tariff/EditTariffDto.java
+++ b/service-api/src/main/java/greencity/dto/tariff/EditTariffDto.java
@@ -1,0 +1,25 @@
+package greencity.dto.tariff;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor
+public class EditTariffDto {
+    @NotEmpty
+    private List<@Min(1) Long> locationIds;
+    @NotEmpty
+    private List<@Min(1) Long> receivingStationIds;
+}

--- a/service-api/src/main/java/greencity/service/SuperAdminService.java
+++ b/service-api/src/main/java/greencity/service/SuperAdminService.java
@@ -220,6 +220,14 @@ public interface SuperAdminService {
     AddNewTariffResponseDto addNewTariff(AddNewTariffDto addNewTariffDto, String userUUID);
 
     /**
+     * Method for editing TariffsInfo.
+     *
+     * @param id  {@link Long} tariff id.
+     * @param dto {@link EditTariffDto} edited tariff dto.
+     */
+    void editTariff(Long id, EditTariffDto dto);
+
+    /**
      * Method checks if passed TariffsInfo exists in database.
      *
      * @param addNewTariffDto {@link AddNewTariffDto}

--- a/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
@@ -19,6 +19,7 @@ import greencity.dto.service.GetServiceDto;
 import greencity.dto.service.GetTariffServiceDto;
 import greencity.dto.tariff.AddNewTariffResponseDto;
 import greencity.dto.tariff.ChangeTariffLocationStatusDto;
+import greencity.dto.tariff.EditTariffDto;
 import greencity.dto.tariff.GetTariffLimitsDto;
 import greencity.dto.tariff.GetTariffsInfoDto;
 import greencity.dto.tariff.SetTariffLimitsDto;
@@ -425,7 +426,7 @@ public class SuperAdminServiceImpl implements SuperAdminService {
 
     private Location tryToFindLocationById(Long id) {
         return locationRepository.findById(id).orElseThrow(
-            () -> new NotFoundException(ErrorMessage.LOCATION_DOESNT_FOUND));
+            () -> new NotFoundException(ErrorMessage.LOCATION_DOESNT_FOUND_BY_ID + id));
     }
 
     @Override
@@ -563,6 +564,82 @@ public class SuperAdminServiceImpl implements SuperAdminService {
     private Courier tryToFindCourier(Long courierId) {
         return courierRepository.findById(courierId)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.COURIER_IS_NOT_FOUND_BY_ID + courierId));
+    }
+
+    private ReceivingStation tryToFindReceivingStationById(Long id) {
+        return receivingStationRepository.findById(id)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.RECEIVING_STATION_NOT_FOUND_BY_ID + id));
+    }
+
+    private List<Location> tryToFindLocationsInSameRegion(List<Long> locationIds) {
+        List<Location> locations = locationIds.stream()
+            .map(this::tryToFindLocationById)
+            .collect(Collectors.toList());
+        long regionsCount = locations.stream()
+            .map(Location::getRegion)
+            .distinct()
+            .count();
+        if (regionsCount != 1) {
+            throw new BadRequestException(ErrorMessage.LOCATIONS_BELONG_TO_DIFFERENT_REGIONS);
+        }
+        return locations;
+    }
+
+    private void checkIfLocationBelongsToAnotherTariff(List<Long> locationIds, TariffsInfo tariffsInfo) {
+        long locationsInAnotherTariffsCount = tariffsLocationRepository
+            .findAllByCourierIdAndLocationIds(tariffsInfo.getCourier().getId(), locationIds)
+            .stream()
+            .filter(it -> !tariffsInfo.equals(it.getTariffsInfo()))
+            .count();
+        if (locationsInAnotherTariffsCount != 0) {
+            throw new TariffAlreadyExistsException(ErrorMessage.TARIFF_IS_ALREADY_EXISTS);
+        }
+    }
+
+    private Set<ReceivingStation> tryToFindReceivingStations(List<Long> receivingStationIds) {
+        return receivingStationIds.stream()
+            .map(this::tryToFindReceivingStationById)
+            .collect(Collectors.toSet());
+    }
+
+    private Set<TariffLocation> getUpdatedTariffLocations(List<Location> locations, TariffsInfo tariffsInfo) {
+        return locations.stream()
+            .map(location -> updateTariffLocation(location, tariffsInfo))
+            .collect(Collectors.toSet());
+    }
+
+    private TariffLocation updateTariffLocation(Location location, TariffsInfo tariffsInfo) {
+        return tariffsLocationRepository.findTariffLocationByTariffsInfoAndLocation(tariffsInfo, location)
+            .orElseGet(() -> TariffLocation.builder()
+                .tariffsInfo(tariffsInfo)
+                .location(location)
+                .locationStatus(LocationStatus.ACTIVE)
+                .build());
+    }
+
+    private void deleteUnusedTariffLocations(Set<TariffLocation> tariffLocations, TariffsInfo tariffsInfo) {
+        tariffsLocationRepository.findAllByTariffsInfo(tariffsInfo)
+            .forEach(it -> {
+                if (!tariffLocations.contains(it)) {
+                    tariffsLocationRepository.delete(it);
+                }
+            });
+    }
+
+    @Override
+    @Transactional
+    public void editTariff(Long id, EditTariffDto dto) {
+        TariffsInfo tariffsInfo = tryToFindTariffById(id);
+        List<Location> locations = tryToFindLocationsInSameRegion(dto.getLocationIds());
+        checkIfLocationBelongsToAnotherTariff(dto.getLocationIds(), tariffsInfo);
+        Set<ReceivingStation> receivingStations = tryToFindReceivingStations(dto.getReceivingStationIds());
+        Set<TariffLocation> tariffLocations = getUpdatedTariffLocations(locations, tariffsInfo);
+        deleteUnusedTariffLocations(tariffLocations, tariffsInfo);
+
+        tariffsInfo.setReceivingStationList(receivingStations);
+        tariffsInfo.setTariffLocations(tariffLocations);
+
+        tariffsInfoRepository.save(tariffsInfo);
     }
 
     @Override

--- a/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
@@ -586,12 +586,12 @@ public class SuperAdminServiceImpl implements SuperAdminService {
     }
 
     private void checkIfLocationBelongsToAnotherTariff(List<Long> locationIds, TariffsInfo tariffsInfo) {
-        long locationsInAnotherTariffsCount = tariffsLocationRepository
+        long tariffsWithLocationsCount = tariffsLocationRepository
             .findAllByCourierIdAndLocationIds(tariffsInfo.getCourier().getId(), locationIds)
             .stream()
             .filter(it -> !tariffsInfo.equals(it.getTariffsInfo()))
             .count();
-        if (locationsInAnotherTariffsCount != 0) {
+        if (tariffsWithLocationsCount != 0) {
             throw new TariffAlreadyExistsException(ErrorMessage.TARIFF_IS_ALREADY_EXISTS);
         }
     }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -102,10 +102,7 @@ import greencity.dto.service.ServiceDto;
 import greencity.dto.service.GetServiceDto;
 import greencity.dto.service.TariffServiceDto;
 import greencity.dto.service.GetTariffServiceDto;
-import greencity.dto.tariff.GetTariffInfoForEmployeeDto;
-import greencity.dto.tariff.GetTariffLimitsDto;
-import greencity.dto.tariff.GetTariffsInfoDto;
-import greencity.dto.tariff.SetTariffLimitsDto;
+import greencity.dto.tariff.*;
 import greencity.dto.user.AddBonusesToUserDto;
 import greencity.dto.user.PersonalDataDto;
 import greencity.dto.user.UserInfoDto;
@@ -1206,6 +1203,28 @@ public class ModelUtils {
             .build();
     }
 
+    public static TariffLocation getTariffLocation2() {
+        return TariffLocation
+            .builder()
+            .id(1L)
+            .tariffsInfo(
+                TariffsInfo.builder()
+                    .id(2L)
+                    .build())
+            .location(getLocation())
+            .locationStatus(LocationStatus.ACTIVE)
+            .build();
+    }
+
+    public static List<TariffLocation> getTariffLocationList() {
+        return List.of(getTariffLocation(),
+            TariffLocation
+                .builder()
+                .id(2L)
+                .locationStatus(LocationStatus.ACTIVE)
+                .build());
+    }
+
     public static EmployeeWithTariffsIdDto getEmployeeWithTariffsIdDto() {
         return EmployeeWithTariffsIdDto
             .builder()
@@ -2012,6 +2031,23 @@ public class ModelUtils {
             .region(getRegion())
             .coordinates(getCoordinates())
             .build());
+    }
+
+    public static List<Location> getLocationList2() {
+        return List.of(Location.builder()
+            .id(1L)
+            .region(
+                Region.builder()
+                    .id(1L)
+                    .build())
+            .build(),
+            Location.builder()
+                .id(2L)
+                .region(
+                    Region.builder()
+                        .id(2L)
+                        .build())
+                .build());
     }
 
     private static EmployeePositionDtoResponse createEmployeePositionDtoResponse() {
@@ -3797,6 +3833,20 @@ public class ModelUtils {
             .locationIdList(List.of(1L))
             .receivingStationsIdList(List.of(1L))
             .regionId(1L)
+            .build();
+    }
+
+    public static EditTariffDto getEditTariffDto() {
+        return EditTariffDto.builder()
+            .locationIds(List.of(1L))
+            .receivingStationIds(List.of(1L))
+            .build();
+    }
+
+    public static EditTariffDto getEditTariffDtoWith2Locations() {
+        return EditTariffDto.builder()
+            .locationIds(List.of(1L, 2L))
+            .receivingStationIds(List.of(1L))
             .build();
     }
 


### PR DESCRIPTION
# GreenCityUBS PR
[UBS] - create endpoint to edit tariff info #5357 #1040

## Summary Of Changes :fire:
Created endpoint to edit tariff by tariff id

## Issue Link :clipboard:
https://github.com/ita-social-projects/GreenCity/issues/5357

## Added
* new endpoint /editTariffInfo/{id} to SuperAdminController class.
* new EditTariffDto class.
* editTariff() method to SuperAdminService class and its imlementation to SuperAdminServiceImpl class.
* findAllByTariffsInfo() method to TariffLocationRepository class.
* static field to ErrorMessage  class.
* endpoint /editTariffInfo/{id} to antMatchers of SecurityConfig class.
* Test methods to SuperAdminControllerTest and  SuperAdminServiceImplTest classes.

## How to test :clipboard:
Sign-in with ubs-admin credentials to GreenCityUbs swagger by localhost 8050.
Test endpoint /ubs/superAdmin/editTariffInfo/{id}.