### PR TITLE
Checking order status before adding violation #5391

### DIFF
--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -61,6 +61,8 @@ public final class ErrorMessage {
     public static final String ORDER_ALREADY_PAID = "Current order is already paid";
     public static final String VIOLATION_DOES_NOT_EXIST = "Violation does not exist for current order";
     public static final String ORDER_HAS_NOT_VIOLATION = "Order has not violation";
+    public static final String INCOMPATIBLE_ORDER_STATUS_FOR_VIOLATION =
+        "Cannot add a violation to order with this status: ";
     public static final String EVENTS_NOT_FOUND_EXCEPTION = "Events didn't find in order id: ";
     public static final String NOT_ENOUGH_BIG_BAGS_EXCEPTION = "Not enough big bags, minimal amount is:";
     public static final String NOTIFICATION_DOES_NOT_EXIST = "Notification does not exist";

--- a/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
@@ -5,6 +5,7 @@ import greencity.constant.OrderHistory;
 import greencity.dto.pageble.PageableDto;
 import greencity.dto.violation.*;
 import greencity.entity.user.employee.Employee;
+import greencity.enums.OrderStatus;
 import greencity.enums.SortingOrder;
 import greencity.enums.ViolationLevel;
 import greencity.entity.order.Order;
@@ -83,6 +84,10 @@ public class ViolationServiceImpl implements ViolationService {
         Order order = orderRepository.findById(add.getOrderID()).orElseThrow(() -> new NotFoundException(
             ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST));
         checkAvailableOrderForEmployee(order.getId(), email);
+        OrderStatus orderStatus = order.getOrderStatus();
+        if (orderStatus != OrderStatus.NOT_TAKEN_OUT && orderStatus != OrderStatus.DONE) {
+            throw new BadRequestException(INCOMPATIBLE_ORDER_STATUS_FOR_VIOLATION + orderStatus.name());
+        }
         if (violationRepository.findByOrderId(order.getId()).isEmpty()) {
             User user = order.getUser();
             Violation violation = violationBuilder(add, order, user);

--- a/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -115,13 +116,14 @@ class ViolationServiceImplTest {
         verify(employeeRepository, times(1)).findByUuid(anyString());
     }
 
-    @Test
-    void checkAddUserViolation() {
+    @ParameterizedTest
+    @EnumSource(value = OrderStatus.class, names = {"DONE", "NOT_TAKEN_OUT"})
+    void checkAddUserViolation(OrderStatus orderStatus) {
         Employee employee = ModelUtils.getEmployee();
         User user = ModelUtils.getTestUser();
         Order order = user.getOrders().get(0);
         order.setUser(user);
-        order.setOrderStatus(OrderStatus.DONE);
+        order.setOrderStatus(orderStatus);
         TariffsInfo tariffsInfo = ModelUtils.getTariffInfo();
         order.setTariffsInfo(tariffsInfo);
         AddingViolationsToUserDto add = ModelUtils.getAddingViolationsToUserDto();


### PR DESCRIPTION
# GreenCityUBS PR
_&lt;Checking order status before adding violation #5391&gt;_

## Summary Of Changes :fire:
_&lt;At the point when the user just creates an order and it is in the "Formed" status and not yet paid, if the user wants to cancel this order, it is completely removed from the database. At this point, at any status of the order, a violation can be added to it, which will result in a 500 error when trying to delete such an order from the database. To avoid this situation, allowable order statuses have been defined to which violations can be added, such as " Done" and "Not taken out".&gt;_

## Issue Link :clipboard:
_&lt;[Link to the issue](https://github.com/ita-social-projects/GreenCity/issues/5391)&gt;_

## Added
* _&lt;Checking order status before adding violation&gt;_

## Changed
* _&lt;Existing tests&gt;_

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
