### PR TITLE
[UBS. Order details. Admin cabinet] - fix employee duplicate #5395 #5396 #5397 #5398

### DIFF
--- a/dao/src/main/java/greencity/repository/TariffsInfoRepository.java
+++ b/dao/src/main/java/greencity/repository/TariffsInfoRepository.java
@@ -133,4 +133,20 @@ public interface TariffsInfoRepository extends JpaRepository<TariffsInfo, Long>,
             + "WHERE b.id IN :bagIds)")
     Optional<TariffsInfo> findTariffsInfoByBagIdAndLocationId(
         @Param("bagIds") List<Integer> bagIds, @Param("locationId") Long locationId);
+
+    /**
+     * Method finds tariff by id and receiving employee id.
+     *
+     * @param tariffId   {@link Long} - tariff id.
+     * @param employeeId {@link Long} - employee id.
+     * @return {@link Optional} of {@link TariffsInfo}.
+     * @author - Julia Seti.
+     */
+
+    @Query(nativeQuery = true,
+        value = "SELECT * FROM tariff_infos_receiving_employee_mapping te "
+            + "LEFT JOIN tariffs_info ti on ti.id = te.tariffs_info_id "
+            + "LEFT JOIN employees e on te.employee_id = e.id "
+            + "WHERE ti.id = :tariffId AND e.id = :employeeId")
+    Optional<TariffsInfo> findTariffsInfoByIdForEmployee(Long tariffId, Long employeeId);
 }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -55,6 +55,7 @@ import greencity.entity.order.Order;
 import greencity.entity.order.OrderPaymentStatusTranslation;
 import greencity.entity.order.OrderStatusTranslation;
 import greencity.entity.order.Payment;
+import greencity.entity.order.TariffsInfo;
 import greencity.entity.user.User;
 import greencity.entity.user.employee.Employee;
 import greencity.entity.user.employee.EmployeeOrderPosition;
