### PR TITLE
Set order status

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1024,11 +1024,9 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         }
         order.setReceivingStation(getUpdatedReceivingStation(dto.getReceivingStationId(), order));
         order.setDateOfExport(getUpdatedDateExport(dto.getDateExport(), order));
-        if (order.getDateOfExport() != null) {
-            if (order.getDateOfExport().equals(LocalDate.now())
-                && order.getOrderStatus().equals(OrderStatus.CONFIRMED)) {
-                order.setOrderStatus(OrderStatus.ON_THE_ROUTE);
-            }
+        if (order.getDateOfExport() != null && order.getDateOfExport().equals(LocalDate.now())
+            && order.getOrderStatus().equals(OrderStatus.CONFIRMED)) {
+            order.setOrderStatus(OrderStatus.ON_THE_ROUTE);
         }
         order.setDeliverFrom(getUpdatedDeliveryFrom(dto.getTimeDeliveryFrom(), order));
         order.setDeliverTo(getUpdatedDeliveryTo(dto.getTimeDeliveryTo(), order));

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1024,6 +1024,12 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         }
         order.setReceivingStation(getUpdatedReceivingStation(dto.getReceivingStationId(), order));
         order.setDateOfExport(getUpdatedDateExport(dto.getDateExport(), order));
+        if (order.getDateOfExport() != null) {
+            if (order.getDateOfExport().equals(LocalDate.now())
+                && order.getOrderStatus().equals(OrderStatus.CONFIRMED)) {
+                order.setOrderStatus(OrderStatus.ON_THE_ROUTE);
+            }
+        }
         order.setDeliverFrom(getUpdatedDeliveryFrom(dto.getTimeDeliveryFrom(), order));
         order.setDeliverTo(getUpdatedDeliveryTo(dto.getTimeDeliveryTo(), order));
         orderRepository.save(order);
@@ -1437,10 +1443,6 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             }
             if (nonNull(updateOrderPageDto.getExportDetailsDto())) {
                 updateOrderExportDetails(orderId, updateOrderPageDto.getExportDetailsDto(), email);
-            }
-            if (order.getDateOfExport().equals(LocalDate.now())
-                && order.getOrderStatus().equals(OrderStatus.CONFIRMED)) {
-                order.setOrderStatus(OrderStatus.ON_THE_ROUTE);
             }
             if (nonNull(updateOrderPageDto.getEcoNumberFromShop())) {
                 updateEcoNumberForOrder(updateOrderPageDto.getEcoNumberFromShop(), orderId, email);

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1438,6 +1438,10 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             if (nonNull(updateOrderPageDto.getExportDetailsDto())) {
                 updateOrderExportDetails(orderId, updateOrderPageDto.getExportDetailsDto(), email);
             }
+            if (order.getDateOfExport().equals(LocalDate.now())
+                && order.getOrderStatus().equals(OrderStatus.CONFIRMED)) {
+                order.setOrderStatus(OrderStatus.ON_THE_ROUTE);
+            }
             if (nonNull(updateOrderPageDto.getEcoNumberFromShop())) {
                 updateEcoNumberForOrder(updateOrderPageDto.getEcoNumberFromShop(), orderId, email);
             }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -169,6 +169,7 @@ import org.springframework.data.domain.Sort;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.Month;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -621,6 +622,15 @@ public class ModelUtils {
             .timeDeliveryTo("1990-12-11T19:30:30")
             .receivingStationId(1L)
             .allReceivingStations(List.of(getReceivingStationDto(), getReceivingStationDto()))
+            .build();
+    }
+
+    public static ExportDetailsDtoUpdate getExportDetailsRequestToday() {
+        return ExportDetailsDtoUpdate.builder()
+            .dateExport(String.valueOf(LocalDate.now()))
+            .timeDeliveryFrom(String.valueOf(LocalDateTime.now()))
+            .timeDeliveryTo(String.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.MIDNIGHT)))
+            .receivingStationId(1L)
             .build();
     }
 

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -1134,9 +1134,6 @@ class UBSManagementServiceImplTest {
         ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, 1L, "en", "test@gmail.com");
         UpdateOrderPageAdminDto emptyDto = new UpdateOrderPageAdminDto();
         ubsManagementService.updateOrderAdminPageInfo(emptyDto, 1L, "en", "test@gmail.com");
-        order.setOrderStatus(OrderStatus.ON_THE_ROUTE);
-
-        assertEquals(OrderStatus.ON_THE_ROUTE, order.getOrderStatus());
 
         verify(ubsClientService, times(1))
             .updateUbsUserInfoInOrder(ModelUtils.getUbsCustomersDtoUpdate(), "test@gmail.com");
@@ -1522,15 +1519,20 @@ class UBSManagementServiceImplTest {
     @Test
     void updateOrderExportDetails() {
         User user = getTestUser();
-        Order order = getOrder();
+        Order order = getOrderDoneByUser();
+        order.setDateOfExport(LocalDate.now());
+
         List<ReceivingStation> receivingStations = List.of(getReceivingStation());
-        ExportDetailsDtoUpdate testDetails = getExportDetailsRequest();
+        ExportDetailsDtoUpdate testDetails = getExportDetailsRequestToday();
         var receivingStation = ModelUtils.getReceivingStation();
         when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(receivingStation));
         when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
         when(receivingStationRepository.findAll()).thenReturn(receivingStations);
 
         ubsManagementService.updateOrderExportDetails(user.getId(), testDetails, "test@gmail.com");
+
+        assertEquals(OrderStatus.ON_THE_ROUTE, order.getOrderStatus());
+
         verify(orderRepository, times(1)).save(order);
     }
 

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -1134,6 +1134,9 @@ class UBSManagementServiceImplTest {
         ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, 1L, "en", "test@gmail.com");
         UpdateOrderPageAdminDto emptyDto = new UpdateOrderPageAdminDto();
         ubsManagementService.updateOrderAdminPageInfo(emptyDto, 1L, "en", "test@gmail.com");
+        order.setOrderStatus(OrderStatus.ON_THE_ROUTE);
+
+        assertEquals(OrderStatus.ON_THE_ROUTE, order.getOrderStatus());
 
         verify(ubsClientService, times(1))
             .updateUbsUserInfoInOrder(ModelUtils.getUbsCustomersDtoUpdate(), "test@gmail.com");

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -1520,7 +1520,6 @@ class UBSManagementServiceImplTest {
     void updateOrderExportDetails() {
         User user = getTestUser();
         Order order = getOrderDoneByUser();
-        order.setDateOfExport(LocalDate.now());
 
         List<ReceivingStation> receivingStations = List.of(getReceivingStation());
         ExportDetailsDtoUpdate testDetails = getExportDetailsRequestToday();


### PR DESCRIPTION
dev
## JIRA

* [Main ticket](https://github.com/ita-social-projects/GreenCity/issues/5034)

## Summary of issue

When changing the export date of a product, on the admin page, to today, the product with the status "CONFIRMED" did not change to "ON THE ROUTE"

## Summary of change

Added a check that if the date is equal to today and the status is "CONFIRMED", then the status is changed to "ON THE ROUTE"

## Testing approach

Go to https://www.testgreencity.ga/#/ubs as ADMIN
Go to table with orders
Select item with status "CONFIRMED"
Set pickup date to today

Result: status changes to "ON THE ROUTE"

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions