### PR TITLE
[UBS] - fix telegram bot notification functionality #5447 #5423

### DIFF
--- a/core/src/main/java/greencity/controller/UserProfileController.java
+++ b/core/src/main/java/greencity/controller/UserProfileController.java
@@ -39,6 +39,7 @@ public class UserProfileController {
         @ApiResponse(code = 200, message = HttpStatuses.OK, response = UserProfileDto.class),
         @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
         @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
     @PutMapping("/user/update")
     public ResponseEntity<UserProfileUpdateDto> updateUserData(@ApiIgnore @CurrentUserUuid String userUuid,

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -43,12 +43,7 @@ import greencity.dto.service.TariffServiceDto;
 import greencity.dto.tariff.EditTariffDto;
 import greencity.dto.tariff.GetTariffsInfoDto;
 import greencity.dto.tariff.SetTariffLimitsDto;
-import greencity.dto.user.AddBonusesToUserDto;
-import greencity.dto.user.AddingPointsToUserDto;
-import greencity.dto.user.PersonalDataDto;
-import greencity.dto.user.UserInfoDto;
-import greencity.dto.user.UserProfileDto;
-import greencity.dto.user.UserProfileCreateDto;
+import greencity.dto.user.*;
 import greencity.dto.violation.ViolationDetailInfoDto;
 import greencity.entity.coords.Coordinates;
 import greencity.entity.user.ubs.Address;
@@ -167,6 +162,8 @@ public class ModelUtils {
             .recipientSurname("Petrov")
             .recipientPhone("666051373")
             .recipientEmail("petrov@gmail.com")
+            .telegramIsNotify(true)
+            .viberIsNotify(false)
             .build();
     }
 

--- a/core/src/test/java/greencity/controller/UserProfileControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserProfileControllerTest.java
@@ -8,6 +8,7 @@ import greencity.constant.AppConstant;
 import greencity.converters.UserArgumentResolver;
 import greencity.dto.address.AddressDto;
 import greencity.dto.user.UserProfileDto;
+import greencity.exception.handler.CustomExceptionHandler;
 import greencity.service.ubs.UBSClientService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,10 +16,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.Validator;
 
 import java.security.Principal;
 import java.util.List;
@@ -47,12 +52,20 @@ class UserProfileControllerTest {
     @Mock
     UserRemoteClient userRemoteClient;
 
+    @Mock
+    private Validator mockValidator;
+
     private Principal principal = getPrincipal();
+    private ErrorAttributes errorAttributes = new DefaultErrorAttributes();
 
     @BeforeEach
     void setup() {
         this.mockMvc = MockMvcBuilders.standaloneSetup(userProfileController)
-            .setCustomArgumentResolvers(new UserArgumentResolver(userRemoteClient))
+            .setCustomArgumentResolvers(
+                new PageableHandlerMethodArgumentResolver(),
+                new UserArgumentResolver(userRemoteClient))
+            .setControllerAdvice(new CustomExceptionHandler(errorAttributes))
+            .setValidator(mockValidator)
             .build();
     }
 

--- a/dao/src/main/java/greencity/entity/telegram/TelegramBot.java
+++ b/dao/src/main/java/greencity/entity/telegram/TelegramBot.java
@@ -16,9 +16,11 @@ public class TelegramBot {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(name = "chat_id")
+    @Column(nullable = false, name = "chat_id")
     private Long chatId;
+    @Column(nullable = false, name = "notify")
+    private Boolean isNotify;
     @OneToOne()
-    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    @JoinColumn(nullable = false, name = "user_id", referencedColumnName = "id")
     private User user;
 }

--- a/dao/src/main/java/greencity/repository/TelegramBotRepository.java
+++ b/dao/src/main/java/greencity/repository/TelegramBotRepository.java
@@ -1,15 +1,41 @@
 package greencity.repository;
 
 import greencity.entity.telegram.TelegramBot;
+import greencity.entity.user.User;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface TelegramBotRepository extends CrudRepository<TelegramBot, Long> {
     /**
      * The method finds telegram bot by chatId.
      *
-     * @return list of {@link TelegramBot}.
+     * @param chatId {@link Long}.
+     * @return {@link TelegramBot}.
      */
     TelegramBot findByChatId(Long chatId);
+
+    /**
+     * The method finds telegram bot by user and chat id and isNotify.
+     *
+     * @param user     {@link User}.
+     * @param chatId   {@link Long}.
+     * @param isNotify {@link Boolean}
+     * @return {@link Optional} {@link TelegramBot}.
+     *
+     * @author Julia Seti
+     */
+    Optional<TelegramBot> findByUserAndChatIdAndIsNotify(User user, Long chatId, Boolean isNotify);
+
+    /**
+     * The method finds telegram bot by user.
+     *
+     * @param user {@link User}.
+     * @return {@link Optional} {@link TelegramBot}.
+     *
+     * @author Julia Seti
+     */
+    Optional<TelegramBot> findByUser(User user);
 }

--- a/dao/src/main/java/greencity/repository/ViberBotRepository.java
+++ b/dao/src/main/java/greencity/repository/ViberBotRepository.java
@@ -1,5 +1,6 @@
 package greencity.repository;
 
+import greencity.entity.user.User;
 import greencity.entity.viber.ViberBot;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -14,4 +15,14 @@ public interface ViberBotRepository extends JpaRepository<ViberBot, Long> {
      * @return list of {@link ViberBot}.
      */
     Optional<ViberBot> findViberBotByChatId(String chatId);
+
+    /**
+     * The method finds viber bot by user.
+     *
+     * @param user {@link User}.
+     * @return {@link Optional} {@link ViberBot}.
+     *
+     * @author Julia Seti
+     */
+    Optional<ViberBot> findByUser(User user);
 }

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -181,4 +181,5 @@
     <include file="db/changelog/logs/ch-add-foreign-key-column-locationId-to-OrderAddress-table-Safarov.xml"/>
     <include file="db/changelog/logs/ch-drop-column-receiving-station-Kharchenko.xml"/>
     <include file="db/changelog/logs/ch-drop-table-order-employee-Kharchenko.xml"/>
+    <include file="db/changelog/logs/ch-add-column-notify-to-telegram-bot-Seti.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-add-column-notify-to-telegram-bot-Seti.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-column-notify-to-telegram-bot-Seti.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet id="Seti-8" author="Julia Seti">
+        <addColumn tableName="telegram_bot">
+            <column name="notify" type="boolean">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/service-api/src/main/java/greencity/dto/user/UserProfileDto.java
+++ b/service-api/src/main/java/greencity/dto/user/UserProfileDto.java
@@ -3,7 +3,14 @@ package greencity.dto.user;
 import greencity.annotations.ValidPhoneNumber;
 import greencity.dto.address.AddressDto;
 import greencity.util.Bot;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.ToString;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -36,4 +43,8 @@ public class UserProfileDto {
     private List<AddressDto> addressDto;
     private List<Bot> botList;
     private Boolean hasPassword;
+    @NonNull
+    private Boolean telegramIsNotify;
+    @NonNull
+    private Boolean viberIsNotify;
 }

--- a/service-api/src/main/java/greencity/dto/user/UserProfileUpdateDto.java
+++ b/service-api/src/main/java/greencity/dto/user/UserProfileUpdateDto.java
@@ -2,21 +2,30 @@ package greencity.dto.user;
 
 import greencity.annotations.ValidPhoneNumber;
 import greencity.dto.address.AddressDto;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.ToString;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
+import java.io.Serializable;
 import java.util.List;
 
 @Getter
+@Setter
 @ToString
 @NoArgsConstructor
 @Builder
 @AllArgsConstructor
 @EqualsAndHashCode
-public class UserProfileUpdateDto {
+public class UserProfileUpdateDto implements Serializable {
     @NotBlank
     @Pattern(regexp = "[ЁёІіЇїҐґЄєА-Яа-яA-Za-z-ʼ'`ʹ\\s.]{1,30}")
     private String recipientName;
@@ -31,4 +40,8 @@ public class UserProfileUpdateDto {
     private String recipientPhone;
     @Valid
     private List<AddressDto> addressDto;
+    @NonNull
+    private Boolean telegramIsNotify;
+    @NonNull
+    private Boolean viberIsNotify;
 }

--- a/service/src/main/java/greencity/mapping/user/UserToUserProfileDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/user/UserToUserProfileDtoMapper.java
@@ -15,6 +15,8 @@ public class UserToUserProfileDtoMapper extends AbstractConverter<User, UserProf
             .recipientEmail(user.getRecipientEmail())
             .alternateEmail(user.getAlternateEmail())
             .recipientPhone(user.getRecipientPhone())
+            .telegramIsNotify(user.getTelegramBot() != null && user.getTelegramBot().getIsNotify())
+            .viberIsNotify(user.getViberBot() != null && user.getViberBot().getIsNotify())
             .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/user/UserToUserProfileUpdateDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/user/UserToUserProfileUpdateDtoMapper.java
@@ -25,6 +25,8 @@ public class UserToUserProfileUpdateDtoMapper extends AbstractConverter<User, Us
             .recipientPhone(user.getRecipientPhone())
             .alternateEmail(user.getAlternateEmail())
             .addressDto(addressDtoList)
+            .telegramIsNotify(user.getTelegramBot() != null && user.getTelegramBot().getIsNotify())
+            .viberIsNotify(user.getViberBot() != null && user.getViberBot().getIsNotify())
             .build();
     }
 

--- a/service/src/main/java/greencity/ubstelegrambot/TelegramService.java
+++ b/service/src/main/java/greencity/ubstelegrambot/TelegramService.java
@@ -39,7 +39,9 @@ public class TelegramService extends AbstractNotificationProvider {
         if (Objects.isNull(user)) {
             return false;
         }
-        return Objects.nonNull(user.getTelegramBot()) && Objects.nonNull(user.getTelegramBot().getChatId());
+        return Objects.nonNull(user.getTelegramBot())
+            && Objects.nonNull(user.getTelegramBot().getChatId())
+            && Objects.equals(user.getTelegramBot().getIsNotify(), true);
     }
 
     private void sendMessageToUser(SendMessage sendMessage) {

--- a/service/src/main/java/greencity/ubstelegrambot/UBSTelegramBot.java
+++ b/service/src/main/java/greencity/ubstelegrambot/UBSTelegramBot.java
@@ -47,8 +47,7 @@ public class UBSTelegramBot extends TelegramLongPollingBot {
         Optional<TelegramBot> telegramBotOptional =
             telegramBotRepository.findByUserAndChatIdAndIsNotify(user, message.getChatId(), true);
         if (telegramBotOptional.isEmpty() && message.getText().startsWith("/start")) {
-            TelegramBot telegramBot = getTelegramBot(user, message.getChatId());
-            user.setTelegramBot(telegramBot);
+            user.setTelegramBot(getTelegramBot(user, message.getChatId()));
             userRepository.save(user);
             SendMessage sendMessage =
                 new SendMessage(message.getChatId().toString(), "Вітаємо!\nВи підписались на UbsBot");
@@ -70,7 +69,7 @@ public class UBSTelegramBot extends TelegramLongPollingBot {
                 .user(user)
                 .isNotify(true)
                 .build();
-        } else if (!telegramBot.getIsNotify()) {
+        } else if (!telegramBot.getIsNotify().booleanValue()) {
             telegramBot.setIsNotify(true);
         }
         return telegramBotRepository.save(telegramBot);

--- a/service/src/main/java/greencity/ubstelegrambot/UBSTelegramBot.java
+++ b/service/src/main/java/greencity/ubstelegrambot/UBSTelegramBot.java
@@ -3,6 +3,7 @@ package greencity.ubstelegrambot;
 import greencity.constant.ErrorMessage;
 import greencity.entity.telegram.TelegramBot;
 import greencity.entity.user.User;
+import greencity.exceptions.NotFoundException;
 import greencity.exceptions.bots.MessageWasNotSent;
 import greencity.exceptions.bots.TelegramBotAlreadyConnected;
 import greencity.repository.TelegramBotRepository;
@@ -14,6 +15,8 @@ import org.telegram.telegrambots.bots.TelegramLongPollingBot;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -39,13 +42,12 @@ public class UBSTelegramBot extends TelegramLongPollingBot {
     public void onUpdateReceived(Update update) {
         Message message = update.getMessage();
         String uuId = message.getText().replace("/start", "").trim();
-        User user = userRepository.findByUuid(uuId);
-        if (user != null && user.getTelegramBot() == null && message.getText().startsWith("/start")) {
-            telegramBotRepository.save(TelegramBot.builder()
-                .chatId(message.getChatId())
-                .user(user)
-                .build());
-            TelegramBot telegramBot = telegramBotRepository.findByChatId(message.getChatId());
+        User user = userRepository.findUserByUuid(uuId)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_WITH_CURRENT_UUID_DOES_NOT_EXIST));
+        Optional<TelegramBot> telegramBotOptional =
+            telegramBotRepository.findByUserAndChatIdAndIsNotify(user, message.getChatId(), true);
+        if (telegramBotOptional.isEmpty() && message.getText().startsWith("/start")) {
+            TelegramBot telegramBot = getTelegramBot(user, message.getChatId());
             user.setTelegramBot(telegramBot);
             userRepository.save(user);
             SendMessage sendMessage =
@@ -58,5 +60,19 @@ public class UBSTelegramBot extends TelegramLongPollingBot {
         } else {
             throw new TelegramBotAlreadyConnected(ErrorMessage.THE_USER_ALREADY_HAS_CONNECTED_TO_TELEGRAM_BOT);
         }
+    }
+
+    private TelegramBot getTelegramBot(User user, Long chatId) {
+        TelegramBot telegramBot = user.getTelegramBot();
+        if (telegramBot == null) {
+            telegramBot = TelegramBot.builder()
+                .chatId(chatId)
+                .user(user)
+                .isNotify(true)
+                .build();
+        } else if (!telegramBot.getIsNotify()) {
+            telegramBot.setIsNotify(true);
+        }
+        return telegramBotRepository.save(telegramBot);
     }
 }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -102,7 +102,11 @@ import greencity.dto.service.ServiceDto;
 import greencity.dto.service.GetServiceDto;
 import greencity.dto.service.TariffServiceDto;
 import greencity.dto.service.GetTariffServiceDto;
-import greencity.dto.tariff.*;
+import greencity.dto.tariff.EditTariffDto;
+import greencity.dto.tariff.GetTariffInfoForEmployeeDto;
+import greencity.dto.tariff.GetTariffLimitsDto;
+import greencity.dto.tariff.GetTariffsInfoDto;
+import greencity.dto.tariff.SetTariffLimitsDto;
 import greencity.dto.user.AddBonusesToUserDto;
 import greencity.dto.user.PersonalDataDto;
 import greencity.dto.user.UserInfoDto;
@@ -132,6 +136,7 @@ import greencity.entity.order.TariffLocation;
 import greencity.entity.order.TariffsInfo;
 import greencity.entity.parameters.CustomTableView;
 import greencity.entity.schedule.NotificationSchedule;
+import greencity.entity.telegram.TelegramBot;
 import greencity.entity.user.Location;
 import greencity.entity.user.Region;
 import greencity.entity.user.User;
@@ -143,6 +148,7 @@ import greencity.entity.user.employee.ReceivingStation;
 import greencity.entity.user.ubs.Address;
 import greencity.entity.user.ubs.OrderAddress;
 import greencity.entity.user.ubs.UBSuser;
+import greencity.entity.viber.ViberBot;
 import greencity.enums.AddressStatus;
 import greencity.enums.CancellationReason;
 import greencity.enums.CertificateStatus;
@@ -1352,6 +1358,15 @@ public class ModelUtils {
             .recipientPhoneNumber("095123456").build();
     }
 
+    public static UserProfileDto getUserProfileDto() {
+        return UserProfileDto.builder()
+            .addressDto(List.of(addressDto()))
+            .botList(botList())
+            .telegramIsNotify(false)
+            .viberIsNotify(false)
+            .build();
+    }
+
     public static List<AddressDto> addressDtoList() {
         List<AddressDto> list = new ArrayList<>();
         list.add(AddressDto.builder()
@@ -1384,6 +1399,8 @@ public class ModelUtils {
             .recipientSurname("Petrov")
             .recipientPhone("0666051373")
             .recipientEmail("petrov@gmail.com")
+            .telegramIsNotify(true)
+            .viberIsNotify(false)
             .build();
     }
 
@@ -1393,6 +1410,45 @@ public class ModelUtils {
             .recipientSurname("Petrov")
             .recipientPhone("0666051373")
             .recipientEmail("petrov@gmail.com")
+            .telegramBot(getTelegramBot())
+            .build();
+    }
+
+    public static TelegramBot getTelegramBot() {
+        return TelegramBot.builder()
+            .id(1L)
+            .chatId(111111L)
+            .isNotify(true)
+            .build();
+    }
+
+    public static ViberBot getViberBot() {
+        return ViberBot.builder()
+            .id(1L)
+            .chatId("111111L")
+            .isNotify(true)
+            .build();
+    }
+
+    public static UserProfileUpdateDto getUserProfileUpdateDto() {
+        User user = getUserWithBot();
+        return UserProfileUpdateDto.builder().addressDto(addressDtoList())
+            .recipientName(user.getRecipientName()).recipientSurname(user.getRecipientSurname())
+            .recipientPhone(user.getRecipientPhone())
+            .alternateEmail("test@email.com")
+            .telegramIsNotify(true)
+            .viberIsNotify(true)
+            .build();
+    }
+
+    public static UserProfileUpdateDto getUserProfileUpdateDtoWithBotsIsNotifyFalse() {
+        User user = getUserWithBot();
+        return UserProfileUpdateDto.builder().addressDto(addressDtoList())
+            .recipientName(user.getRecipientName()).recipientSurname(user.getRecipientSurname())
+            .recipientPhone(user.getRecipientPhone())
+            .alternateEmail("test@email.com")
+            .telegramIsNotify(false)
+            .viberIsNotify(false)
             .build();
     }
 
@@ -1645,6 +1701,22 @@ public class ModelUtils {
             .uuid("uuid")
             .ubsUsers(getUbsUsers())
             .currentPoints(100)
+            .build();
+    }
+
+    public static User getUserWithBot() {
+        return User.builder()
+            .id(1L)
+            .addresses(singletonList(getAddress()))
+            .recipientEmail("someUser@gmail.com")
+            .recipientPhone("962473289")
+            .recipientSurname("Ivanov")
+            .uuid("87df9ad5-6393-441f-8423-8b2e770b01a8")
+            .recipientName("Taras")
+            .uuid("uuid")
+            .ubsUsers(getUbsUsers())
+            .currentPoints(100)
+            .telegramBot(getTelegramBot())
             .build();
     }
 
@@ -2973,6 +3045,8 @@ public class ModelUtils {
             .recipientSurname("Ivanov")
             .recipientPhone("962473289")
             .addressDto(addressDtoList())
+            .telegramIsNotify(true)
+            .viberIsNotify(false)
             .build();
     }
 
@@ -3531,7 +3605,7 @@ public class ModelUtils {
         List<Bot> botList = new ArrayList<>();
         botList.add(new Bot()
             .setType("TELEGRAM")
-            .setLink("https://t.me/ubs_test_bot?start=87df9ad5-6393-441f-8423-8b2e770b01a8"));
+            .setLink("https://telegram.me/ubs_test_bot?start=87df9ad5-6393-441f-8423-8b2e770b01a8"));
         botList.add(new Bot()
             .setType("VIBER")
             .setLink("viber://pa?chatURI=ubstestbot1&context=87df9ad5-6393-441f-8423-8b2e770b01a8"));

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1410,15 +1410,23 @@ public class ModelUtils {
             .recipientSurname("Petrov")
             .recipientPhone("0666051373")
             .recipientEmail("petrov@gmail.com")
-            .telegramBot(getTelegramBot())
+            .telegramBot(getTelegramBotNotifyTrue())
             .build();
     }
 
-    public static TelegramBot getTelegramBot() {
+    public static TelegramBot getTelegramBotNotifyTrue() {
         return TelegramBot.builder()
             .id(1L)
             .chatId(111111L)
             .isNotify(true)
+            .build();
+    }
+
+    public static TelegramBot getTelegramBotNotifyFalse() {
+        return TelegramBot.builder()
+            .id(1L)
+            .chatId(111111L)
+            .isNotify(false)
             .build();
     }
 
@@ -1431,7 +1439,7 @@ public class ModelUtils {
     }
 
     public static UserProfileUpdateDto getUserProfileUpdateDto() {
-        User user = getUserWithBot();
+        User user = getUserWithBotNotifyTrue();
         return UserProfileUpdateDto.builder().addressDto(addressDtoList())
             .recipientName(user.getRecipientName()).recipientSurname(user.getRecipientSurname())
             .recipientPhone(user.getRecipientPhone())
@@ -1442,7 +1450,7 @@ public class ModelUtils {
     }
 
     public static UserProfileUpdateDto getUserProfileUpdateDtoWithBotsIsNotifyFalse() {
-        User user = getUserWithBot();
+        User user = getUserWithBotNotifyTrue();
         return UserProfileUpdateDto.builder().addressDto(addressDtoList())
             .recipientName(user.getRecipientName()).recipientSurname(user.getRecipientSurname())
             .recipientPhone(user.getRecipientPhone())
@@ -1704,7 +1712,7 @@ public class ModelUtils {
             .build();
     }
 
-    public static User getUserWithBot() {
+    public static User getUserWithBotNotifyTrue() {
         return User.builder()
             .id(1L)
             .addresses(singletonList(getAddress()))
@@ -1716,7 +1724,23 @@ public class ModelUtils {
             .uuid("uuid")
             .ubsUsers(getUbsUsers())
             .currentPoints(100)
-            .telegramBot(getTelegramBot())
+            .telegramBot(getTelegramBotNotifyTrue())
+            .build();
+    }
+
+    public static User getUserWithBotNotifyFalse() {
+        return User.builder()
+            .id(1L)
+            .addresses(singletonList(getAddress()))
+            .recipientEmail("someUser@gmail.com")
+            .recipientPhone("962473289")
+            .recipientSurname("Ivanov")
+            .uuid("87df9ad5-6393-441f-8423-8b2e770b01a8")
+            .recipientName("Taras")
+            .uuid("uuid")
+            .ubsUsers(getUbsUsers())
+            .currentPoints(100)
+            .telegramBot(getTelegramBotNotifyFalse())
             .build();
     }
 

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1430,11 +1430,19 @@ public class ModelUtils {
             .build();
     }
 
-    public static ViberBot getViberBot() {
+    public static ViberBot getViberBotNotifyTrue() {
         return ViberBot.builder()
             .id(1L)
             .chatId("111111L")
             .isNotify(true)
+            .build();
+    }
+
+    public static ViberBot getViberBotNotifyFalse() {
+        return ViberBot.builder()
+            .id(1L)
+            .chatId("111111L")
+            .isNotify(false)
             .build();
     }
 

--- a/service/src/test/java/greencity/mapping/user/UserToUserProfileDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/user/UserToUserProfileDtoMapperTest.java
@@ -2,7 +2,9 @@ package greencity.mapping.user;
 
 import greencity.ModelUtils;
 import greencity.dto.user.UserProfileDto;
+import greencity.entity.telegram.TelegramBot;
 import greencity.entity.user.User;
+import greencity.entity.viber.ViberBot;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -20,7 +22,28 @@ class UserToUserProfileDtoMapperTest {
     void convert() {
         UserProfileDto expected = ModelUtils.userProfileDto();
         User user = ModelUtils.getUserProfile();
+        ViberBot viberBot = ModelUtils.getViberBotNotifyTrue();
 
+        assertEquals(expected, mapper.convert(user));
+
+        user.setViberBot(viberBot);
+        user.setTelegramBot(null);
+        expected.setViberIsNotify(true);
+        expected.setTelegramIsNotify(false);
+        assertEquals(expected, mapper.convert(user));
+
+        TelegramBot telegramBot = ModelUtils.getTelegramBotNotifyFalse();
+        viberBot = ModelUtils.getViberBotNotifyFalse();
+        user.setViberBot(viberBot);
+        user.setTelegramBot(telegramBot);
+        expected.setViberIsNotify(false);
+        expected.setTelegramIsNotify(false);
+        assertEquals(expected, mapper.convert(user));
+
+        user.setViberBot(null);
+        user.setTelegramBot(null);
+        expected.setViberIsNotify(false);
+        expected.setTelegramIsNotify(false);
         assertEquals(expected, mapper.convert(user));
     }
 }

--- a/service/src/test/java/greencity/mapping/user/UserToUserProfileDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/user/UserToUserProfileDtoMapperTest.java
@@ -3,7 +3,6 @@ package greencity.mapping.user;
 import greencity.ModelUtils;
 import greencity.dto.user.UserProfileDto;
 import greencity.entity.user.User;
-import greencity.mapping.user.UserToUserProfileDtoMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/service/src/test/java/greencity/mapping/user/UserToUserProfileUpdateDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/user/UserToUserProfileUpdateDtoMapperTest.java
@@ -3,7 +3,6 @@ package greencity.mapping.user;
 import greencity.ModelUtils;
 import greencity.dto.user.UserProfileUpdateDto;
 import greencity.entity.user.User;
-import greencity.mapping.user.UserToUserProfileUpdateDtoMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,9 +17,12 @@ class UserToUserProfileUpdateDtoMapperTest {
     @Test
     void convert() {
         UserProfileUpdateDto userProfileUpdateDto = ModelUtils.updateUserProfileDto();
-        User user = ModelUtils.getUser();
-        Assertions.assertEquals(userProfileUpdateDto.getRecipientName(), mapper.convert(user).getRecipientName());
-        Assertions.assertEquals(userProfileUpdateDto.getRecipientSurname(), mapper.convert(user).getRecipientSurname());
-        Assertions.assertEquals(userProfileUpdateDto.getRecipientPhone(), mapper.convert(user).getRecipientPhone());
+        User user = ModelUtils.getUserWithBot();
+        UserProfileUpdateDto converted = mapper.convert(user);
+        Assertions.assertEquals(userProfileUpdateDto.getRecipientName(), converted.getRecipientName());
+        Assertions.assertEquals(userProfileUpdateDto.getRecipientSurname(), converted.getRecipientSurname());
+        Assertions.assertEquals(userProfileUpdateDto.getRecipientPhone(), converted.getRecipientPhone());
+        Assertions.assertEquals(userProfileUpdateDto.getTelegramIsNotify(), converted.getTelegramIsNotify());
+        Assertions.assertEquals(userProfileUpdateDto.getViberIsNotify(), converted.getViberIsNotify());
     }
 }

--- a/service/src/test/java/greencity/mapping/user/UserToUserProfileUpdateDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/user/UserToUserProfileUpdateDtoMapperTest.java
@@ -17,7 +17,7 @@ class UserToUserProfileUpdateDtoMapperTest {
     @Test
     void convert() {
         UserProfileUpdateDto userProfileUpdateDto = ModelUtils.updateUserProfileDto();
-        User user = ModelUtils.getUserWithBot();
+        User user = ModelUtils.getUserWithBotNotifyTrue();
         UserProfileUpdateDto converted = mapper.convert(user);
         Assertions.assertEquals(userProfileUpdateDto.getRecipientName(), converted.getRecipientName());
         Assertions.assertEquals(userProfileUpdateDto.getRecipientSurname(), converted.getRecipientSurname());

--- a/service/src/test/java/greencity/mapping/user/UserToUserProfileUpdateDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/user/UserToUserProfileUpdateDtoMapperTest.java
@@ -2,7 +2,9 @@ package greencity.mapping.user;
 
 import greencity.ModelUtils;
 import greencity.dto.user.UserProfileUpdateDto;
+import greencity.entity.telegram.TelegramBot;
 import greencity.entity.user.User;
+import greencity.entity.viber.ViberBot;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +24,33 @@ class UserToUserProfileUpdateDtoMapperTest {
         Assertions.assertEquals(userProfileUpdateDto.getRecipientName(), converted.getRecipientName());
         Assertions.assertEquals(userProfileUpdateDto.getRecipientSurname(), converted.getRecipientSurname());
         Assertions.assertEquals(userProfileUpdateDto.getRecipientPhone(), converted.getRecipientPhone());
+        Assertions.assertEquals(userProfileUpdateDto.getTelegramIsNotify(), converted.getTelegramIsNotify());
+        Assertions.assertEquals(userProfileUpdateDto.getViberIsNotify(), converted.getViberIsNotify());
+
+        ViberBot viberBot = ModelUtils.getViberBotNotifyTrue();
+        user.setViberBot(viberBot);
+        user.setTelegramBot(null);
+        userProfileUpdateDto.setViberIsNotify(true);
+        userProfileUpdateDto.setTelegramIsNotify(false);
+        converted = mapper.convert(user);
+        Assertions.assertEquals(userProfileUpdateDto.getTelegramIsNotify(), converted.getTelegramIsNotify());
+        Assertions.assertEquals(userProfileUpdateDto.getViberIsNotify(), converted.getViberIsNotify());
+
+        viberBot = ModelUtils.getViberBotNotifyFalse();
+        TelegramBot telegramBot = ModelUtils.getTelegramBotNotifyFalse();
+        user.setViberBot(viberBot);
+        user.setTelegramBot(telegramBot);
+        userProfileUpdateDto.setViberIsNotify(false);
+        userProfileUpdateDto.setTelegramIsNotify(false);
+        converted = mapper.convert(user);
+        Assertions.assertEquals(userProfileUpdateDto.getTelegramIsNotify(), converted.getTelegramIsNotify());
+        Assertions.assertEquals(userProfileUpdateDto.getViberIsNotify(), converted.getViberIsNotify());
+
+        user.setViberBot(null);
+        user.setTelegramBot(null);
+        userProfileUpdateDto.setViberIsNotify(false);
+        userProfileUpdateDto.setTelegramIsNotify(false);
+        converted = mapper.convert(user);
         Assertions.assertEquals(userProfileUpdateDto.getTelegramIsNotify(), converted.getTelegramIsNotify());
         Assertions.assertEquals(userProfileUpdateDto.getViberIsNotify(), converted.getViberIsNotify());
     }

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -1192,8 +1192,8 @@ class UBSClientServiceImplTest {
 
     @Test
     void updateProfileData() {
-        User user = getUserWithBot();
-        TelegramBot telegramBot = getTelegramBot();
+        User user = getUserWithBotNotifyTrue();
+        TelegramBot telegramBot = getTelegramBotNotifyTrue();
         ViberBot viberBot = getViberBot();
         List<AddressDto> addressDto = addressDtoList();
         List<Address> address = addressList();
@@ -1243,7 +1243,7 @@ class UBSClientServiceImplTest {
 
     @Test
     void updateProfileDataIfTelegramBotNotExists() {
-        User user = getUserWithBot();
+        User user = getUserWithBotNotifyTrue();
         List<AddressDto> addressDto = addressDtoList();
         List<Address> address = addressList();
         UserProfileUpdateDto userProfileUpdateDto = getUserProfileUpdateDtoWithBotsIsNotifyFalse();

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -1194,7 +1194,7 @@ class UBSClientServiceImplTest {
     void updateProfileData() {
         User user = getUserWithBotNotifyTrue();
         TelegramBot telegramBot = getTelegramBotNotifyTrue();
-        ViberBot viberBot = getViberBot();
+        ViberBot viberBot = getViberBotNotifyTrue();
         List<AddressDto> addressDto = addressDtoList();
         List<Address> address = addressList();
         List<Bot> botList = botList();

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -3,27 +3,48 @@ package greencity.service.ubs;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import javax.persistence.EntityNotFoundException;
 
 import greencity.dto.bag.BagOrderDto;
 import greencity.dto.bag.BagTranslationDto;
 import greencity.dto.employee.UserEmployeeAuthorityDto;
-import greencity.entity.order.*;
+import greencity.entity.order.Bag;
+import greencity.entity.order.Certificate;
+import greencity.entity.order.Event;
+import greencity.entity.order.Order;
+import greencity.entity.order.OrderPaymentStatusTranslation;
+import greencity.entity.order.OrderStatusTranslation;
+import greencity.entity.order.Payment;
+import greencity.entity.order.TariffsInfo;
+import greencity.entity.telegram.TelegramBot;
 import greencity.entity.user.employee.Employee;
 import greencity.entity.user.ubs.OrderAddress;
-import greencity.enums.*;
-import greencity.repository.*;
+import greencity.entity.viber.ViberBot;
+import greencity.enums.AddressStatus;
+import greencity.enums.CertificateStatus;
+import greencity.enums.CourierLimit;
+import greencity.enums.OrderPaymentStatus;
+import greencity.enums.OrderStatus;
+import greencity.repository.AddressRepository;
+import greencity.repository.BagRepository;
+import greencity.repository.CertificateRepository;
+import greencity.repository.EmployeeRepository;
+import greencity.repository.EventRepository;
+import greencity.repository.LocationRepository;
+import greencity.repository.OrderAddressRepository;
+import greencity.repository.OrderPaymentStatusTranslationRepository;
+import greencity.repository.OrderRepository;
+import greencity.repository.OrderStatusTranslationRepository;
+import greencity.repository.OrdersForUserRepository;
+import greencity.repository.PaymentRepository;
+import greencity.repository.TariffLocationRepository;
+import greencity.repository.TariffsInfoRepository;
+import greencity.repository.TelegramBotRepository;
+import greencity.repository.UBSuserRepository;
+import greencity.repository.UserRepository;
+import greencity.repository.ViberBotRepository;
 import greencity.service.google.GoogleApiService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -152,7 +173,6 @@ class UBSClientServiceImplTest {
     private OrderAddressRepository orderAddressRepository;
     @Mock
     private OrderRepository orderRepository;
-
     @Mock
     private EmployeeRepository employeeRepository;
     @InjectMocks
@@ -174,13 +194,16 @@ class UBSClientServiceImplTest {
     private OrderPaymentStatusTranslationRepository orderPaymentStatusTranslationRepository;
     @Mock
     private TariffsInfoRepository tariffsInfoRepository;
-
     @Mock
     private TariffLocationRepository tariffLocationRepository;
     @Mock
     private LocationRepository locationRepository;
     @Mock
     private GoogleApiService googleApiService;
+    @Mock
+    private TelegramBotRepository telegramBotRepository;
+    @Mock
+    private ViberBotRepository viberBotRepository;
 
     @Test
     @Transactional
@@ -1168,41 +1191,90 @@ class UBSClientServiceImplTest {
     }
 
     @Test
-    void saveProfileData() {
-        User user = getUser();
-
-        when(userRepository.findByUuid("87df9ad5-6393-441f-8423-8b2e770b01a8")).thenReturn(user);
-
+    void updateProfileData() {
+        User user = getUserWithBot();
+        TelegramBot telegramBot = getTelegramBot();
+        ViberBot viberBot = getViberBot();
         List<AddressDto> addressDto = addressDtoList();
         List<Address> address = addressList();
         List<Bot> botList = botList();
+        UserProfileUpdateDto userProfileUpdateDto = getUserProfileUpdateDto();
+        String uuid = UUID.randomUUID().toString();
 
-        UserProfileUpdateDto userProfileUpdateDto =
-            UserProfileUpdateDto.builder().addressDto(addressDto)
-                .recipientName(user.getRecipientName()).recipientSurname(user.getRecipientSurname())
-                .recipientPhone(user.getRecipientPhone())
-                .alternateEmail("test@email.com")
-                .build();
-
+        when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.of(user));
+        when(telegramBotRepository.findByUser(user)).thenReturn(Optional.of(telegramBot));
+        when(viberBotRepository.findByUser(user)).thenReturn(Optional.of(viberBot));
         when(modelMapper.map(addressDto.get(0), Address.class)).thenReturn(address.get(0));
         when(modelMapper.map(addressDto.get(1), Address.class)).thenReturn(address.get(1));
         when(userRepository.save(user)).thenReturn(user);
-        when(modelMapper.map(address.get(0), AddressDto.class)).thenReturn(addressDto.get(0));
-        when(modelMapper.map(address.get(1), AddressDto.class)).thenReturn(addressDto.get(1));
         when(modelMapper.map(user, UserProfileUpdateDto.class)).thenReturn(userProfileUpdateDto);
-        ubsService.updateProfileData("87df9ad5-6393-441f-8423-8b2e770b01a8", userProfileUpdateDto);
+
+        ubsService.updateProfileData(uuid, userProfileUpdateDto);
+
         for (Bot bot : botList) {
-            assertNotNull(bot);
+            Assertions.assertNotNull(bot);
         }
-        assertNotNull(userProfileUpdateDto.getAddressDto());
-        assertNotNull(userProfileUpdateDto);
-        assertNotNull(address);
+        Assertions.assertNotNull(userProfileUpdateDto.getAddressDto());
+        Assertions.assertNotNull(userProfileUpdateDto);
+        Assertions.assertNotNull(address);
+        Assertions.assertTrue(userProfileUpdateDto.getTelegramIsNotify());
+        Assertions.assertTrue(userProfileUpdateDto.getViberIsNotify());
+
+        verify(userRepository).findUserByUuid(uuid);
+        verify(telegramBotRepository).findByUser(user);
+        verify(viberBotRepository).findByUser(user);
+        verify(modelMapper).map(addressDto.get(0), Address.class);
+        verify(modelMapper).map(addressDto.get(1), Address.class);
+        verify(userRepository).save(user);
+        verify(modelMapper).map(user, UserProfileUpdateDto.class);
+    }
+
+    @Test
+    void updateProfileDataThrowNotFoundException() {
+        UserProfileUpdateDto userProfileUpdateDto = getUserProfileUpdateDto();
+        String uuid = UUID.randomUUID().toString();
+
+        when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.empty());
+        assertThrows(NotFoundException.class,
+            () -> ubsService.updateProfileData(uuid, userProfileUpdateDto));
+        verify(userRepository).findUserByUuid(uuid);
+
+    }
+
+    @Test
+    void updateProfileDataIfTelegramBotNotExists() {
+        User user = getUserWithBot();
+        List<AddressDto> addressDto = addressDtoList();
+        List<Address> address = addressList();
+        UserProfileUpdateDto userProfileUpdateDto = getUserProfileUpdateDtoWithBotsIsNotifyFalse();
+        String uuid = UUID.randomUUID().toString();
+
+        when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.of(user));
+        when(telegramBotRepository.findByUser(user)).thenReturn(Optional.empty());
+        when(viberBotRepository.findByUser(user)).thenReturn(Optional.empty());
+        when(modelMapper.map(addressDto.get(0), Address.class)).thenReturn(address.get(0));
+        when(modelMapper.map(addressDto.get(1), Address.class)).thenReturn(address.get(1));
+        when(userRepository.save(user)).thenReturn(user);
+        when(modelMapper.map(user, UserProfileUpdateDto.class)).thenReturn(userProfileUpdateDto);
+
+        ubsService.updateProfileData(uuid, userProfileUpdateDto);
+
+        assertFalse(userProfileUpdateDto.getTelegramIsNotify());
+
+        verify(userRepository).findUserByUuid(uuid);
+        verify(telegramBotRepository).findByUser(user);
+        verify(viberBotRepository).findByUser(user);
+        verify(modelMapper).map(addressDto.get(0), Address.class);
+        verify(modelMapper).map(addressDto.get(1), Address.class);
+        verify(userRepository).save(user);
+        verify(modelMapper).map(user, UserProfileUpdateDto.class);
     }
 
     @Test
     void getProfileData() {
         User user = getUser();
-        when(userRepository.findByUuid(user.getUuid())).thenReturn(user);
+        String uuid = UUID.randomUUID().toString();
+        when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.of(user));
         UserProfileDto userProfileDto = new UserProfileDto();
         List<AddressDto> addressDto = addressDtoList();
         userProfileDto.setAddressDto(addressDto);
@@ -1211,13 +1283,23 @@ class UBSClientServiceImplTest {
         userProfileDto.setBotList(botList);
         when(modelMapper.map(user, UserProfileDto.class)).thenReturn(userProfileDto);
         when(userRemoteClient.getPasswordStatus()).thenReturn(new PasswordStatusDto(true));
-        assertEquals(userProfileDto, ubsService.getProfileData(user.getUuid()));
+        assertEquals(userProfileDto, ubsService.getProfileData(uuid));
         for (Bot bot : botList) {
-            assertNotNull(bot);
+            Assertions.assertNotNull(bot);
         }
-        assertNotNull(addressDto);
-        assertNotNull(userProfileDto);
-        assertNotNull(address);
+        Assertions.assertNotNull(addressDto);
+        Assertions.assertNotNull(userProfileDto);
+        Assertions.assertNotNull(address);
+    }
+
+    @Test
+    void getProfileDataNotFoundException() {
+        String uuid = UUID.randomUUID().toString();
+        when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class,
+            () -> ubsService.getProfileData(uuid));
+        verify(userRepository).findUserByUuid(uuid);
     }
 
     @Test
@@ -1674,7 +1756,7 @@ class UBSClientServiceImplTest {
         when(orderRepository.findById(any())).thenReturn(Optional.of(order1));
         when(liqPayService.getCheckoutResponse(any())).thenReturn("Test");
 
-        assertNotNull(ubsService.saveFullOrderToDBFromLiqPay(dto, "35467585763t4sfgchjfuyetf", null));
+        Assertions.assertNotNull(ubsService.saveFullOrderToDBFromLiqPay(dto, "35467585763t4sfgchjfuyetf", null));
 
         verify(bagRepository, times(2)).findById(3);
         verify(ubsUserRepository).findById(1L);

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
@@ -96,5 +96,8 @@ class TelegramServiceTest {
 
         user.setTelegramBot(new TelegramBot(1L, 123L, true, user));
         assertTrue(telegramService.isEnabled(user));
+
+        user.setTelegramBot(new TelegramBot(1L, 123L, false, user));
+        assertFalse(telegramService.isEnabled(user));
     }
 }

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
@@ -40,7 +40,7 @@ class TelegramServiceTest {
     @InjectMocks
     private TelegramService telegramService;
     private final User user = User.builder().id(32L).recipientEmail("user@email.com")
-        .telegramBot(TelegramBot.builder().id(1L).chatId(1L).build())
+        .telegramBot(TelegramBot.builder().id(1L).chatId(1L).isNotify(true).build())
         .build();
     private final UserVO userVO = UserVO.builder().languageVO(LanguageVO.builder().code("en").build()).build();
     private final UserNotification notification = new UserNotification()
@@ -94,7 +94,7 @@ class TelegramServiceTest {
         user.setTelegramBot(new TelegramBot());
         assertFalse(telegramService.isEnabled(user));
 
-        user.setTelegramBot(new TelegramBot(1L, 123L, user));
+        user.setTelegramBot(new TelegramBot(1L, 123L, true, user));
         assertTrue(telegramService.isEnabled(user));
     }
 }

--- a/service/src/test/java/greencity/ubstelegrambot/UBSTelegramBotTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/UBSTelegramBotTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class UBSTelegramBotTest {
+class UBSTelegramBotTest {
     @Mock
     private UserRepository userRepository;
     @Mock

--- a/service/src/test/java/greencity/ubstelegrambot/UBSTelegramBotTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/UBSTelegramBotTest.java
@@ -1,0 +1,154 @@
+package greencity.ubstelegrambot;
+
+import greencity.ModelUtils;
+import greencity.entity.telegram.TelegramBot;
+import greencity.entity.user.User;
+import greencity.exceptions.NotFoundException;
+import greencity.exceptions.bots.MessageWasNotSent;
+import greencity.exceptions.bots.TelegramBotAlreadyConnected;
+import greencity.repository.TelegramBotRepository;
+import greencity.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static greencity.ModelUtils.getUserWithBotNotifyTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UBSTelegramBotTest {
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private TelegramBotRepository telegramBotRepository;
+    @InjectMocks
+    private UBSTelegramBot ubsTelegramBot;
+
+    @Test
+    void getBotUsernameTest() {
+        assertNull(ubsTelegramBot.getBotUsername());
+    }
+
+    @Test
+    void getBotTokenTest() {
+        assertNull(ubsTelegramBot.getBotToken());
+    }
+
+    @Test
+    void onUpdateReceivedThrowMessageWasNotSent1() {
+        User user = ModelUtils.getUser();
+        User userWithBot = getUserWithBotNotifyTrue();
+        TelegramBot telegramBotTrue = ModelUtils.getTelegramBotNotifyTrue();
+        TelegramBot telegramBotWithNullId = telegramBotTrue.setId(null);
+        String uuid = UUID.randomUUID().toString();
+
+        Update update = new Update();
+        Message message = mock(Message.class);
+        update.setMessage(message);
+
+        when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.of(user));
+        when(message.getChatId()).thenReturn(telegramBotTrue.getChatId());
+        when(message.getText()).thenReturn("/start" + uuid);
+        when(telegramBotRepository.findByUserAndChatIdAndIsNotify(user, message.getChatId(), true))
+            .thenReturn(Optional.empty());
+        when(telegramBotRepository.save(telegramBotWithNullId)).thenReturn(telegramBotTrue);
+        when(userRepository.save(user)).thenReturn(userWithBot);
+
+        assertThrows(MessageWasNotSent.class,
+            () -> ubsTelegramBot.onUpdateReceived(update));
+
+        verify(userRepository).findUserByUuid(uuid);
+        verify(message, atLeast(1)).getChatId();
+        verify(message, atLeast(1)).getText();
+        verify(telegramBotRepository).findByUserAndChatIdAndIsNotify(user, message.getChatId(), true);
+        verify(telegramBotRepository).save(telegramBotWithNullId);
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void onUpdateReceivedThrowMessageWasNotSent2() {
+        User user = ModelUtils.getUserWithBotNotifyFalse();
+        User userWithBot = getUserWithBotNotifyTrue();
+        TelegramBot telegramBotTrue = ModelUtils.getTelegramBotNotifyTrue();
+        String uuid = UUID.randomUUID().toString();
+
+        Update update = new Update();
+        Message message = mock(Message.class);
+        update.setMessage(message);
+
+        when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.of(user));
+        when(message.getChatId()).thenReturn(telegramBotTrue.getChatId());
+        when(message.getText()).thenReturn("/start" + uuid);
+        when(telegramBotRepository.findByUserAndChatIdAndIsNotify(user, message.getChatId(), true))
+            .thenReturn(Optional.empty());
+        when(telegramBotRepository.save(telegramBotTrue)).thenReturn(telegramBotTrue);
+        when(userRepository.save(user)).thenReturn(userWithBot);
+
+        assertThrows(MessageWasNotSent.class,
+            () -> ubsTelegramBot.onUpdateReceived(update));
+
+        verify(userRepository).findUserByUuid(uuid);
+        verify(message, atLeast(1)).getChatId();
+        verify(message, atLeast(1)).getText();
+        verify(telegramBotRepository).findByUserAndChatIdAndIsNotify(user, message.getChatId(), true);
+        verify(telegramBotRepository).save(telegramBotTrue);
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void onUpdateReceivedThrowTelegramBotAlreadyConnected() {
+        Long chatId = 1234567824356L;
+        String uuid = UUID.randomUUID().toString();
+        User user = ModelUtils.getUser();
+        TelegramBot telegramBot = ModelUtils.getTelegramBotNotifyTrue();
+
+        Update update = new Update();
+        Message message = mock(Message.class);
+        update.setMessage(message);
+
+        when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.of(user));
+        when(message.getChatId()).thenReturn(chatId);
+        when(message.getText()).thenReturn("/start" + uuid);
+        when(telegramBotRepository.findByUserAndChatIdAndIsNotify(user, message.getChatId(), true))
+            .thenReturn(Optional.of(telegramBot));
+
+        assertThrows(TelegramBotAlreadyConnected.class,
+            () -> ubsTelegramBot.onUpdateReceived(update));
+
+        verify(userRepository).findUserByUuid(uuid);
+        verify(message, atLeast(1)).getChatId();
+        verify(message, atLeast(1)).getText();
+        verify(telegramBotRepository).findByUserAndChatIdAndIsNotify(user, message.getChatId(), true);
+        verify(telegramBotRepository, never()).save(any(TelegramBot.class));
+        verify(userRepository, never()).save(user);
+    }
+
+    @Test
+    void onUpdateReceivedThrowNotFoundException() {
+        String uuid = UUID.randomUUID().toString();
+
+        Update update = new Update();
+        Message message = mock(Message.class);
+        update.setMessage(message);
+
+        when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.empty());
+        when(message.getText()).thenReturn("/start" + uuid);
+
+        assertThrows(NotFoundException.class,
+            () -> ubsTelegramBot.onUpdateReceived(update));
+
+        verify(userRepository).findUserByUuid(uuid);
+        verify(message, atLeast(1)).getText();
+        verify(telegramBotRepository, never()).save(any(TelegramBot.class));
+        verify(userRepository, never()).save(any(User.class));
+    }
+}


### PR DESCRIPTION
## Link to issue

https://github.com/ita-social-projects/GreenCity/issues/5447
https://github.com/ita-social-projects/GreenCity/issues/5423

## Summary of change

- added field isNotify to TelegramBot class,
- added column notify to telegram_bot table,
- added new methods to TelegramBotRepository and ViberBotRepository,
- added fields telegramIsNotify and viberIsNotify to UserProfileDto and UserProfileUpdateDto,
- added bots notificstion enable/disable functionality in updateProfileData() at UBSClientServiceImpl,
- fixed isEnabled() implementation in TelegramService,
- fixed onUpdateReceived() implementation in UBSTelegramBot,
- changed mappers methods,
- added test methods.

## Testing approach

Testing in swagger by endpoints /ubs/userProfile/user/getUserProfile and /ubs/userProfite/user/update.