### PR TITLE
[UBS Admin. Orders. Order details] Change event on update order export details #5427

### DIFF
--- a/service-api/src/main/java/greencity/constant/OrderHistory.java
+++ b/service-api/src/main/java/greencity/constant/OrderHistory.java
@@ -31,7 +31,7 @@ public final class OrderHistory {
     public static final String UPDATE_EXPORT_DETAILS = "Змінено деталі вивезення.";
     public static final String UPDATE_EXPORT_DATA = " Дата вивезення: %s.";
     public static final String UPDATE_DELIVERY_TIME = " Час вивезення: %s - %s.";
-    public static final String UPDATE_RECEIVING_STATION = " Станція приймання: %s";
+    public static final String UPDATE_RECEIVING_STATION = " Станція приймання: %s.";
     public static final String SET_EXPORT_DETAILS = "Встановлено деталі вивезення.";
     public static final String RETURN_OVERPAYMENT_TO_CLIENT = "Повернено кошти клієнту";
     public static final String RETURN_OVERPAYMENT_AS_BONUS_TO_CLIENT = "Зараховано кошти на бонусний рахунок клієнта";

--- a/service-api/src/main/java/greencity/constant/OrderHistory.java
+++ b/service-api/src/main/java/greencity/constant/OrderHistory.java
@@ -28,8 +28,11 @@ public final class OrderHistory {
     public static final String UPDATE_PAYMENT_MANUALLY = "Змінено деталі оплати № ";
     public static final String DELETE_PAYMENT_MANUALLY = "Видалено оплату №";
     public static final String ADD_PAYMENT_SYSTEM = "Додано оплату  №";
-    public static final String UPDATE_EXPORT_DETAILS = "Змінено деталі вивезення";
-    public static final String SET_EXPORT_DETAILS = "Встановлено деталі вивезення";
+    public static final String UPDATE_EXPORT_DETAILS = "Змінено деталі вивезення.";
+    public static final String UPDATE_EXPORT_DATA = " Дата вивезення: %s.";
+    public static final String UPDATE_DELIVERY_TIME = " Час вивезення: %s - %s.";
+    public static final String UPDATE_RECEIVING_STATION = " Станція приймання: %s";
+    public static final String SET_EXPORT_DETAILS = "Встановлено деталі вивезення.";
     public static final String RETURN_OVERPAYMENT_TO_CLIENT = "Повернено кошти клієнту";
     public static final String RETURN_OVERPAYMENT_AS_BONUS_TO_CLIENT = "Зараховано кошти на бонусний рахунок клієнта";
     public static final String WASTE_REMOVAL_ADDRESS_CHANGE = "Змінено адресу вивезення відходів";

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -6,21 +6,53 @@ import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
 import greencity.constant.OrderHistory;
 import greencity.dto.address.AddressExportDetailsDto;
-import greencity.dto.bag.*;
+import greencity.dto.bag.AdditionalBagInfoDto;
+import greencity.dto.bag.BagInfoDto;
+import greencity.dto.bag.BagMappingDto;
+import greencity.dto.bag.BagTransDto;
+import greencity.dto.bag.ReasonNotTakeBagDto;
 import greencity.dto.certificate.CertificateDtoForSearching;
 import greencity.dto.courier.CourierInfoDto;
 import greencity.dto.courier.ReceivingStationDto;
 import greencity.dto.employee.EmployeeNameIdDto;
 import greencity.dto.employee.EmployeePositionDtoRequest;
-import greencity.dto.order.*;
+import greencity.dto.order.AdminCommentDto;
+import greencity.dto.order.CounterOrderDetailsDto;
+import greencity.dto.order.DetailsOrderInfoDto;
+import greencity.dto.order.EcoNumberDto;
+import greencity.dto.order.ExportDetailsDto;
+import greencity.dto.order.ExportDetailsDtoUpdate;
+import greencity.dto.order.GeneralOrderInfo;
+import greencity.dto.order.OrderAddressDtoResponse;
+import greencity.dto.order.OrderAddressExportDetailsDtoUpdate;
+import greencity.dto.order.OrderDetailDto;
+import greencity.dto.order.OrderDetailInfoDto;
+import greencity.dto.order.OrderDetailStatusDto;
+import greencity.dto.order.OrderDetailStatusRequestDto;
+import greencity.dto.order.OrderInfoDto;
+import greencity.dto.order.OrderPaymentStatusesTranslationDto;
+import greencity.dto.order.OrderStatusPageDto;
+import greencity.dto.order.OrderStatusesTranslationDto;
+import greencity.dto.order.ReadAddressByOrderDto;
+import greencity.dto.order.UpdateAllOrderPageDto;
+import greencity.dto.order.UpdateOrderPageAdminDto;
 import greencity.dto.pageble.PageableDto;
-import greencity.dto.payment.*;
+import greencity.dto.payment.ManualPaymentRequestDto;
+import greencity.dto.payment.ManualPaymentResponseDto;
+import greencity.dto.payment.PaymentInfoDto;
+import greencity.dto.payment.PaymentTableInfoDto;
 import greencity.dto.position.PositionDto;
 import greencity.dto.user.AddBonusesToUserDto;
 import greencity.dto.user.AddingPointsToUserDto;
 import greencity.dto.user.UserInfoDto;
 import greencity.dto.violation.ViolationsInfoDto;
-import greencity.entity.order.*;
+import greencity.entity.order.Bag;
+import greencity.entity.order.Certificate;
+import greencity.entity.order.ChangeOfPoints;
+import greencity.entity.order.Order;
+import greencity.entity.order.OrderPaymentStatusTranslation;
+import greencity.entity.order.OrderStatusTranslation;
+import greencity.entity.order.Payment;
 import greencity.entity.user.User;
 import greencity.entity.user.employee.Employee;
 import greencity.entity.user.employee.EmployeeOrderPosition;
@@ -28,10 +60,29 @@ import greencity.entity.user.employee.Position;
 import greencity.entity.user.employee.ReceivingStation;
 import greencity.entity.user.ubs.Address;
 import greencity.entity.user.ubs.OrderAddress;
-import greencity.enums.*;
+import greencity.enums.CancellationReason;
+import greencity.enums.OrderPaymentStatus;
+import greencity.enums.OrderStatus;
+import greencity.enums.PaymentStatus;
+import greencity.enums.PaymentType;
+import greencity.enums.SortingOrder;
 import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
-import greencity.repository.*;
+import greencity.repository.AddressRepository;
+import greencity.repository.BagRepository;
+import greencity.repository.CertificateRepository;
+import greencity.repository.EmployeeOrderPositionRepository;
+import greencity.repository.EmployeeRepository;
+import greencity.repository.OrderAddressRepository;
+import greencity.repository.OrderDetailRepository;
+import greencity.repository.OrderPaymentStatusTranslationRepository;
+import greencity.repository.OrderRepository;
+import greencity.repository.OrderStatusTranslationRepository;
+import greencity.repository.PaymentRepository;
+import greencity.repository.PositionRepository;
+import greencity.repository.ReceivingStationRepository;
+import greencity.repository.ServiceRepository;
+import greencity.repository.UserRepository;
 import greencity.service.notification.NotificationServiceImpl;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -55,7 +106,15 @@ import javax.persistence.EntityNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static greencity.constant.ErrorMessage.*;
@@ -1027,8 +1086,24 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         order.setDeliverFrom(getUpdatedDeliveryFrom(dto.getTimeDeliveryFrom(), order));
         order.setDeliverTo(getUpdatedDeliveryTo(dto.getTimeDeliveryTo(), order));
         orderRepository.save(order);
-        eventService.saveEvent(action, email, order);
+        eventService.saveEvent(action + getEventOnUpdateExportDetails(order), email, order);
         return buildExportDto(order, receivingStation);
+    }
+
+    private String getEventOnUpdateExportDetails(Order order) {
+        String action = "";
+        if (order.getDateOfExport() != null) {
+            action = String.format(OrderHistory.UPDATE_EXPORT_DATA, order.getDateOfExport());
+        }
+        if (order.getDeliverFrom() != null && order.getDeliverTo() != null) {
+            action = action + String.format(OrderHistory.UPDATE_DELIVERY_TIME, order.getDeliverFrom().toLocalTime(),
+                order.getDeliverTo().toLocalTime());
+        }
+        if (order.getReceivingStation() != null) {
+            action =
+                action + String.format(OrderHistory.UPDATE_RECEIVING_STATION, order.getReceivingStation().getName());
+        }
+        return action;
     }
 
     private List<ReceivingStation> getAllReceivingStations() {

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -2123,4 +2123,52 @@ class UBSManagementServiceImplTest {
             Arguments.of(orderWithoutDeliverFromTo,
                 OrderHistory.UPDATE_EXPORT_DETAILS + updateExportDetails));
     }
+
+    @Test
+    void updateOrderExportDetailsWhenDeliverFromIsNull() {
+        Employee employee = getEmployee();
+        List<ReceivingStation> receivingStations = List.of(getReceivingStation());
+        ExportDetailsDtoUpdate testDetails = getExportDetailsRequest();
+        Order order = getOrderExportDetails();
+        var receivingStation = ModelUtils.getReceivingStation();
+        order.setDeliverFrom(null);
+        testDetails.setTimeDeliveryFrom(null);
+        String expectedHistoryEvent = OrderHistory.UPDATE_EXPORT_DETAILS
+            + String.format(OrderHistory.UPDATE_EXPORT_DATA,
+                LocalDate.of(1997, 12, 4))
+            +
+            String.format(OrderHistory.UPDATE_RECEIVING_STATION, "Петрівка");
+
+        when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(receivingStation));
+        when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
+        when(receivingStationRepository.findAll()).thenReturn(receivingStations);
+
+        ubsManagementService.updateOrderExportDetails(order.getId(), testDetails, employee.getEmail());
+        verify(orderRepository, times(1)).save(order);
+        verify(eventService, times(1)).saveEvent(expectedHistoryEvent, employee.getEmail(), order);
+    }
+
+    @Test
+    void updateOrderExportDetailsWhenDeliverToIsNull() {
+        Employee employee = getEmployee();
+        List<ReceivingStation> receivingStations = List.of(getReceivingStation());
+        ExportDetailsDtoUpdate testDetails = getExportDetailsRequest();
+        Order order = getOrderExportDetails();
+        var receivingStation = ModelUtils.getReceivingStation();
+        order.setDeliverTo(null);
+        testDetails.setTimeDeliveryTo(null);
+        String expectedHistoryEvent = OrderHistory.UPDATE_EXPORT_DETAILS
+            + String.format(OrderHistory.UPDATE_EXPORT_DATA,
+                LocalDate.of(1997, 12, 4))
+            +
+            String.format(OrderHistory.UPDATE_RECEIVING_STATION, "Петрівка");
+
+        when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(receivingStation));
+        when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
+        when(receivingStationRepository.findAll()).thenReturn(receivingStations);
+
+        ubsManagementService.updateOrderExportDetails(order.getId(), testDetails, employee.getEmail());
+        verify(orderRepository, times(1)).save(order);
+        verify(eventService, times(1)).saveEvent(expectedHistoryEvent, employee.getEmail(), order);
+    }
 }

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -10,14 +10,32 @@ import greencity.dto.bag.BagInfoDto;
 import greencity.dto.bag.BagMappingDto;
 import greencity.dto.certificate.CertificateDtoForSearching;
 import greencity.dto.employee.EmployeePositionDtoRequest;
