### PR TITLE
[UBS] - bug with viber bot subscription #5668

### DIFF
--- a/service/src/test/java/greencity/ubsviberbot/ViberServiceImplTest.java
+++ b/service/src/test/java/greencity/ubsviberbot/ViberServiceImplTest.java
@@ -7,12 +7,13 @@ import greencity.dto.language.LanguageVO;
 import greencity.dto.user.UserVO;
 import greencity.dto.viber.dto.SendMessageToUserDto;
 import greencity.dto.viber.enums.MessageType;
-import greencity.enums.NotificationType;
 import greencity.entity.notifications.NotificationTemplate;
 import greencity.entity.notifications.UserNotification;
 import greencity.entity.user.User;
 import greencity.entity.viber.ViberBot;
+import greencity.enums.NotificationType;
 import greencity.exceptions.bots.MessageWasNotSent;
+import greencity.exceptions.bots.ViberBotAlreadyConnected;
 import greencity.exceptions.user.UserNotFoundException;
 import greencity.repository.NotificationTemplateRepository;
 import greencity.repository.UserRepository;
@@ -27,11 +28,16 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
-import static greencity.enums.NotificationReceiverType.EMAIL;
-//import static greencity.enums.NotificationReceiverType.OTHER;
 import static greencity.enums.NotificationReceiverType.MOBILE;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ViberServiceImplTest {
@@ -40,7 +46,7 @@ class ViberServiceImplTest {
     private NotificationTemplateRepository templateRepository;
 
     @Mock
-    private UserRemoteClient userRemoteClient;;
+    private UserRemoteClient userRemoteClient;
 
     @Mock
     private ViberClient viberClient;
@@ -82,6 +88,14 @@ class ViberServiceImplTest {
         when(viberBotRepository.save(any())).thenReturn(user.getViberBot());
         viberService.sendWelcomeMessageAndPreRegisterViberBotForUser("42", "32L");
         verify(viberBotRepository, times(1)).save(any());
+        verify(userRepository, times(1)).findUserByUuid(anyString());
+    }
+
+    @Test
+    void testSendWelcomeMessageAndPreRegisterViberBotForUserThrowViberBotAlreadyConnected() {
+        when(userRepository.findUserByUuid(anyString())).thenReturn(Optional.of(user));
+        assertThrows(ViberBotAlreadyConnected.class,
+                () -> viberService.sendWelcomeMessageAndPreRegisterViberBotForUser("42", "32L"));
         verify(userRepository, times(1)).findUserByUuid(anyString());
     }
 

--- a/service/src/test/java/greencity/ubsviberbot/ViberServiceImplTest.java
+++ b/service/src/test/java/greencity/ubsviberbot/ViberServiceImplTest.java
@@ -95,7 +95,7 @@ class ViberServiceImplTest {
     void testSendWelcomeMessageAndPreRegisterViberBotForUserThrowViberBotAlreadyConnected() {
         when(userRepository.findUserByUuid(anyString())).thenReturn(Optional.of(user));
         assertThrows(ViberBotAlreadyConnected.class,
-                () -> viberService.sendWelcomeMessageAndPreRegisterViberBotForUser("42", "32L"));
+            () -> viberService.sendWelcomeMessageAndPreRegisterViberBotForUser("42", "32L"));
         verify(userRepository, times(1)).findUserByUuid(anyString());
     }
 


### PR DESCRIPTION
## Summary of issue

When the user clicks on the Viber bot subscription link and does not subscribe, the next attempt to click on the subscription link causes a ViberBotAlreadyConnected error.

https://github.com/ita-social-projects/GreenCity/issues/5668

## Changed

service/src/main/java/greencity/ubsviberbot/ViberServiceImpl.java
service/src/test/java/greencity/ubsviberbot/ViberServiceImplTest.java

## Testing approach

From the user's personal cabinet enable viber notification subscription, follow the subscription link and does not subscribe. Try to do it again. A welcome notification should appear at each subsequent attempt.