### PR TITLE
[API.UBS.Save address] The 500 status code is displayed when unauthorized user save the address. #5460

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -210,6 +210,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 UBS_LINK + "/processOrder",
                 UBS_LINK + "/processLiqPayOrder",
                 UBS_LINK + "/processLiqPayOrder/{id}",
+                UBS_LINK + "/save-order-address",
                 UBS_LINK + "/client/**",
                 "/notifications/**")
             .hasAnyRole(USER, ADMIN)
@@ -221,7 +222,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 "/notifications/quantityUnreadenNotifications")
             .hasAnyRole(USER, ADMIN)
             .antMatchers(HttpMethod.PUT,
-                UBS_LINK + "/userProfile/**")
+                UBS_LINK + "/userProfile/**",
+                UBS_LINK + "/update-order-address")
             .hasAnyRole(USER, ADMIN)
             .antMatchers(HttpMethod.PATCH,
                 UBS_LINK + "/userProfile/**",


### PR DESCRIPTION
## Link to of issue

https://github.com/ita-social-projects/GreenCity/issues/5460

## Summary of change

 Added endpoints /ubs/save-order-address and /ubs/update-order-address to SecurityConfig.

## Testing approach

Test in swagger http://localhost:8050/swagger-ui by endpoints /ubs/save-order-address and /ubs/update-order-address.