### PR TITLE
Change NotificationTemplateWithPlatformsUpdateDto fields to update notifications

### DIFF
--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -434,13 +434,7 @@ public class ModelUtils {
 
     public static NotificationTemplateWithPlatformsUpdateDto getNotificationTemplateWithPlatformsUpdateDto() {
         return NotificationTemplateWithPlatformsUpdateDto.builder()
-            .type(NotificationType.UNPAID_ORDER)
-            .trigger(NotificationTrigger.ORDER_NOT_PAID_FOR_3_DAYS)
-            .time(NotificationTime.AT_6PM_3DAYS_AFTER_ORDER_FORMED_NOT_PAID)
-            .schedule("0 0 18 * * ?")
-            .title("Неопачене замовлення")
-            .titleEng("Unpaid order")
-            .notificationStatus(NotificationStatus.ACTIVE)
+            .notificationTemplateMainInfoDto(getNotificationTemplateMainInfoDto())
             .platforms(List.of(
                 getNotificationPlatformDto(NotificationReceiverType.SITE)))
             .build();

--- a/service-api/src/main/java/greencity/dto/notification/NotificationTemplateWithPlatformsUpdateDto.java
+++ b/service-api/src/main/java/greencity/dto/notification/NotificationTemplateWithPlatformsUpdateDto.java
@@ -20,18 +20,7 @@ import java.util.List;
 @Builder
 public class NotificationTemplateWithPlatformsUpdateDto {
     @NotNull
-    private NotificationType type;
-    @NotNull
-    private NotificationTrigger trigger;
-    @NotNull
-    private NotificationTime time;
-    private String schedule;
-    @NotNull
-    private String title;
-    @NotNull
-    private String titleEng;
-    @NotNull
-    private NotificationStatus notificationStatus;
+    private NotificationTemplateMainInfoDto notificationTemplateMainInfoDto;
     @NotNull
     private List<NotificationPlatformDto> platforms;
 }

--- a/service-api/src/main/java/greencity/dto/notification/NotificationTemplateWithPlatformsUpdateDto.java
+++ b/service-api/src/main/java/greencity/dto/notification/NotificationTemplateWithPlatformsUpdateDto.java
@@ -1,9 +1,5 @@
 package greencity.dto.notification;
 
-import greencity.enums.NotificationStatus;
-import greencity.enums.NotificationTime;
-import greencity.enums.NotificationTrigger;
-import greencity.enums.NotificationType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
@@ -47,12 +47,12 @@ public class NotificationTemplateServiceImpl implements NotificationTemplateServ
 
     private void updateNotificationTemplate(NotificationTemplate template,
         NotificationTemplateWithPlatformsUpdateDto dto) {
-        template.setTitle(dto.getTitle());
-        template.setTitleEng(dto.getTitleEng());
-        template.setNotificationType(dto.getType());
-        template.setTrigger(dto.getTrigger());
-        template.setTime(dto.getTime());
-        template.setSchedule(dto.getSchedule());
+        template.setTitle(dto.getNotificationTemplateMainInfoDto().getTitle());
+        template.setTitleEng(dto.getNotificationTemplateMainInfoDto().getTitleEng());
+        template.setNotificationType(dto.getNotificationTemplateMainInfoDto().getType());
+        template.setTrigger(dto.getNotificationTemplateMainInfoDto().getTrigger());
+        template.setTime(dto.getNotificationTemplateMainInfoDto().getTime());
+        template.setSchedule(dto.getNotificationTemplateMainInfoDto().getSchedule());
     }
 
     private void updateNotificationTemplatePlatforms(List<NotificationPlatform> platforms,

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2204,13 +2204,7 @@ public class ModelUtils {
 
     private static NotificationTemplateWithPlatformsUpdateDto createNotificationTemplateWithPlatformsUpdateDto() {
         return NotificationTemplateWithPlatformsUpdateDto.builder()
-            .type(UNPAID_ORDER)
-            .trigger(ORDER_NOT_PAID_FOR_3_DAYS)
-            .time(AT_6PM_3DAYS_AFTER_ORDER_FORMED_NOT_PAID)
-            .schedule("0 0 18 * * ?")
-            .title("Title")
-            .titleEng("TitleEng")
-            .notificationStatus(ACTIVE)
+            .notificationTemplateMainInfoDto(createNotificationTemplateMainInfoDto())
             .platforms(List.of(
                 createNotificationPlatformDto(SITE)))
             .build();

--- a/service/src/test/java/greencity/service/notification/NotificationTemplateServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationTemplateServiceImplTest.java
@@ -60,22 +60,23 @@ class NotificationTemplateServiceImplTest {
     void updateTest() {
         Long id = 1L;
 
-        var dto = ModelUtils.TEST_NOTIFICATION_TEMPLATE_UPDATE_DTO;
-        var platformDto = dto.getPlatforms().get(0);
+        var updateDto = ModelUtils.TEST_NOTIFICATION_TEMPLATE_UPDATE_DTO;
+        var mainInfoDto = updateDto.getNotificationTemplateMainInfoDto();
+        var platformDto = updateDto.getPlatforms().get(0);
 
         var notification = ModelUtils.TEST_NOTIFICATION_TEMPLATE;
         var platform = notification.getNotificationPlatforms().get(0);
 
         when(templateRepository.findById(id)).thenReturn(Optional.of(notification));
 
-        notificationService.update(id, dto);
+        notificationService.update(id, updateDto);
 
-        assertEquals(dto.getTitle(), notification.getTitle());
-        assertEquals(dto.getTitleEng(), notification.getTitleEng());
-        assertEquals(dto.getType(), notification.getNotificationType());
-        assertEquals(dto.getTrigger(), notification.getTrigger());
-        assertEquals(dto.getTime(), notification.getTime());
-        assertEquals(dto.getSchedule(), notification.getSchedule());
+        assertEquals(mainInfoDto.getTitle(), notification.getTitle());
+        assertEquals(mainInfoDto.getTitleEng(), notification.getTitleEng());
+        assertEquals(mainInfoDto.getType(), notification.getNotificationType());
+        assertEquals(mainInfoDto.getTrigger(), notification.getTrigger());
+        assertEquals(mainInfoDto.getTime(), notification.getTime());
+        assertEquals(mainInfoDto.getSchedule(), notification.getSchedule());
 
         assertEquals(platformDto.getBody(), platform.getBody());
         assertEquals(platformDto.getBodyEng(), platform.getBodyEng());


### PR DESCRIPTION
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)

## Code reviewers

- [x] @ABbondar 
- [x] @juseti 
- [x] @OlegVat 
- [x] @Markiro1  

## Summary of issue

dto for updating notifications must have the same fields as dto for receiving notifications by id

## Summary of change

1) fields (type, trigger, time, schedule, title, titleEng, notificationStatus) was replaced by NotificationTemplateMainInfoDto
2) changed utils methods in ModelUtils for 'core' and 'service' packages 
3) refactored code in NotificationTemplateServiceImpl and NotificationTemplateServiceImplTest classes

## Testing approach

ToDo

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions