### PR TITLE
Updated filter options for order status, fixed filtering by city #5498

### DIFF
--- a/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
+++ b/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
@@ -110,7 +110,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
 
     // @Test
     void get_All_Orders_Filter_By_City_DESC() {
-        var filter = new OrderSearchCriteria().setCity(new String[] {"Київ"});
+        var filter = new OrderSearchCriteria().setCities(new String[] {"Київ"});
         var orders = ModelUtils.getListBOTViewsStandardPageDESC();
         List<Long> tariffsInfoIds = new ArrayList<>();
         tariffsInfoIds.add(1L);

--- a/dao/src/main/java/greencity/enums/OrderStatus.java
+++ b/dao/src/main/java/greencity/enums/OrderStatus.java
@@ -10,8 +10,7 @@ public enum OrderStatus {
     ON_THE_ROUTE(5, "DONE", "NOT_TAKEN_OUT", OrderStatus.CANCELED_STR),
     DONE(6, "DONE"),
     NOT_TAKEN_OUT(7, "ADJUSTMENT", "BROUGHT_IT_HIMSELF", OrderStatus.CANCELED_STR),
-    CANCELED(8, OrderStatus.CANCELED_STR),
-    PAID(9, "PAID", OrderStatus.CANCELED_STR);
+    CANCELED(8, OrderStatus.CANCELED_STR);
 
     private static final String CANCELED_STR = "CANCELED";
     private final int statusValue;

--- a/dao/src/main/java/greencity/filters/OrderSearchCriteria.java
+++ b/dao/src/main/java/greencity/filters/OrderSearchCriteria.java
@@ -17,10 +17,10 @@ public class OrderSearchCriteria {
     private DateFilter deliveryDate;
     private DateFilter paymentDate;
     private String[] region;
-    private String[] city;
+    private String[] cities;
     private String[] districts;
     private String[] regionEn;
-    private String[] cityEn;
+    private String[] citiesEn;
     private String[] districtsEn;
     private String[] search;
 }

--- a/dao/src/main/java/greencity/repository/OrderFilterDataProvider.java
+++ b/dao/src/main/java/greencity/repository/OrderFilterDataProvider.java
@@ -13,10 +13,10 @@ public class OrderFilterDataProvider {
 
     private static final Map<String, Function<OrderSearchCriteria, String[]>> FILTERS_STRING_MAP = Map.of(
         "region", OrderSearchCriteria::getRegion,
-        "city", OrderSearchCriteria::getCity,
+        "city", OrderSearchCriteria::getCities,
         "district", OrderSearchCriteria::getDistricts,
         "regionEn", OrderSearchCriteria::getRegionEn,
-        "cityEn", OrderSearchCriteria::getCityEn,
+        "cityEn", OrderSearchCriteria::getCitiesEn,
         "districtEn", OrderSearchCriteria::getDistrictsEn);
 
     private static final Map<String, Function<OrderSearchCriteria, DateFilter>> FILTERS_DATEFILTER_MAP = Map.of(

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -185,4 +185,5 @@
     <include file="/db/changelog/logs/ch-change-columns-location_status-to-tariff_status-in-table-tariff_info-Oliyarnik.xml"/>
     <include file="/db/changelog/logs/ch-modify-column-address_comment-address-table-Andzheychak.xml"/>
     <include file="db/changelog/logs/ch-update_big_order_table_view-Golik.xml"/>
+    <include file="db/changelog/logs/ch-delete-order-status-translations-Golik.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-delete-order-status-translations-Golik.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-delete-order-status-translations-Golik.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet id="Golik-2" author="Maksym Golik">
+        <delete tableName="order_status_translations">
+            <where>status_id=9</where>
+        </delete>
+    </changeSet>
+</databaseChangeLog>

--- a/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
@@ -185,9 +185,6 @@ class OrdersAdminsPageServiceImplTest {
         when(orderStatusTranslationRepository.getOrderStatusTranslationById(8L))
             .thenReturn(Optional.ofNullable(orderStatusTranslation.setStatusId(8L)));
 
-        when(orderStatusTranslationRepository.getOrderStatusTranslationById(9L))
-            .thenReturn(Optional.ofNullable(orderStatusTranslation.setStatusId(9L)));
-
         when(orderPaymentStatusTranslationRepository.getOrderPaymentStatusTranslationById(anyLong()))
             .thenReturn(Optional.ofNullable(orderPaymentStatusTranslation));
 


### PR DESCRIPTION
# GreenCityUBS PR
_&lt;Updated filter options for order status, fixed filtering by city #5498 title&gt;_

## Summary Of Changes :fire:
_&lt;Order status - PAID was removed from OrderStatus, because this status exists in OrderPaymentStatus. Fixed bug with no filtering orders by city&gt;_

## Issue Link :clipboard:
_&lt;[Link to the issue](https://github.com/ita-social-projects/GreenCity/issues/5498)&gt;_

## Added
* _&lt;Changelock for deleting row from order_status_translations table&gt;_

## Changed
* _&lt;OrderStatus enum&gt;_
* _&lt;changed naming in method OrderFilterDataProvider according to changed fields naming in class OrderSearchCriteria&gt;_
* _&lt;Existed tests&gt;_

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