@@ -1566,9 +1567,11 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     private void checkAvailableOrderForEmployee(Order order, String email) {
         Long employeeId = employeeRepository.findByEmail(email)
             .orElseThrow(() -> new NotFoundException(EMPLOYEE_NOT_FOUND)).getId();
-        tariffsInfoRepository.findTariffsInfoByIdForEmployee(order.getTariffsInfo().getId(), employeeId)
-            .orElseThrow(
-                () -> new BadRequestException(ErrorMessage.CANNOT_ACCESS_ORDER_FOR_EMPLOYEE + order.getId()));
+        Optional<TariffsInfo> tariffsInfoOptional = tariffsInfoRepository.findTariffsInfoByIdForEmployee(
+            order.getTariffsInfo().getId(), employeeId);
+        if (tariffsInfoOptional.isEmpty()) {
+            throw new BadRequestException(ErrorMessage.CANNOT_ACCESS_ORDER_FOR_EMPLOYEE + order.getId());
+        }
     }
 
     private List<Employee> listAvailableEmployeeWithPosition(Order order, Position position) {

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -23,8 +23,10 @@ import greencity.dto.order.EcoNumberDto;
 import greencity.dto.order.ExportDetailsDto;
 import greencity.dto.order.ExportDetailsDtoUpdate;
 import greencity.dto.order.GeneralOrderInfo;
+import greencity.dto.order.NotTakenOrderReasonDto;
 import greencity.dto.order.OrderAddressDtoResponse;
 import greencity.dto.order.OrderAddressExportDetailsDtoUpdate;
+import greencity.dto.order.OrderCancellationReasonDto;
 import greencity.dto.order.OrderDetailDto;
 import greencity.dto.order.OrderDetailInfoDto;
 import greencity.dto.order.OrderDetailStatusDto;
@@ -36,8 +38,6 @@ import greencity.dto.order.OrderStatusesTranslationDto;
 import greencity.dto.order.ReadAddressByOrderDto;
 import greencity.dto.order.UpdateAllOrderPageDto;
 import greencity.dto.order.UpdateOrderPageAdminDto;
-import greencity.dto.order.NotTakenOrderReasonDto;
-import greencity.dto.order.OrderCancellationReasonDto;
 import greencity.dto.pageble.PageableDto;
 import greencity.dto.payment.ManualPaymentRequestDto;
 import greencity.dto.payment.ManualPaymentResponseDto;
@@ -70,7 +70,6 @@ import greencity.enums.PaymentType;
 import greencity.enums.SortingOrder;
 import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
-import greencity.repository.AddressRepository;
 import greencity.repository.BagRepository;
 import greencity.repository.CertificateRepository;
 import greencity.repository.EmployeeOrderPositionRepository;
@@ -84,6 +83,7 @@ import greencity.repository.PaymentRepository;
 import greencity.repository.PositionRepository;
 import greencity.repository.ReceivingStationRepository;
 import greencity.repository.ServiceRepository;
+import greencity.repository.TariffsInfoRepository;
 import greencity.repository.UserRepository;
 import greencity.service.notification.NotificationServiceImpl;
 import lombok.AllArgsConstructor;
@@ -119,7 +119,16 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static greencity.constant.ErrorMessage.*;
+import static greencity.constant.ErrorMessage.BAG_NOT_FOUND;
+import static greencity.constant.ErrorMessage.EMPLOYEE_NOT_FOUND;
+import static greencity.constant.ErrorMessage.INCORRECT_ECO_NUMBER;
+import static greencity.constant.ErrorMessage.NOT_FOUND_ADDRESS_BY_ORDER_ID;
+import static greencity.constant.ErrorMessage.ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST;
+import static greencity.constant.ErrorMessage.PAYMENT_NOT_FOUND;
+import static greencity.constant.ErrorMessage.RECEIVING_STATION_NOT_FOUND;
+import static greencity.constant.ErrorMessage.RECEIVING_STATION_NOT_FOUND_BY_ID;
+import static greencity.constant.ErrorMessage.USER_HAS_NO_OVERPAYMENT;
+import static greencity.constant.ErrorMessage.USER_WITH_CURRENT_UUID_DOES_NOT_EXIST;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
@@ -127,7 +136,7 @@ import static java.util.Objects.nonNull;
 @AllArgsConstructor
 @Slf4j
 public class UBSManagementServiceImpl implements UBSManagementService {
-    private final AddressRepository addressRepository;
+    private final TariffsInfoRepository tariffsInfoRepository;
     private final OrderRepository orderRepository;
     private final OrderAddressRepository orderAddressRepository;
     private final ModelMapper modelMapper;
@@ -145,16 +154,17 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     private final OrderStatusTranslationRepository orderStatusTranslationRepository;
     private final PositionRepository positionRepository;
     private final EmployeeOrderPositionRepository employeeOrderPositionRepository;
-    private static final String DEFAULT_IMAGE_PATH = AppConstant.DEFAULT_IMAGE;
     private final EventService eventService;
     private final OrderPaymentStatusTranslationRepository orderPaymentStatusTranslationRepository;
     private final ServiceRepository serviceRepository;
+    private final OrdersAdminsPageService ordersAdminsPageService;
+
+    private static final String DEFAULT_IMAGE_PATH = AppConstant.DEFAULT_IMAGE;
 
     private final Set<OrderStatus> orderStatusesBeforeShipment =
         EnumSet.of(OrderStatus.FORMED, OrderStatus.CONFIRMED, OrderStatus.ADJUSTMENT);
     private final Set<OrderStatus> orderStatusesAfterConfirmation =
         EnumSet.of(OrderStatus.ON_THE_ROUTE, OrderStatus.DONE, OrderStatus.BROUGHT_IT_HIMSELF, OrderStatus.CANCELED);
-    private final OrdersAdminsPageService ordersAdminsPageService;
     private static final String FORMAT_DATE = "dd-MM-yyyy";
     @Lazy
     @Autowired
@@ -1396,7 +1406,6 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                     .name(employee.getFirstName() + " " + employee.getLastName())
                     .build())
                 .collect(Collectors.toList()));
-            dto.setAllPositionsEmployees(allPositionEmployee);
         }
         dto.setAllPositionsEmployees(allPositionEmployee);
 
