### PR TITLE
Fix #5443/user not exists when violations is deleted

### DIFF
--- a/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
@@ -183,7 +183,7 @@ public class ViolationServiceImpl implements ViolationService {
     @Override
     public void updateUserViolation(UpdateViolationToUserDto add, MultipartFile[] multipartFiles, String uuid) {
         Employee currentUser = employeeRepository.findByUuid(uuid)
-                .orElseThrow(() -> new UserNotFoundException(USER_WITH_CURRENT_ID_DOES_NOT_EXIST));
+            .orElseThrow(() -> new UserNotFoundException(USER_WITH_CURRENT_ID_DOES_NOT_EXIST));
         Violation violation = violationRepository.findByOrderId(add.getOrderID())
             .orElseThrow(() -> new NotFoundException(ORDER_HAS_NOT_VIOLATION));
         updateViolation(violation, add, multipartFiles);

--- a/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
@@ -182,13 +182,13 @@ public class ViolationServiceImpl implements ViolationService {
 
     @Override
     public void updateUserViolation(UpdateViolationToUserDto add, MultipartFile[] multipartFiles, String uuid) {
-        User currentUser = userRepository.findUserByUuid(uuid)
-            .orElseThrow(() -> new UserNotFoundException(USER_WITH_CURRENT_ID_DOES_NOT_EXIST));
+        Employee currentUser = employeeRepository.findByUuid(uuid)
+                .orElseThrow(() -> new UserNotFoundException(USER_WITH_CURRENT_ID_DOES_NOT_EXIST));
         Violation violation = violationRepository.findByOrderId(add.getOrderID())
             .orElseThrow(() -> new NotFoundException(ORDER_HAS_NOT_VIOLATION));
         updateViolation(violation, add, multipartFiles);
         violationRepository.save(violation);
-        eventService.saveEvent(OrderHistory.CHANGES_VIOLATION, currentUser.getRecipientEmail(), violation.getOrder());
+        eventService.saveEvent(OrderHistory.CHANGES_VIOLATION, currentUser.getEmail(), violation.getOrder());
     }
 
     private void updateViolation(Violation violation, UpdateViolationToUserDto add, MultipartFile[] multipartFiles) {

--- a/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
@@ -4,6 +4,7 @@ import greencity.constant.ErrorMessage;
 import greencity.constant.OrderHistory;
 import greencity.dto.pageble.PageableDto;
 import greencity.dto.violation.*;
+import greencity.entity.user.employee.Employee;
 import greencity.enums.SortingOrder;
 import greencity.enums.ViolationLevel;
 import greencity.entity.order.Order;
@@ -157,8 +158,9 @@ public class ViolationServiceImpl implements ViolationService {
     @Override
     @Transactional
     public void deleteViolation(Long id, String uuid) {
-        User currentUser = userRepository.findUserByUuid(uuid)
+        Employee currentUser = employeeRepository.findByUuid(uuid)
             .orElseThrow(() -> new UserNotFoundException(USER_WITH_CURRENT_ID_DOES_NOT_EXIST));
+
         Optional<Violation> violationOptional = violationRepository.findByOrderId(id);
         if (violationOptional.isPresent()) {
             List<String> images = violationOptional.get().getImages();
@@ -171,7 +173,7 @@ public class ViolationServiceImpl implements ViolationService {
             User user = violationOptional.get().getOrder().getUser();
             user.setViolations(userRepository.countTotalUsersViolations(user.getId()));
             userRepository.save(user);
-            eventService.saveEvent(OrderHistory.DELETE_VIOLATION, currentUser.getRecipientEmail(),
+            eventService.save(OrderHistory.DELETE_VIOLATION, currentUser.getEmail(),
                 violationOptional.get().getOrder());
         } else {
             throw new NotFoundException(VIOLATION_DOES_NOT_EXIST);

--- a/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
@@ -130,12 +130,12 @@ class ViolationServiceImplTest {
 
     @Test
     void updateUserViolation() {
-        User user = ModelUtils.getUser();
+        Employee employee = ModelUtils.getEmployee();
         UpdateViolationToUserDto updateViolationToUserDto = ModelUtils.getUpdateViolationToUserDto();
         Violation violation = ModelUtils.getViolation();
         List<String> violationImages = violation.getImages();
 
-        when(userRepository.findUserByUuid("abc")).thenReturn(Optional.of(user));
+        when(employeeRepository.findByUuid("abc")).thenReturn(Optional.of(employee));
         when(violationRepository.findByOrderId(1L)).thenReturn(Optional.of(violation));
         if (updateViolationToUserDto.getImagesToDelete() != null) {
             List<String> images = updateViolationToUserDto.getImagesToDelete();
@@ -145,11 +145,11 @@ class ViolationServiceImplTest {
             }
         }
 
-        violationService.updateUserViolation(updateViolationToUserDto, new MultipartFile[2], "abc");
+        violationService.gupdateUserViolation(updateViolationToUserDto, new MultipartFile[2], "abc");
 
         assertEquals(2, violation.getImages().size());
 
-        verify(userRepository).findUserByUuid("abc");
+        verify(employeeRepository).findByUuid("abc");
         verify(violationRepository).findByOrderId(1L);
     }
 

--- a/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
@@ -84,6 +84,14 @@ class ViolationServiceImplTest {
     }
 
     @Test
+    void deleteViolationFromOrderResponsesNotFoundWhenNoViolationInOrder() {
+        Employee employee = ModelUtils.getEmployee();
+        when(employeeRepository.findByUuid("abc")).thenReturn(Optional.of(employee));
+        when(violationRepository.findByOrderId(1l)).thenReturn(Optional.empty());
+        Assertions.assertThrows(NotFoundException.class, () -> violationService.deleteViolation(1L, "abc"));
+        verify(violationRepository, times(1)).findByOrderId(1L);
+    }
+    @Test
     void deleteViolationFromOrderByOrderId() {
         Employee user = ModelUtils.getEmployee();
         when(employeeRepository.findByUuid("abc")).thenReturn(Optional.of(user));
@@ -94,6 +102,7 @@ class ViolationServiceImplTest {
         violationService.deleteViolation(1L, "abc");
 
         verify(violationRepository, times(1)).deleteById(id);
+        verify(employeeRepository, times(1)).findByUuid(anyString());
     }
 
     @Test

--- a/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
@@ -3,6 +3,7 @@ package greencity.service.ubs;
 import java.util.List;
 import java.util.Optional;
 
+import greencity.entity.user.employee.Employee;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -83,18 +84,9 @@ class ViolationServiceImplTest {
     }
 
     @Test
-    void deleteViolationFromOrderResponsesNotFoundWhenNoViolationInOrder() {
-        User user = ModelUtils.getTestUser();
-        when(userRepository.findUserByUuid("abc")).thenReturn(Optional.of(user));
-        when(violationRepository.findByOrderId(1l)).thenReturn(Optional.empty());
-        Assertions.assertThrows(NotFoundException.class, () -> violationService.deleteViolation(1L, "abc"));
-        verify(violationRepository, times(1)).findByOrderId(1L);
-    }
-
-    @Test
     void deleteViolationFromOrderByOrderId() {
-        User user = ModelUtils.getTestUser();
-        when(userRepository.findUserByUuid("abc")).thenReturn(Optional.of(user));
+        Employee user = ModelUtils.getEmployee();
+        when(employeeRepository.findByUuid("abc")).thenReturn(Optional.of(user));
         Violation violation = ModelUtils.getViolation2();
         Long id = ModelUtils.getViolation().getOrder().getId();
         when(violationRepository.findByOrderId(1L)).thenReturn(Optional.of(violation));

--- a/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
@@ -92,6 +92,7 @@ class ViolationServiceImplTest {
         verify(violationRepository, times(1)).findByOrderId(1L);
         verify(employeeRepository, times(1)).findByUuid(anyString());
     }
+
     @Test
     void deleteViolationFromOrderByOrderId() {
         Employee user = ModelUtils.getEmployee();

--- a/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
@@ -90,6 +90,7 @@ class ViolationServiceImplTest {
         when(violationRepository.findByOrderId(1l)).thenReturn(Optional.empty());
         Assertions.assertThrows(NotFoundException.class, () -> violationService.deleteViolation(1L, "abc"));
         verify(violationRepository, times(1)).findByOrderId(1L);
+        verify(employeeRepository, times(1)).findByUuid(anyString());
     }
     @Test
     void deleteViolationFromOrderByOrderId() {

--- a/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
@@ -145,8 +145,6 @@ class ViolationServiceImplTest {
             }
         }
 
-        violationService.gupdateUserViolation(updateViolationToUserDto, new MultipartFile[2], "abc");
-
         assertEquals(2, violation.getImages().size());
 
         verify(employeeRepository).findByUuid("abc");

--- a/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
@@ -145,6 +145,8 @@ class ViolationServiceImplTest {
             }
         }
 
+        violationService.updateUserViolation(updateViolationToUserDto, new MultipartFile[2], "abc");
+
         assertEquals(2, violation.getImages().size());
 
         verify(employeeRepository).findByUuid("abc");


### PR DESCRIPTION
# GreenCityUBS PR
Bug when an admin is trying to delete order violation

## Summary Of Changes
Unit testing, controllers, service layer

## Issue Link
https://github.com/ita-social-projects/GreenCity/issues/5443

##Changes
* service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
* service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
