### PR TITLE
Added InterruptedException handling and re-interrupted thread inside

### DIFF
--- a/core/src/main/java/greencity/security/filters/AccessTokenAuthenticationFilter.java
+++ b/core/src/main/java/greencity/security/filters/AccessTokenAuthenticationFilter.java
@@ -1,7 +1,5 @@
 package greencity.security.filters;
 
-import com.netflix.hystrix.exception.HystrixRuntimeException;
-import greencity.client.UserRemoteClient;
 import greencity.dto.user.UserVO;
 import greencity.security.JwtTool;
 import greencity.service.FeignClientCallAsync;
@@ -77,6 +75,9 @@ public class AccessTokenAuthenticationFilter extends OncePerRequestFilter {
                 }
             } catch (ExpiredJwtException e) {
                 log.info("Token has expired: " + token);
+            } catch (InterruptedException e){
+                log.info("Thread was interrupted: " + e.getMessage());
+                Thread.currentThread().interrupt();
             } catch (Exception e) {
                 log.info("Access denied with token: " + e.getMessage());
             }

--- a/core/src/main/java/greencity/security/filters/AccessTokenAuthenticationFilter.java
+++ b/core/src/main/java/greencity/security/filters/AccessTokenAuthenticationFilter.java
@@ -75,7 +75,7 @@ public class AccessTokenAuthenticationFilter extends OncePerRequestFilter {
                 }
             } catch (ExpiredJwtException e) {
                 log.info("Token has expired: " + token);
-            } catch (InterruptedException e){
+            } catch (InterruptedException e) {
                 log.info("Thread was interrupted: " + e.getMessage());
                 Thread.currentThread().interrupt();
             } catch (Exception e) {


### PR DESCRIPTION
# Summary of issue

SonarCloud analysis failed with reliability bug. Either re-interrupt this method or rethrow the "InterruptedException" that can be caught here.

## Summary of change

Added InterruptedException handling and re-interrupted thread inside
