### PR TITLE
Changed address_comment field in order_address table and added Length…

### DIFF
--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -111,6 +111,7 @@
     <include file="db/changelog/logs/ch-update-locations-table-Kozak.xml"/>
     <include file="db/changelog/logs/ch-add-column-receiving_station_id-to-orders-Kuzbyt_Maksym.xml"/>
     <include file="db/changelog/logs/ch-add-some-columns-to-ubsUser-for-Sender-Kuzbyt_Maksym.xml"/>
+    <include file="/db/changelog/logs/ch-modify-column-address_comment-order_address-table-Andzheychak.xml"/>
     <include file="db/changelog/logs/ch-add-big_order_table-view-Kuzbyt_Maksym.xml"/>
     <include file="db/changelog/logs/ch-drop-column-language_id-in-table-bag_translations-Boiarchuk.xml"/>
     <include file="db/changelog/logs/ch-update-notification-templates-Kozak.xml"/>
@@ -185,5 +186,4 @@
     <include file="/db/changelog/logs/ch-change-columns-location_status-to-tariff_status-in-table-tariff_info-Oliyarnik.xml"/>
     <include file="/db/changelog/logs/ch-modify-column-address_comment-address-table-Andzheychak.xml"/>
     <include file="db/changelog/logs/ch-update_big_order_table_view-Golik.xml"/>
-    <include file="/db/changelog/logs/ch-modify-column-address_comment-order_address-table-Andzheychak.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -186,4 +186,5 @@
     <include file="/db/changelog/logs/ch-change-columns-location_status-to-tariff_status-in-table-tariff_info-Oliyarnik.xml"/>
     <include file="/db/changelog/logs/ch-modify-column-address_comment-address-table-Andzheychak.xml"/>
     <include file="db/changelog/logs/ch-update_big_order_table_view-Golik.xml"/>
+    <include file="db/changelog/logs/ch-delete-order-status-translations-Golik.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -111,8 +111,10 @@
     <include file="db/changelog/logs/ch-update-locations-table-Kozak.xml"/>
     <include file="db/changelog/logs/ch-add-column-receiving_station_id-to-orders-Kuzbyt_Maksym.xml"/>
     <include file="db/changelog/logs/ch-add-some-columns-to-ubsUser-for-Sender-Kuzbyt_Maksym.xml"/>
+    <include file="/db/changelog/logs/ch-modify-column-address_comment-address-table-Andzheychak.xml"/>
     <include file="db/changelog/logs/ch-add-order-address-table-Safarov.xml"/>
-    <include file="/db/changelog/logs/ch-modify-column-address_comment-order_address-table-Andzheychak.xml"/>
+    <include file="db/changelog/logs/ch-modify-column-address_comment-order_address-table-Andzheychak.xml"/>
+    <include file="db/changelog/logs/ch-fk_ubs_users_and_order_address-Safarov.xml"/>
     <include file="db/changelog/logs/ch-add-big_order_table-view-Kuzbyt_Maksym.xml"/>
     <include file="db/changelog/logs/ch-drop-column-language_id-in-table-bag_translations-Boiarchuk.xml"/>
     <include file="db/changelog/logs/ch-update-notification-templates-Kozak.xml"/>
@@ -166,7 +168,6 @@
     <include file="db/changelog/logs/ch-drop-table-courier-translation-Korzh.xml"/>
     <include file="db/changelog/logs/ch-add-column-limit-description-to-tariffs-info-Korzh.xml"/>
     <include file="db/changelog/logs/ch-modify-employee-table-Korzh.xml"/>
-    <include file="db/changelog/logs/ch-fk_ubs_users_and_order_address-Safarov.xml"/>
     <include file="db/changelog/logs/ch-update_big_order_table-view-Safarov.xml"/>
     <include file="db/changelog/logs/ch-drop-column_address_id-in-ubs_user-Safarov.xml"/>
     <include file="db/changelog/logs/сh-add-column-min-max-delete-min-max-amount-and-price-again.xml"/>
@@ -184,7 +185,6 @@
     <include file="db/changelog/logs/ch-drop-table-order-employee-Kharchenko.xml"/>
     <include file="db/changelog/logs/ch-add-column-notify-to-telegram-bot-Seti.xml"/>
     <include file="/db/changelog/logs/ch-change-columns-location_status-to-tariff_status-in-table-tariff_info-Oliyarnik.xml"/>
-    <include file="/db/changelog/logs/ch-modify-column-address_comment-address-table-Andzheychak.xml"/>
     <include file="db/changelog/logs/ch-update_big_order_table_view-Golik.xml"/>
     <include file="db/changelog/logs/ch-delete-order-status-translations-Golik.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -111,7 +111,6 @@
     <include file="db/changelog/logs/ch-update-locations-table-Kozak.xml"/>
     <include file="db/changelog/logs/ch-add-column-receiving_station_id-to-orders-Kuzbyt_Maksym.xml"/>
     <include file="db/changelog/logs/ch-add-some-columns-to-ubsUser-for-Sender-Kuzbyt_Maksym.xml"/>
-    <include file="/db/changelog/logs/ch-modify-column-address_comment-order_address-table-Andzheychak.xml"/>
     <include file="db/changelog/logs/ch-add-big_order_table-view-Kuzbyt_Maksym.xml"/>
     <include file="db/changelog/logs/ch-drop-column-language_id-in-table-bag_translations-Boiarchuk.xml"/>
     <include file="db/changelog/logs/ch-update-notification-templates-Kozak.xml"/>
@@ -169,6 +168,7 @@
     <include file="db/changelog/logs/ch-fk_ubs_users_and_order_address-Safarov.xml"/>
     <include file="db/changelog/logs/ch-update_big_order_table-view-Safarov.xml"/>
     <include file="db/changelog/logs/ch-drop-column_address_id-in-ubs_user-Safarov.xml"/>
+    <include file="/db/changelog/logs/ch-modify-column-address_comment-order_address-table-Andzheychak.xml"/>
     <include file="db/changelog/logs/сh-add-column-min-max-delete-min-max-amount-and-price-again.xml"/>
     <include file="db/changelog/logs/ch-alter-table-service-add-columns-service-translations-drop-columns-Seti.xml"/>
     <include file="db/changelog/logs/ch-drop-table-service-translations-Seti.xml"/>

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -111,6 +111,8 @@
     <include file="db/changelog/logs/ch-update-locations-table-Kozak.xml"/>
     <include file="db/changelog/logs/ch-add-column-receiving_station_id-to-orders-Kuzbyt_Maksym.xml"/>
     <include file="db/changelog/logs/ch-add-some-columns-to-ubsUser-for-Sender-Kuzbyt_Maksym.xml"/>
+    <include file="db/changelog/logs/ch-add-order-address-table-Safarov.xml"/>
+    <include file="/db/changelog/logs/ch-modify-column-address_comment-order_address-table-Andzheychak.xml"/>
     <include file="db/changelog/logs/ch-add-big_order_table-view-Kuzbyt_Maksym.xml"/>
     <include file="db/changelog/logs/ch-drop-column-language_id-in-table-bag_translations-Boiarchuk.xml"/>
     <include file="db/changelog/logs/ch-update-notification-templates-Kozak.xml"/>
@@ -164,11 +166,9 @@
     <include file="db/changelog/logs/ch-drop-table-courier-translation-Korzh.xml"/>
     <include file="db/changelog/logs/ch-add-column-limit-description-to-tariffs-info-Korzh.xml"/>
     <include file="db/changelog/logs/ch-modify-employee-table-Korzh.xml"/>
-    <include file="db/changelog/logs/ch-add-order-address-table-Safarov.xml"/>
     <include file="db/changelog/logs/ch-fk_ubs_users_and_order_address-Safarov.xml"/>
     <include file="db/changelog/logs/ch-update_big_order_table-view-Safarov.xml"/>
     <include file="db/changelog/logs/ch-drop-column_address_id-in-ubs_user-Safarov.xml"/>
-    <include file="/db/changelog/logs/ch-modify-column-address_comment-order_address-table-Andzheychak.xml"/>
     <include file="db/changelog/logs/сh-add-column-min-max-delete-min-max-amount-and-price-again.xml"/>
     <include file="db/changelog/logs/ch-alter-table-service-add-columns-service-translations-drop-columns-Seti.xml"/>
     <include file="db/changelog/logs/ch-drop-table-service-translations-Seti.xml"/>

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -185,4 +185,5 @@
     <include file="/db/changelog/logs/ch-change-columns-location_status-to-tariff_status-in-table-tariff_info-Oliyarnik.xml"/>
     <include file="/db/changelog/logs/ch-modify-column-address_comment-address-table-Andzheychak.xml"/>
     <include file="db/changelog/logs/ch-update_big_order_table_view-Golik.xml"/>
+    <include file="/db/changelog/logs/ch-modify-column-address_comment-order_address-table-Andzheychak.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-modify-column-address_comment-order_address-table-Andzheychak.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-modify-column-address_comment-order_address-table-Andzheychak.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="Andzheychak-2" author="Mark Andzheychak">
+        <modifyDataType tableName="order_address" columnName="address_comment" newDataType="VARCHAR(255)"/>
+    </changeSet>
+</databaseChangeLog>

--- a/service-api/src/main/java/greencity/dto/address/AddressDto.java
+++ b/service-api/src/main/java/greencity/dto/address/AddressDto.java
@@ -40,6 +40,7 @@ public class AddressDto implements Serializable {
     @Pattern(regexp = CH_UA + "{1,50}")
     private String street;
 
+    @Length(max = 255)
     private String addressComment;
 
     private Coordinates coordinates;


### PR DESCRIPTION
Added changelog to change address_comment field length in order_address table and added Length annotation over addressComment field in AddressDtoRequest

## Summary of issue
User couldn't save address with more than 200 but less than 255 character length

## Summary of change
Changed address_comment field's length up to 255 characters by creating changelog