@@ -1557,29 +1566,19 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     private void checkAvailableOrderForEmployee(Order order, String email) {
         Long employeeId = employeeRepository.findByEmail(email)
             .orElseThrow(() -> new NotFoundException(EMPLOYEE_NOT_FOUND)).getId();
-        boolean status = false;
-        List<Long> tariffsInfoIds = employeeRepository.findTariffsInfoForEmployee(employeeId);
-        for (Long id : tariffsInfoIds) {
-            status = id.equals(order.getTariffsInfo().getId()) ? true : status;
-        }
-        if (!status) {
-            throw new BadRequestException(ErrorMessage.CANNOT_ACCESS_ORDER_FOR_EMPLOYEE + order.getId());
-        }
+        tariffsInfoRepository.findTariffsInfoByIdForEmployee(order.getTariffsInfo().getId(), employeeId)
+            .orElseThrow(
+                () -> new BadRequestException(ErrorMessage.CANNOT_ACCESS_ORDER_FOR_EMPLOYEE + order.getId()));
     }
 
     private List<Employee> listAvailableEmployeeWithPosition(Order order, Position position) {
-        List<Employee> employees = employeeRepository.findAllByEmployeePositionId(position.getId());
-        List<Employee> emps = new ArrayList<>();
-        for (Employee emp : employees) {
-            boolean status = false;
-            List<Long> tariffsInfoIds = employeeRepository.findTariffsInfoForEmployee(emp.getId());
-            for (Long id : tariffsInfoIds) {
-                if (status = id.equals(order.getTariffsInfo().getId()) ? true : status) {
-                    emps.add(emp);
-                }
-            }
-        }
-        return emps;
+        Long tariffId = order.getTariffsInfo().getId();
+        return employeeRepository.findAllByEmployeePositionId(position.getId())
+            .stream()
+            .filter(
+                employee -> tariffsInfoRepository.findTariffsInfoByIdForEmployee(tariffId, employee.getId())
+                    .isPresent())
+            .collect(Collectors.toList());
     }
 
     /**

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -16,8 +16,10 @@ import greencity.dto.order.DetailsOrderInfoDto;
 import greencity.dto.order.EcoNumberDto;
 import greencity.dto.order.ExportDetailsDto;
 import greencity.dto.order.ExportDetailsDtoUpdate;
+import greencity.dto.order.NotTakenOrderReasonDto;
 import greencity.dto.order.OrderAddressDtoResponse;
 import greencity.dto.order.OrderAddressExportDetailsDtoUpdate;
+import greencity.dto.order.OrderCancellationReasonDto;
 import greencity.dto.order.OrderDetailInfoDto;
 import greencity.dto.order.OrderDetailStatusDto;
 import greencity.dto.order.OrderDetailStatusRequestDto;
@@ -25,8 +27,6 @@ import greencity.dto.order.OrderInfoDto;
 import greencity.dto.order.ReadAddressByOrderDto;
 import greencity.dto.order.UpdateAllOrderPageDto;
 import greencity.dto.order.UpdateOrderPageAdminDto;
-import greencity.dto.order.NotTakenOrderReasonDto;
-import greencity.dto.order.OrderCancellationReasonDto;
 import greencity.dto.pageble.PageableDto;
 import greencity.dto.payment.ManualPaymentRequestDto;
 import greencity.dto.payment.PaymentInfoDto;
@@ -38,6 +38,7 @@ import greencity.entity.order.Order;
 import greencity.entity.order.OrderPaymentStatusTranslation;
 import greencity.entity.order.OrderStatusTranslation;
 import greencity.entity.order.Payment;
+import greencity.entity.order.TariffsInfo;
 import greencity.entity.user.User;
 import greencity.entity.user.employee.Employee;
 import greencity.entity.user.employee.EmployeeOrderPosition;
@@ -62,6 +63,7 @@ import greencity.repository.PaymentRepository;
 import greencity.repository.PositionRepository;
 import greencity.repository.ReceivingStationRepository;
 import greencity.repository.ServiceRepository;
+import greencity.repository.TariffsInfoRepository;
 import greencity.repository.UserRepository;
 import greencity.service.notification.NotificationServiceImpl;
 import org.junit.jupiter.api.Assertions;
@@ -108,6 +110,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.lenient;
@@ -188,6 +191,9 @@ class UBSManagementServiceImplTest {
 
     @Mock
     OrdersAdminsPageService ordersAdminsPageService;
+
+    @Mock
+    TariffsInfoRepository tariffsInfoRepository;
 
     @Test
     void getAllCertificates() {
@@ -284,16 +290,16 @@ class UBSManagementServiceImplTest {
         user.setRecipientName("Петро");
         user.setRecipientSurname("Петренко");
         Order order = ModelUtils.getFormedOrder();
-        order.setTariffsInfo(getTariffsInfo());
+        TariffsInfo tariffsInfo = getTariffsInfo();
+        order.setTariffsInfo(tariffsInfo);
         Payment payment = ModelUtils.getManualPayment();
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
             .settlementdate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(paymentRepository.save(any()))
             .thenReturn(payment);
@@ -304,6 +310,7 @@ class UBSManagementServiceImplTest {
             .save("Замовлення Оплачено", "Система", order);
         verify(paymentRepository, times(1)).save(any());
         verify(orderRepository, times(1)).findById(1L);
+        verify(tariffsInfoRepository).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
     }
 
     @Test
@@ -571,10 +578,9 @@ class UBSManagementServiceImplTest {
     @Test
     void getAllEmployeesByPosition() {
         Order order = ModelUtils.getOrder();
-        order.setTariffsInfo(getTariffsInfo());
+        TariffsInfo tariffsInfo = ModelUtils.getTariffsInfo();
+        order.setTariffsInfo(tariffsInfo);
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         EmployeePositionDtoRequest dto = ModelUtils.getEmployeePositionDtoRequest();
         List<EmployeeOrderPosition> newList = new ArrayList<>();
         newList.add(ModelUtils.getEmployeeOrderPosition());
@@ -584,12 +590,35 @@ class UBSManagementServiceImplTest {
         employeeList.add(ModelUtils.getEmployee());
         when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(employeeOrderPositionRepository.findAllByOrderId(anyLong())).thenReturn(newList);
         when(positionRepository.findAll()).thenReturn(positionList);
         when(employeeRepository.findAllByEmployeePositionId(anyLong())).thenReturn(employeeList);
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
         assertEquals(dto, ubsManagementService.getAllEmployeesByPosition(order.getId(), "test@gmail.com"));
+        verify(orderRepository).findById(anyLong());
+        verify(employeeRepository).findByEmail("test@gmail.com");
+        verify(employeeOrderPositionRepository).findAllByOrderId(anyLong());
+        verify(positionRepository).findAll();
+        verify(employeeRepository).findAllByEmployeePositionId(anyLong());
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
+    }
+
+    @Test
+    void getAllEmployeesByPositionThrowBadRequestException() {
+        Order order = ModelUtils.getOrder();
+        TariffsInfo tariffsInfo = ModelUtils.getTariffsInfo();
+        order.setTariffsInfo(tariffsInfo);
+        Employee employee = ModelUtils.getEmployee();
+        when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
+        when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.empty());
+        assertThrows(BadRequestException.class,
+            () -> ubsManagementService.getAllEmployeesByPosition(order.getId(), "test@gmail.com"));
+        verify(orderRepository).findById(anyLong());
+        verify(employeeRepository).findByEmail("test@gmail.com");
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
     }
 
     @Test
@@ -1075,16 +1104,17 @@ class UBSManagementServiceImplTest {
     @Test
     void testSaveAdminToOrder() {
         Order order = ModelUtils.getOrder();
-        order.setTariffsInfo(getTariffsInfo());
+        TariffsInfo tariffsInfo = getTariffsInfo();
+        order.setTariffsInfo(tariffsInfo);
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         ubsManagementService.saveAdminCommentToOrder(ModelUtils.getAdminCommentDto(), "test@gmail.com");
         verify(orderRepository, times(1)).save(order);
         verify(eventService, times(1)).save(any(), any(), any());
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
     }
 
     @Test
@@ -1160,13 +1190,13 @@ class UBSManagementServiceImplTest {
     void updateOrderAdminPageInfoTest() {
         OrderDetailStatusRequestDto orderDetailStatusRequestDto = ModelUtils.getTestOrderDetailStatusRequestDto();
         Order order = ModelUtils.getOrder();
-        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(getTariffsInfo());
+        TariffsInfo tariffsInfo = getTariffsInfo();
+        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(tariffsInfo);
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(paymentRepository.findAllByOrderId(1L))
             .thenReturn(List.of(ModelUtils.getPayment()));
         lenient().when(ubsManagementServiceMock.updateOrderDetailStatus(1L, orderDetailStatusRequestDto, "abc"))
@@ -1191,23 +1221,24 @@ class UBSManagementServiceImplTest {
 
         verify(ubsClientService, times(1))
             .updateUbsUserInfoInOrder(ModelUtils.getUbsCustomersDtoUpdate(), "test@gmail.com");
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
     }
 
     @Test
     void updateOrderAdminPageInfoWithStatusFormedTest() {
         Order order = ModelUtils.getOrder();
-        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(getTariffsInfo());
+        TariffsInfo tariffsInfo = getTariffsInfo();
+        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(tariffsInfo);
         order.setOrderStatus(OrderStatus.FORMED);
         EmployeeOrderPosition employeeOrderPosition = ModelUtils.getEmployeeOrderPosition();
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         UpdateOrderPageAdminDto updateOrderPageAdminDto = ModelUtils.updateOrderPageAdminDtoWithStatusFormed();
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(orderRepository.save(order)).thenReturn(order);
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(ModelUtils.getPayment()));
         when(receivingStationRepository.findAll()).thenReturn(List.of(ModelUtils.getReceivingStation()));
         when(employeeOrderPositionRepository.findAllByOrderId(1L)).thenReturn(List.of(employeeOrderPosition));
@@ -1217,30 +1248,31 @@ class UBSManagementServiceImplTest {
         verify(orderRepository, times(3)).findById(1L);
         verify(orderRepository, times(2)).save(order);
         verify(employeeRepository, times(1)).findByEmail("test@gmail.com");
-        verify(employeeRepository).findTariffsInfoForEmployee(employee.getId());
+        verify(tariffsInfoRepository).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
         verify(paymentRepository).findAllByOrderId(1L);
         verify(receivingStationRepository).findAll();
         verify(employeeOrderPositionRepository).findAllByOrderId(1L);
         verify(employeeOrderPositionRepository).deleteAll(List.of(employeeOrderPosition));
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
         verifyNoMoreInteractions(orderRepository, employeeRepository, paymentRepository, receivingStationRepository,
-            employeeOrderPositionRepository);
+            employeeOrderPositionRepository, tariffsInfoRepository);
     }
 
     @Test
     void updateOrderAdminPageInfoWithStatusCanceledTest() {
         Order order = ModelUtils.getOrder();
-        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(getTariffsInfo());
+        TariffsInfo tariffsInfo = getTariffsInfo();
+        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(tariffsInfo);
         order.setOrderStatus(OrderStatus.CANCELED);
         EmployeeOrderPosition employeeOrderPosition = ModelUtils.getEmployeeOrderPosition();
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         UpdateOrderPageAdminDto updateOrderPageAdminDto = ModelUtils.updateOrderPageAdminDtoWithStatusCanceled();
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(orderRepository.save(order)).thenReturn(order);
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(ModelUtils.getPayment()));
         when(receivingStationRepository.findAll()).thenReturn(List.of(ModelUtils.getReceivingStation()));
         when(employeeOrderPositionRepository.findAllByOrderId(1L)).thenReturn(List.of(employeeOrderPosition));
@@ -1250,31 +1282,32 @@ class UBSManagementServiceImplTest {
         verify(orderRepository, times(3)).findById(1L);
         verify(orderRepository, times(2)).save(order);
         verify(employeeRepository, times(1)).findByEmail("test@gmail.com");
-        verify(employeeRepository).findTariffsInfoForEmployee(employee.getId());
+        verify(tariffsInfoRepository).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
         verify(paymentRepository).findAllByOrderId(1L);
         verify(receivingStationRepository).findAll();
         verify(employeeOrderPositionRepository).findAllByOrderId(1L);
         verify(employeeOrderPositionRepository).deleteAll(List.of(employeeOrderPosition));
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
         verifyNoMoreInteractions(orderRepository, employeeRepository, paymentRepository, receivingStationRepository,
-            employeeOrderPositionRepository);
+            employeeOrderPositionRepository, tariffsInfoRepository);
     }
 
     @Test
     void updateOrderAdminPageInfoWithStatusBroughtItHimselfTest() {
         Order order = ModelUtils.getOrder();
-        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(getTariffsInfo());
+        TariffsInfo tariffsInfo = getTariffsInfo();
+        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(tariffsInfo);
         order.setOrderStatus(OrderStatus.BROUGHT_IT_HIMSELF);
         EmployeeOrderPosition employeeOrderPosition = ModelUtils.getEmployeeOrderPosition();
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         UpdateOrderPageAdminDto updateOrderPageAdminDto =
             ModelUtils.updateOrderPageAdminDtoWithStatusBroughtItHimself();
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(orderRepository.save(order)).thenReturn(order);
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(ModelUtils.getPayment()));
         when(receivingStationRepository.findAll()).thenReturn(List.of(ModelUtils.getReceivingStation()));
         when(employeeOrderPositionRepository.findAllByOrderId(1L)).thenReturn(List.of(employeeOrderPosition));
@@ -1284,31 +1317,32 @@ class UBSManagementServiceImplTest {
         verify(orderRepository, times(3)).findById(1L);
         verify(orderRepository, times(2)).save(order);
         verify(employeeRepository, times(1)).findByEmail("test@gmail.com");
-        verify(employeeRepository).findTariffsInfoForEmployee(employee.getId());
+        verify(tariffsInfoRepository).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
         verify(paymentRepository).findAllByOrderId(1L);
         verify(receivingStationRepository).findAll();
         verify(employeeOrderPositionRepository).findAllByOrderId(1L);
         verify(employeeOrderPositionRepository).deleteAll(List.of(employeeOrderPosition));
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
         verifyNoMoreInteractions(orderRepository, employeeRepository, paymentRepository, receivingStationRepository,
-            employeeOrderPositionRepository);
+            employeeOrderPositionRepository, tariffsInfoRepository);
     }
 
     @Test
     void updateOrderAdminPageInfoWithNullFieldsTest() {
         Order order = ModelUtils.getOrder();
-        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(getTariffsInfo());
+        TariffsInfo tariffsInfo = getTariffsInfo();
+        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(tariffsInfo);
         order.setOrderStatus(OrderStatus.BROUGHT_IT_HIMSELF);
         EmployeeOrderPosition employeeOrderPosition = ModelUtils.getEmployeeOrderPosition();
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         UpdateOrderPageAdminDto updateOrderPageAdminDto =
             ModelUtils.updateOrderPageAdminDtoWithNullFields();
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(orderRepository.save(order)).thenReturn(order);
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(ModelUtils.getPayment()));
         when(receivingStationRepository.findAll()).thenReturn(List.of(ModelUtils.getReceivingStation()));
 
@@ -1317,25 +1351,31 @@ class UBSManagementServiceImplTest {
         verify(orderRepository, times(3)).findById(1L);
         verify(orderRepository, times(2)).save(order);
         verify(employeeRepository, times(1)).findByEmail("test@gmail.com");
-        verify(employeeRepository).findTariffsInfoForEmployee(employee.getId());
+        verify(tariffsInfoRepository).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
         verify(paymentRepository).findAllByOrderId(1L);
         verify(receivingStationRepository).findAll();
-        verifyNoMoreInteractions(orderRepository, employeeRepository, paymentRepository, receivingStationRepository);
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
+        verifyNoMoreInteractions(orderRepository, employeeRepository, paymentRepository, receivingStationRepository,
+            tariffsInfoRepository);
     }
 
     @Test
     void updateOrderAdminPageInfoTestThrowsException() {
         UpdateOrderPageAdminDto updateOrderPageAdminDto = updateOrderPageAdminDto();
+        TariffsInfo tariffsInfo = getTariffsInfo();
         Order order = ModelUtils.getOrder();
-        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(getTariffsInfo());
+        order.setOrderDate(LocalDateTime.now()).setTariffsInfo(tariffsInfo);
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         assertThrows(BadRequestException.class,
-            () -> ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, 1L, "en", "test@gmail.com"));
+            () -> ubsManagementService.updateOrderAdminPageInfo(
+                updateOrderPageAdminDto, 1L, "en", "test@gmail.com"));
+        verify(orderRepository, atLeastOnce()).findById(1L);
+        verify(employeeRepository).findByEmail("test@gmail.com");
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
     }
 
     @Test
@@ -1429,13 +1469,13 @@ class UBSManagementServiceImplTest {
     void getOrderStatusDataTest() {
         Order order = ModelUtils.getOrderForGetOrderStatusData2Test();
         BagInfoDto bagInfoDto = ModelUtils.getBagInfoDto();
-        order.setTariffsInfo(getTariffsInfo());
+        TariffsInfo tariffsInfo = getTariffsInfo();
+        order.setTariffsInfo(tariffsInfo);
         Employee employee = getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(bagRepository.findBagsByOrderId(1L)).thenReturn(getBaglist());
         when(bagRepository.findBagsByTariffsInfoId(1L)).thenReturn(getBaglist());
@@ -1463,19 +1503,20 @@ class UBSManagementServiceImplTest {
         verify(orderStatusTranslationRepository).getOrderStatusTranslationById(6L);
         verify(orderPaymentStatusTranslationRepository).getById(1L);
         verify(receivingStationRepository).findAll();
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
     }
 
     @Test
     void getOrderStatusDataTestEmptyPriceDetails() {
         Order order = getOrderForGetOrderStatusEmptyPriceDetails();
         BagInfoDto bagInfoDto = getBagInfoDto();
-        order.setTariffsInfo(getTariffsInfo());
+        TariffsInfo tariffsInfo = getTariffsInfo();
+        order.setTariffsInfo(tariffsInfo);
         Employee employee = getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(getOrderForGetOrderStatusData2Test()));
         when(bagRepository.findBagsByTariffsInfoId(1L)).thenReturn(getBaglist());
@@ -1504,6 +1545,7 @@ class UBSManagementServiceImplTest {
         verify(orderStatusTranslationRepository).getOrderStatusTranslationById(6L);
         verify(orderPaymentStatusTranslationRepository).getById(1L);
         verify(receivingStationRepository).findAll();
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
 
     }
 
@@ -1511,13 +1553,13 @@ class UBSManagementServiceImplTest {
     void getOrderStatusDataWithEmptyCertificateTest() {
         Order order = ModelUtils.getOrderForGetOrderStatusData2Test();
         BagInfoDto bagInfoDto = ModelUtils.getBagInfoDto();
-        order.setTariffsInfo(getTariffsInfo());
+        TariffsInfo tariffsInfo = getTariffsInfo();
+        order.setTariffsInfo(tariffsInfo);
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(bagRepository.findBagsByOrderId(1L)).thenReturn(getBaglist());
         when(bagRepository.findBagsByTariffsInfoId(1L)).thenReturn(getBaglist());
@@ -1543,19 +1585,20 @@ class UBSManagementServiceImplTest {
         verify(orderStatusTranslationRepository).getOrderStatusTranslationById(6L);
         verify(orderPaymentStatusTranslationRepository).getById(1L);
         verify(receivingStationRepository).findAll();
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
     }
 
     @Test
     void getOrderStatusDataExceptionTest() {
         Order order = ModelUtils.getOrderForGetOrderStatusData2Test();
+        TariffsInfo tariffsInfo = getTariffsInfo();
         BagInfoDto bagInfoDto = ModelUtils.getBagInfoDto();
-        order.setTariffsInfo(getTariffsInfo());
+        order.setTariffsInfo(tariffsInfo);
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(bagRepository.findBagsByOrderId(1L)).thenReturn(ModelUtils.getBaglist());
         when(certificateRepository.findCertificate(1L)).thenReturn(ModelUtils.getCertificateList());
@@ -1826,16 +1869,16 @@ class UBSManagementServiceImplTest {
         user.setRecipientName("Петро");
         user.setRecipientSurname("Петренко");
         Order order = ModelUtils.getFormedOrder();
-        order.setTariffsInfo(getTariffsInfo());
+        TariffsInfo tariffsInfo = getTariffsInfo();
+        order.setTariffsInfo(tariffsInfo);
         Payment payment = ModelUtils.getManualPayment();
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
             .settlementdate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(paymentRepository.save(any()))
             .thenReturn(payment);
@@ -1847,6 +1890,7 @@ class UBSManagementServiceImplTest {
             .save("Замовлення Оплачено", "Система", order);
         verify(paymentRepository, times(1)).save(any());
         verify(orderRepository, times(1)).findById(1L);
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
     }
 
     @Test
@@ -1854,13 +1898,13 @@ class UBSManagementServiceImplTest {
         Order order = getOrderForGetOrderStatusData2Test();
         BagInfoDto bagInfoDto = getBagInfoDto();
         OrderPaymentStatusTranslation orderPaymentStatusTranslation = mock(OrderPaymentStatusTranslation.class);
-        order.setTariffsInfo(getTariffsInfo());
+        TariffsInfo tariffsInfo = getTariffsInfo();
+        order.setTariffsInfo(tariffsInfo);
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(bagRepository.findBagsByTariffsInfoId(1L)).thenReturn(getBaglist());
         when(bagRepository.findBagsByOrderId(1L)).thenReturn(getBaglist());
@@ -1890,6 +1934,7 @@ class UBSManagementServiceImplTest {
         verify(orderPaymentStatusTranslationRepository).getById(
             1L);
         verify(receivingStationRepository).findAll();
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
     }
 
     @Test
@@ -1898,14 +1943,14 @@ class UBSManagementServiceImplTest {
         BagInfoDto bagInfoDto = getBagInfoDto();
         OrderPaymentStatusTranslation orderPaymentStatusTranslation = mock(OrderPaymentStatusTranslation.class);
         List<OrderStatusTranslation> list = new ArrayList<>();
+        TariffsInfo tariffsInfo = getTariffsInfo();
         list.add(getOrderStatusTranslation());
-        order.setTariffsInfo(getTariffsInfo());
+        order.setTariffsInfo(tariffsInfo);
         Employee employee = ModelUtils.getEmployee();
-        List<Long> tariffsInfoIds = new ArrayList<>();
-        tariffsInfoIds.add(1L);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
-        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
+            .thenReturn(Optional.of(tariffsInfo));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(bagRepository.findBagsByOrderId(1L)).thenReturn(getBaglist());
         when(bagRepository.findBagsByTariffsInfoId(1L)).thenReturn(getBaglist());
@@ -1940,6 +1985,7 @@ class UBSManagementServiceImplTest {
         verify(orderPaymentStatusTranslationRepository).getById(
             1L);
         verify(receivingStationRepository).findAll();
+        verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
 
     }
 

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -595,7 +595,7 @@ class UBSManagementServiceImplTest {
         when(employeeOrderPositionRepository.findAllByOrderId(anyLong())).thenReturn(newList);
         when(positionRepository.findAll()).thenReturn(positionList);
         when(employeeRepository.findAllByEmployeePositionId(anyLong())).thenReturn(employeeList);
-        assertEquals(dto, ubsManagementService.getAllEmployeesByPosition(order.getId(), "test@gmail.com"));
+        assertEquals(dto, ubsManagementService.getAllEmployeesByPosition(1L, "test@gmail.com"));
         verify(orderRepository).findById(anyLong());
         verify(employeeRepository).findByEmail("test@gmail.com");
         verify(employeeOrderPositionRepository).findAllByOrderId(anyLong());
@@ -615,7 +615,7 @@ class UBSManagementServiceImplTest {
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
             .thenReturn(Optional.empty());
         assertThrows(BadRequestException.class,
-            () -> ubsManagementService.getAllEmployeesByPosition(order.getId(), "test@gmail.com"));
+            () -> ubsManagementService.getAllEmployeesByPosition(1L, "test@gmail.com"));
         verify(orderRepository).findById(anyLong());
         verify(employeeRepository).findByEmail("test@gmail.com");
         verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());


### PR DESCRIPTION
## Summary of issue

Employees duplicate in drop-down list at admin order details page.

https://github.com/ita-social-projects/GreenCity/issues/5395
https://github.com/ita-social-projects/GreenCity/issues/5396
https://github.com/ita-social-projects/GreenCity/issues/5397
https://github.com/ita-social-projects/GreenCity/issues/5398

## Summary of change

- fixed listAvailableEmployeeWithPosition() method in UBSManagementServiceImpl,
- changed checkAvailableOrderForEmployee() method implementation in UBSManagementServiceImpl,
- added new method findTariffsInfoByIdForEmployee() to TariffsInfoRepository,
- test methods changed.

## Testing approach

Test in swagger by endpoints /ubs/management/get-all-employee-by-position/{id}, /ubs/management/get-data-for-order/{id}.