-import greencity.dto.order.*;
+import greencity.dto.order.AdminCommentDto;
+import greencity.dto.order.CounterOrderDetailsDto;
+import greencity.dto.order.DetailsOrderInfoDto;
+import greencity.dto.order.EcoNumberDto;
+import greencity.dto.order.ExportDetailsDto;
+import greencity.dto.order.ExportDetailsDtoUpdate;
+import greencity.dto.order.OrderAddressDtoResponse;
+import greencity.dto.order.OrderAddressExportDetailsDtoUpdate;
+import greencity.dto.order.OrderDetailInfoDto;
+import greencity.dto.order.OrderDetailStatusDto;
+import greencity.dto.order.OrderDetailStatusRequestDto;
+import greencity.dto.order.OrderInfoDto;
+import greencity.dto.order.ReadAddressByOrderDto;
+import greencity.dto.order.UpdateAllOrderPageDto;
+import greencity.dto.order.UpdateOrderPageAdminDto;
 import greencity.dto.pageble.PageableDto;
 import greencity.dto.payment.ManualPaymentRequestDto;
 import greencity.dto.payment.PaymentInfoDto;
 import greencity.dto.user.AddBonusesToUserDto;
 import greencity.dto.user.AddingPointsToUserDto;
 import greencity.dto.violation.ViolationsInfoDto;
