### PR TITLE
Bug #4495

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -209,6 +209,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 UBS_LINK + "/order/**",
                 UBS_LINK + "/processOrder",
                 UBS_LINK + "/processLiqPayOrder",
+                UBS_LINK + "/processLiqPayOrder/{id}",
                 UBS_LINK + "/client/**",
                 "/notifications/**")
             .hasAnyRole(USER, ADMIN)

--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -68,7 +68,6 @@ public class OrderController {
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK, response = UserPointsAndAllBagsDto.class),
         @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
         @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
     @GetMapping("/order-details-for-tariff")

--- a/service-api/src/main/java/greencity/constant/OrderHistory.java
+++ b/service-api/src/main/java/greencity/constant/OrderHistory.java
@@ -6,7 +6,6 @@ public final class OrderHistory {
     public static final String ORDER_BROUGHT_IT_HIMSELF = "Статус Замовлення - Привезе сам";
     public static final String ORDER_CANCELLED = "Статус Замовлення - Скасовано";
     public static final String ORDER_PAID = "Замовлення Оплачено";
-    public static final String ORDER_HALF_PAID = "Замовлення Частково оплачено";
     public static final String SYSTEM = "Система";
     public static final String ORDER_FORMED = "Статус Замовлення - Сформовано";
     public static final String CLIENT = "Клієнт";
@@ -36,7 +35,7 @@ public final class OrderHistory {
     public static final String SET_EXPORT_DETAILS = "Встановлено деталі вивезення.";
     public static final String RETURN_OVERPAYMENT_TO_CLIENT = "Повернено кошти клієнту";
     public static final String RETURN_OVERPAYMENT_AS_BONUS_TO_CLIENT = "Зараховано кошти на бонусний рахунок клієнта";
-    public static final String RETURN_BONUSES_TO_CLIENT = "Використані бонуси повернено на бонусний рахунок клієнта";
+    public static final String RETURN_BONUSES_TO_CLIENT = "Невикористані бонуси повернено на бонусний рахунок клієнта";
     public static final String WASTE_REMOVAL_ADDRESS_CHANGE = "Змінено адресу вивезення відходів";
     public static final String ADD_ADMIN_COMMENT = "Додано коментар";
     public static final String ADD_NEW_ECO_NUMBER = "Додано номер замовлення з магазину";

--- a/service-api/src/main/java/greencity/constant/OrderHistory.java
+++ b/service-api/src/main/java/greencity/constant/OrderHistory.java
@@ -6,6 +6,7 @@ public final class OrderHistory {
     public static final String ORDER_BROUGHT_IT_HIMSELF = "Статус Замовлення - Привезе сам";
     public static final String ORDER_CANCELLED = "Статус Замовлення - Скасовано";
     public static final String ORDER_PAID = "Замовлення Оплачено";
+    public static final String ORDER_HALF_PAID = "Замовлення Частково оплачено";
     public static final String SYSTEM = "Система";
     public static final String ORDER_FORMED = "Статус Замовлення - Сформовано";
     public static final String CLIENT = "Клієнт";
@@ -35,6 +36,7 @@ public final class OrderHistory {
     public static final String SET_EXPORT_DETAILS = "Встановлено деталі вивезення.";
     public static final String RETURN_OVERPAYMENT_TO_CLIENT = "Повернено кошти клієнту";
     public static final String RETURN_OVERPAYMENT_AS_BONUS_TO_CLIENT = "Зараховано кошти на бонусний рахунок клієнта";
+    public static final String RETURN_BONUSES_TO_CLIENT = "Використані бонуси повернено на бонусний рахунок клієнта";
     public static final String WASTE_REMOVAL_ADDRESS_CHANGE = "Змінено адресу вивезення відходів";
     public static final String ADD_ADMIN_COMMENT = "Додано коментар";
     public static final String ADD_NEW_ECO_NUMBER = "Додано номер замовлення з магазину";

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -1369,9 +1369,6 @@ public class UBSClientServiceImpl implements UBSClientService {
         order.setCancellationComment(dto.getCancellationComment());
         order.setId(id);
         orderRepository.save(order);
-        if (order.getPointsToUse() > 0) {
-            eventService.saveEvent(OrderHistory.RETURN_BONUSES_TO_CLIENT, uuid, order);
-        }
         return dto;
     }
 

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -1565,7 +1565,7 @@ public class UBSClientServiceImpl implements UBSClientService {
     private void setPaymentInfo(Map<String, Object> map, Payment payment) {
         payment.setMaskedCard((String) map.get("sender_card_mask2"));
         payment.setCurrency((String) map.get("currency"));
-        payment.setPaymentSystem("LiqPay");
+        payment.setPaymentSystem((String) map.get("payment_system"));
         payment.setCardType((String) map.get("sender_card_type"));
         payment.setResponseDescription((String) map.get("err_description"));
         payment.setPaymentId(String.valueOf(map.get("payment_id")));

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -1369,6 +1369,9 @@ public class UBSClientServiceImpl implements UBSClientService {
         order.setCancellationComment(dto.getCancellationComment());
         order.setId(id);
         orderRepository.save(order);
+        if (order.getPointsToUse() > 0) {
+            eventService.saveEvent(OrderHistory.RETURN_BONUSES_TO_CLIENT, uuid, order);
+        }
         return dto;
     }
 

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -969,7 +969,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     private boolean isPaidByBonuses(List<Payment> payments) {
         return payments.stream()
             .filter(Objects::nonNull)
-            .anyMatch(payment -> payment.getPaymentSystem().equals("Bonus"));
+            .anyMatch(payment -> null != payment.getPaymentSystem() && payment.getPaymentSystem().equals("Bonus"));
     }
 
     private void setOrderCancellation(Order order, String cancellationReason, String cancellationComment) {

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -966,7 +966,8 @@ public class UBSManagementServiceImpl implements UBSManagementService {
 
     private void verifyPaidWithBonuses(Order order, String email) {
         if (order.getPointsToUse() > 0) {
-            eventService.saveEvent(OrderHistory.RETURN_BONUSES_TO_CLIENT, email, order);
+            eventService.saveEvent(OrderHistory.RETURN_BONUSES_TO_CLIENT + ". Всього " + order.getPointsToUse(), email,
+                order);
         }
     }
 

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -943,11 +943,11 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             } else if (order.getOrderStatus() == OrderStatus.NOT_TAKEN_OUT) {
                 eventService.saveEvent(OrderHistory.ORDER_NOT_TAKEN_OUT, email, order);
             } else if (order.getOrderStatus() == OrderStatus.CANCELED) {
-                setOrderCancellation(order, dto.getCancellationReason(), dto.getCancellationComment());
-                eventService.saveEvent(OrderHistory.ORDER_CANCELLED, email, order);
-                if (isPaidByBonuses(payment)) {
+                if (order.getPointsToUse() > 0) {
                     eventService.saveEvent(OrderHistory.RETURN_BONUSES_TO_CLIENT, email, order);
                 }
+                setOrderCancellation(order, dto.getCancellationReason(), dto.getCancellationComment());
+                eventService.saveEvent(OrderHistory.ORDER_CANCELLED, email, order);
             } else if (order.getOrderStatus() == OrderStatus.DONE) {
                 eventService.saveEvent(OrderHistory.ORDER_DONE, email, order);
             } else if (order.getOrderStatus() == OrderStatus.BROUGHT_IT_HIMSELF) {
@@ -964,12 +964,6 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         }
 
         return buildStatuses(order, payment.get(0));
-    }
-
-    private boolean isPaidByBonuses(List<Payment> payments) {
-        return payments.stream()
-            .filter(Objects::nonNull)
-            .anyMatch(payment -> null != payment.getPaymentSystem() && payment.getPaymentSystem().equals("Bonus"));
     }
 
     private void setOrderCancellation(Order order, String cancellationReason, String cancellationComment) {

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -945,6 +945,9 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             } else if (order.getOrderStatus() == OrderStatus.CANCELED) {
                 setOrderCancellation(order, dto.getCancellationReason(), dto.getCancellationComment());
                 eventService.saveEvent(OrderHistory.ORDER_CANCELLED, email, order);
+                if (isPaidByBonuses(payment)) {
+                    eventService.saveEvent(OrderHistory.RETURN_BONUSES_TO_CLIENT, email, order);
+                }
             } else if (order.getOrderStatus() == OrderStatus.DONE) {
                 eventService.saveEvent(OrderHistory.ORDER_DONE, email, order);
             } else if (order.getOrderStatus() == OrderStatus.BROUGHT_IT_HIMSELF) {
@@ -961,6 +964,12 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         }
 
         return buildStatuses(order, payment.get(0));
+    }
+
+    private boolean isPaidByBonuses(List<Payment> payments) {
+        return payments.stream()
+            .filter(Objects::nonNull)
+            .anyMatch(payment -> payment.getPaymentSystem().equals("Bonus"));
     }
 
     private void setOrderCancellation(Order order, String cancellationReason, String cancellationComment) {

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -943,9 +943,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             } else if (order.getOrderStatus() == OrderStatus.NOT_TAKEN_OUT) {
                 eventService.saveEvent(OrderHistory.ORDER_NOT_TAKEN_OUT, email, order);
             } else if (order.getOrderStatus() == OrderStatus.CANCELED) {
-                if (order.getPointsToUse() > 0) {
-                    eventService.saveEvent(OrderHistory.RETURN_BONUSES_TO_CLIENT, email, order);
-                }
+                paidWithBonus(order, email);
                 setOrderCancellation(order, dto.getCancellationReason(), dto.getCancellationComment());
                 eventService.saveEvent(OrderHistory.ORDER_CANCELLED, email, order);
             } else if (order.getOrderStatus() == OrderStatus.DONE) {
@@ -964,6 +962,12 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         }
 
         return buildStatuses(order, payment.get(0));
+    }
+
+    private void paidWithBonus(Order order, String email) {
+        if (order.getPointsToUse() > 0) {
+            eventService.saveEvent(OrderHistory.RETURN_BONUSES_TO_CLIENT, email, order);
+        }
     }
 
     private void setOrderCancellation(Order order, String cancellationReason, String cancellationComment) {

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -943,7 +943,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             } else if (order.getOrderStatus() == OrderStatus.NOT_TAKEN_OUT) {
                 eventService.saveEvent(OrderHistory.ORDER_NOT_TAKEN_OUT, email, order);
             } else if (order.getOrderStatus() == OrderStatus.CANCELED) {
-                paidWithBonus(order, email);
+                verifyPaidWithBonuses(order, email);
                 setOrderCancellation(order, dto.getCancellationReason(), dto.getCancellationComment());
                 eventService.saveEvent(OrderHistory.ORDER_CANCELLED, email, order);
             } else if (order.getOrderStatus() == OrderStatus.DONE) {
@@ -964,7 +964,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         return buildStatuses(order, payment.get(0));
     }
 
-    private void paidWithBonus(Order order, String email) {
+    private void verifyPaidWithBonuses(Order order, String email) {
         if (order.getPointsToUse() > 0) {
             eventService.saveEvent(OrderHistory.RETURN_BONUSES_TO_CLIENT, email, order);
         }

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -1665,6 +1665,7 @@ class UBSClientServiceImplTest {
     void testUpdateOrderCancellationReason() {
         OrderCancellationReasonDto dto = getCancellationDto();
         Order orderDto = getOrderTest();
+        orderDto.setPointsToUse(0);
         when(orderRepository.findById(anyLong())).thenReturn(Optional.ofNullable(orderDto));
         assert orderDto != null;
         when(userRepository.findByUuid(anyString())).thenReturn(orderDto.getUser());
@@ -1677,6 +1678,26 @@ class UBSClientServiceImplTest {
         assertEquals(dto.getCancellationComment(), result.getCancellationComment());
         verify(orderRepository).save(orderDto);
         verify(orderRepository).findById(1L);
+    }
+
+    @Test
+    void testUpdateOrderCancellationReasonBonusReturnedToClient() {
+        OrderCancellationReasonDto dto = getCancellationDto();
+        Order orderDto = getOrderTest();
+        when(orderRepository.findById(anyLong())).thenReturn(Optional.ofNullable(orderDto));
+        assert orderDto != null;
+        when(userRepository.findByUuid(anyString())).thenReturn(orderDto.getUser());
+        when(orderRepository.save(any())).thenReturn(orderDto);
+        OrderCancellationReasonDto result = ubsService.updateOrderCancellationReason(1L, dto, anyString());
+
+        verify(eventService, times(1))
+                .saveEvent("Статус Замовлення - Скасовано", "", orderDto);
+        assertEquals(dto.getCancellationReason(), result.getCancellationReason());
+        assertEquals(dto.getCancellationComment(), result.getCancellationComment());
+        verify(orderRepository).save(orderDto);
+        verify(orderRepository).findById(1L);
+        verify(eventService, times(1))
+                .saveEvent("Використані бонуси повернено на бонусний рахунок клієнта", "", orderDto);
     }
 
     @Test

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -1665,7 +1665,6 @@ class UBSClientServiceImplTest {
     void testUpdateOrderCancellationReason() {
         OrderCancellationReasonDto dto = getCancellationDto();
         Order orderDto = getOrderTest();
-        orderDto.setPointsToUse(0);
         when(orderRepository.findById(anyLong())).thenReturn(Optional.ofNullable(orderDto));
         assert orderDto != null;
         when(userRepository.findByUuid(anyString())).thenReturn(orderDto.getUser());
@@ -1678,26 +1677,6 @@ class UBSClientServiceImplTest {
         assertEquals(dto.getCancellationComment(), result.getCancellationComment());
         verify(orderRepository).save(orderDto);
         verify(orderRepository).findById(1L);
-    }
-
-    @Test
-    void testUpdateOrderCancellationReasonBonusReturnedToClient() {
-        OrderCancellationReasonDto dto = getCancellationDto();
-        Order orderDto = getOrderTest();
-        when(orderRepository.findById(anyLong())).thenReturn(Optional.ofNullable(orderDto));
-        assert orderDto != null;
-        when(userRepository.findByUuid(anyString())).thenReturn(orderDto.getUser());
-        when(orderRepository.save(any())).thenReturn(orderDto);
-        OrderCancellationReasonDto result = ubsService.updateOrderCancellationReason(1L, dto, anyString());
-
-        verify(eventService, times(1))
-                .saveEvent("Статус Замовлення - Скасовано", "", orderDto);
-        assertEquals(dto.getCancellationReason(), result.getCancellationReason());
-        assertEquals(dto.getCancellationComment(), result.getCancellationComment());
-        verify(orderRepository).save(orderDto);
-        verify(orderRepository).findById(1L);
-        verify(eventService, times(1))
-                .saveEvent("Використані бонуси повернено на бонусний рахунок клієнта", "", orderDto);
     }
 
     @Test

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -504,7 +504,7 @@ class UBSManagementServiceImplTest {
         assertEquals(expectedObject.getPaymentStatus(), producedObjectDone.getPaymentStatus());
         assertEquals(expectedObject.getDate(), producedObjectDone.getDate());
 
-        //order.setPointsToUse(700);
+        order.setPointsToUse(0);
         testOrderDetail.setOrderStatus(OrderStatus.CANCELED.toString());
         expectedObject.setOrderStatus(OrderStatus.CANCELED.toString());
         OrderDetailStatusDto producedObjectCancelled2 = ubsManagementService
@@ -545,8 +545,8 @@ class UBSManagementServiceImplTest {
             .saveEvent("Статус Замовлення - Скасовано",
                 "test@gmail.com", order);
         verify(eventService, times(1))
-                .saveEvent("Використані бонуси повернено на бонусний рахунок клієнта",
-                        "test@gmail.com", order);
+            .saveEvent("Використані бонуси повернено на бонусний рахунок клієнта",
+                "test@gmail.com", order);
     }
 
     @Test

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -504,7 +504,7 @@ class UBSManagementServiceImplTest {
         assertEquals(expectedObject.getPaymentStatus(), producedObjectDone.getPaymentStatus());
         assertEquals(expectedObject.getDate(), producedObjectDone.getDate());
 
-        order.setPointsToUse(0);
+        //order.setPointsToUse(700);
         testOrderDetail.setOrderStatus(OrderStatus.CANCELED.toString());
         expectedObject.setOrderStatus(OrderStatus.CANCELED.toString());
         OrderDetailStatusDto producedObjectCancelled2 = ubsManagementService
@@ -544,7 +544,9 @@ class UBSManagementServiceImplTest {
         verify(eventService, times(3))
             .saveEvent("Статус Замовлення - Скасовано",
                 "test@gmail.com", order);
-
+        verify(eventService, times(1))
+                .saveEvent("Використані бонуси повернено на бонусний рахунок клієнта",
+                        "test@gmail.com", order);
     }
 
     @Test

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -545,7 +545,7 @@ class UBSManagementServiceImplTest {
             .saveEvent("Статус Замовлення - Скасовано",
                 "test@gmail.com", order);
         verify(eventService, times(1))
-            .saveEvent("Використані бонуси повернено на бонусний рахунок клієнта",
+            .saveEvent("Невикористані бонуси повернено на бонусний рахунок клієнта" + ". Всього " + 700,
                 "test@gmail.com", order);
     }
 

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -443,6 +443,8 @@ class UBSManagementServiceImplTest {
         List<Payment> payment = new ArrayList<>();
         payment.add(Payment.builder().build());
 
+        order.setPayment(payment);
+
         when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
         when(paymentRepository.findAllByOrderId(anyLong())).thenReturn(payment);
         when(paymentRepository.saveAll(any())).thenReturn(payment);


### PR DESCRIPTION
# Order which was paid using bonuses is canceled add new event. PR `READY_FOR_REVIEW`

## Summary Of Changes :fire:
When the order which was paid using bonuses is canceled the valid event title were not displayed, now the "Використані бонуси повернено на бонусний рахунок клієнта" message is shown in the order work log "Історія замовлення.

## Issue Link 🔗 
[Git Issue Card #4495](https://github.com/ita-social-projects/GreenCity/issues/4495)

## Added
- Added a verification in updateOrderDetailStatus Service method, to check if the order was paid with bonuses.
- Added the verification in test case

## How to test
This could be tested with Swagger also
1. First you need to run GreenCityClient
2. Create an order payed with bonus
3. Cancel the order
4. That's it! you should be able to see the new message added in Order History ✔️

# PR Checklist Forms ✔️ 
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ GitHub Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x]  All files reviewed before sending to reviewers