### PR TITLE
[UBS] - fix viber bot notification functionality #5543

### DIFF
--- a/core/src/main/resources/application-dev.properties
+++ b/core/src/main/resources/application-dev.properties
@@ -28,7 +28,7 @@ greencity.bots.ubs-bot-name=${TELEGRAM_BOT_NAME}
 greencity.bots.ubs-bot-token=${TELEGRAM_BOT_TOKEN}
 
 #ViberBot
-greencity.bots.viber-bot-uri=${VIBER_BOT_URI:#{"default_viber_bot_name"}}
+greencity.bots.viber-bot-uri=${VIBER_BOT_URI}
 greencity.bots.viber-bot-url=${VIBER_BOT_URL}
 greencity.bots.viber-bot-token=${VIBER_BOT_TOKEN}
 

--- a/core/src/main/resources/application-docker.properties
+++ b/core/src/main/resources/application-docker.properties
@@ -28,7 +28,7 @@ greencity.bots.ubs-bot-name=${TELEGRAM_BOT_NAME}
 greencity.bots.ubs-bot-token=${TELEGRAM_BOT_TOKEN}
 
 #ViberBot
-greencity.bots.viber-bot-uri=${VIBER_BOT_URI:#{"default_viber_bot_name"}}
+greencity.bots.viber-bot-uri=${VIBER_BOT_URI}
 greencity.bots.viber-bot-url=${VIBER_BOT_URL}
 greencity.bots.viber-bot-token=${VIBER_BOT_TOKEN}
 


### PR DESCRIPTION
## Summary of issue

Viber bot should send notifications to subscribed users.
https://github.com/ita-social-projects/GreenCity/issues/5543

## Summary of change

fixed viber bot uri in application-dev.properties and application-docker.properties

## Testing approach
Add to environment variables:
VIBER_BOT_URI=ubsbot
VIBER_BOT_TOKEN=4d2c434b3e67d372-dce5d321601abcaf-e177a703bdcd7dc4
VIBER_BOT_URL={your ngrok link}/bot

Test localy with ngrok and swagger by endpoints /setwebhook, /removewebhook, /bot and /accountinfo.