-import greencity.entity.order.*;
+import greencity.entity.order.Certificate;
+import greencity.entity.order.Order;
+import greencity.entity.order.OrderPaymentStatusTranslation;
+import greencity.entity.order.OrderStatusTranslation;
+import greencity.entity.order.Payment;
 import greencity.entity.user.User;
 import greencity.entity.user.employee.Employee;
 import greencity.entity.user.employee.EmployeeOrderPosition;
@@ -28,16 +46,27 @@ import greencity.enums.OrderPaymentStatus;
 import greencity.enums.OrderStatus;
 import greencity.enums.SortingOrder;
 import greencity.exceptions.BadRequestException;
-import greencity.exceptions.FoundException;
 import greencity.exceptions.NotFoundException;
-import greencity.repository.*;
+import greencity.repository.BagRepository;
+import greencity.repository.CertificateRepository;
+import greencity.repository.EmployeeOrderPositionRepository;
+import greencity.repository.EmployeeRepository;
+import greencity.repository.OrderAddressRepository;
+import greencity.repository.OrderDetailRepository;
+import greencity.repository.OrderPaymentStatusTranslationRepository;
+import greencity.repository.OrderRepository;
+import greencity.repository.OrderStatusTranslationRepository;
+import greencity.repository.PaymentRepository;
+import greencity.repository.PositionRepository;
+import greencity.repository.ReceivingStationRepository;
+import greencity.repository.ServiceRepository;
+import greencity.repository.UserRepository;
 import greencity.service.notification.NotificationServiceImpl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -45,7 +74,11 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
@@ -53,15 +86,34 @@ import org.springframework.web.server.ResponseStatusException;
 import javax.persistence.EntityNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static greencity.ModelUtils.*;
 import static greencity.constant.ErrorMessage.EMPLOYEE_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class UBSManagementServiceImplTest {
@@ -2047,14 +2099,28 @@ class UBSManagementServiceImplTest {
         Order orderWithoutDeliverFromTo = getOrderExportDetails();
         orderWithoutDeliverFromTo.setDeliverFrom(null);
         orderWithoutDeliverFromTo.setDeliverTo(null);
+        String updateExportDetails = String.format(OrderHistory.UPDATE_EXPORT_DATA,
+            LocalDate.of(1997, 12, 4)) +
+            String.format(OrderHistory.UPDATE_DELIVERY_TIME,
+                LocalTime.of(15, 40, 24), LocalTime.of(19, 30, 30))
+            +
+            String.format(OrderHistory.UPDATE_RECEIVING_STATION, "Петрівка");
         return Stream.of(
-            Arguments.of(getOrderExportDetailsWithNullValues(), OrderHistory.SET_EXPORT_DETAILS),
-            Arguments.of(getOrderExportDetailsWithExportDate(), OrderHistory.UPDATE_EXPORT_DETAILS),
-            Arguments.of(getOrderExportDetailsWithExportDateDeliverFrom(), OrderHistory.UPDATE_EXPORT_DETAILS),
-            Arguments.of(getOrderExportDetailsWithExportDateDeliverFromTo(), OrderHistory.UPDATE_EXPORT_DETAILS),
-            Arguments.of(getOrderExportDetails(), OrderHistory.UPDATE_EXPORT_DETAILS),
-            Arguments.of(getOrderExportDetailsWithDeliverFromTo(), OrderHistory.UPDATE_EXPORT_DETAILS),
-            Arguments.of(orderWithoutExportDate, OrderHistory.UPDATE_EXPORT_DETAILS),
-            Arguments.of(orderWithoutExportDate, OrderHistory.UPDATE_EXPORT_DETAILS));
+            Arguments.of(getOrderExportDetailsWithNullValues(),
+                OrderHistory.SET_EXPORT_DETAILS + updateExportDetails),
+            Arguments.of(getOrderExportDetailsWithExportDate(),
+                OrderHistory.UPDATE_EXPORT_DETAILS + updateExportDetails),
+            Arguments.of(getOrderExportDetailsWithExportDateDeliverFrom(),
+                OrderHistory.UPDATE_EXPORT_DETAILS + updateExportDetails),
+            Arguments.of(getOrderExportDetailsWithExportDateDeliverFromTo(),
+                OrderHistory.UPDATE_EXPORT_DETAILS + updateExportDetails),
+            Arguments.of(getOrderExportDetails(),
+                OrderHistory.UPDATE_EXPORT_DETAILS + updateExportDetails),
+            Arguments.of(getOrderExportDetailsWithDeliverFromTo(),
+                OrderHistory.UPDATE_EXPORT_DETAILS + updateExportDetails),
+            Arguments.of(orderWithoutExportDate,
+                OrderHistory.UPDATE_EXPORT_DETAILS + updateExportDetails),
+            Arguments.of(orderWithoutDeliverFromTo,
+                OrderHistory.UPDATE_EXPORT_DETAILS + updateExportDetails));
     }
 }


### PR DESCRIPTION
## Issue

https://github.com/ita-social-projects/GreenCity/issues/5427

## Summary of change

- added new private method to create event message on updating export details in UBSManagementServiceImpl.
- added new static fields to OrderHistory.
- changed/added tests to UBSManagementServiceImplTest.

## Testing approach

Testing in swagger by endpoint /ubs/management/update-order-page-admin-info/{id}.