### PR TITLE
Add new endpoint for deactivating notifications

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -132,6 +132,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 UBS_MANAG_LINK + "/save-reason/{id}",
                 ADMIN_EMPL_LINK + "/**",
                 ADMIN_LINK + "/notification/update-template/{id}",
+                ADMIN_LINK + "/notification/deactivate-template/{id}",
                 SUPER_ADMIN_LINK + "/update-courier",
                 SUPER_ADMIN_LINK + "/update-receiving-station",
                 SUPER_ADMIN_LINK + "/editTariffService/{id}",

--- a/core/src/main/java/greencity/controller/ManagementNotificationController.java
+++ b/core/src/main/java/greencity/controller/ManagementNotificationController.java
@@ -14,12 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
 
 import javax.validation.Valid;
@@ -88,5 +83,24 @@ public class ManagementNotificationController {
     public ResponseEntity<NotificationTemplateWithPlatformsDto> getNotificationTemplate(@PathVariable Long id) {
         return ResponseEntity.status(HttpStatus.OK)
             .body(notificationTemplateService.findById(id));
+    }
+
+    /**
+     * Controller that deactivate notification template and all platforms by id.
+     *
+     * @author Safarov Renat.
+     */
+    @ApiOperation(value = "Deactivate notification template by id")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = HttpStatuses.OK),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+    })
+    @PutMapping("/deactivate-template/{id}")
+    public ResponseEntity<HttpStatus> deactivateNotificationTemplate(@PathVariable Long id) {
+        notificationTemplateService.deactivateNotificationById(id);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/core/src/test/java/greencity/controller/ManagementNotificationControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementNotificationControllerTest.java
@@ -7,6 +7,7 @@ import greencity.configuration.SecurityConfig;
 import greencity.converters.UserArgumentResolver;
 import greencity.dto.notification.NotificationTemplateWithPlatformsUpdateDto;
 import greencity.exception.handler.CustomExceptionHandler;
+import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
 import greencity.service.notification.NotificationTemplateService;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
@@ -30,7 +30,10 @@ import java.security.Principal;
 import java.util.List;
 
 import static greencity.ModelUtils.getUuid;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,10 +64,10 @@ class ManagementNotificationControllerTest {
     void getAllTest() throws Exception {
         ObjectMapper objectMapper = new ObjectMapper();
         String responseJSON = objectMapper.writeValueAsString(List.of(ModelUtils.getNotificationTemplateDto()));
-        mockMvc.perform(MockMvcRequestBuilders.get(url + "/get-all-templates")
+        mockMvc.perform(get(url + "/get-all-templates")
             .content(responseJSON)
             .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(MockMvcResultMatchers.status().isOk());
+            .andExpect(status().isOk());
     }
 
     @Test
@@ -83,10 +86,10 @@ class ManagementNotificationControllerTest {
     void getNotificationTemplateTest() throws Exception {
         ObjectMapper objectMapper = new ObjectMapper();
         String responseJSON = objectMapper.writeValueAsString(ModelUtils.getNotificationTemplateWithPlatformsDto());
-        mockMvc.perform(MockMvcRequestBuilders.get(url + "/get-template/{id}", 1L)
+        mockMvc.perform(get(url + "/get-template/{id}", 1L)
             .content(responseJSON)
             .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(MockMvcResultMatchers.status().isOk());
+            .andExpect(status().isOk());
     }
 
     @Test
@@ -95,12 +98,48 @@ class ManagementNotificationControllerTest {
         NotificationTemplateWithPlatformsUpdateDto dto = ModelUtils.getNotificationTemplateWithPlatformsUpdateDto();
         Long id = 1L;
         String JsonDto = objectMapper.writeValueAsString(dto);
-        Mockito.doThrow(NotFoundException.class)
+        doThrow(NotFoundException.class)
             .when(notificationTemplateService).update(id, dto);
         mockMvc.perform(put(url + "/update-template/{id}", id)
             .principal(principal)
             .content(JsonDto)
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound());
+        verify(notificationTemplateService).update(id, dto);
+    }
+
+    @Test
+    void deactivateNotificationTemplate() throws Exception {
+        Long id = 1L;
+        mockMvc.perform(put(url + "/deactivate-template/{id}", id)
+            .principal(principal))
+            .andExpect(status().isOk());
+        verify(notificationTemplateService).deactivateNotificationById(id);
+    }
+
+    @Test
+    void deactivateNotificationTemplateBadRequestTest() throws Exception {
+        Long id = 1L;
+        doThrow(BadRequestException.class)
+            .when(notificationTemplateService).deactivateNotificationById(id);
+
+        mockMvc.perform(put(url + "/deactivate-template/{id}", id)
+            .principal(principal))
+            .andExpect(status().isBadRequest());
+
+        verify(notificationTemplateService).deactivateNotificationById(id);
+    }
+
+    @Test
+    void deactivateNotificationTemplateNotFoundTest() throws Exception {
+        Long id = 1L;
+        doThrow(NotFoundException.class)
+            .when(notificationTemplateService).deactivateNotificationById(id);
+
+        mockMvc.perform(MockMvcRequestBuilders.put(url + "/deactivate-template/{id}", id)
+            .principal(principal))
+            .andExpect(MockMvcResultMatchers.status().isNotFound());
+
+        verify(notificationTemplateService).deactivateNotificationById(id);
     }
 }

--- a/service-api/src/main/java/greencity/service/notification/NotificationTemplateService.java
+++ b/service-api/src/main/java/greencity/service/notification/NotificationTemplateService.java
@@ -27,4 +27,11 @@ public interface NotificationTemplateService {
      * @author Dima Sannytski
      */
     NotificationTemplateWithPlatformsDto findById(Long id);
+
+    /**
+     * Method that deactivate notification template and all platforms by id.
+     *
+     * @author Dima Sannytski
+     */
+    void deactivateNotificationById(Long id);
 }

--- a/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
@@ -22,8 +22,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static greencity.enums.NotificationStatus.INACTIVE;
+
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @AllArgsConstructor
 public class NotificationTemplateServiceImpl implements NotificationTemplateService {
     private NotificationTemplateRepository notificationTemplateRepository;
@@ -33,6 +35,7 @@ public class NotificationTemplateServiceImpl implements NotificationTemplateServ
      * {@inheritDoc}
      */
     @Override
+    @Transactional
     public void update(Long id, NotificationTemplateWithPlatformsUpdateDto dto) {
         NotificationTemplate template = getById(id);
 
@@ -92,6 +95,15 @@ public class NotificationTemplateServiceImpl implements NotificationTemplateServ
     @Override
     public NotificationTemplateWithPlatformsDto findById(Long id) {
         return modelMapper.map(getById(id), NotificationTemplateWithPlatformsDto.class);
+    }
+
+    @Override
+    @Transactional
+    public void deactivateNotificationById(Long id) {
+        var notificationTemplate = getById(id);
+        notificationTemplate.setNotificationStatus(INACTIVE);
+        notificationTemplate.getNotificationPlatforms()
+            .forEach(platform -> platform.setNotificationStatus(INACTIVE));
     }
 
     /**

--- a/service/src/test/java/greencity/service/notification/NotificationTemplateServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationTemplateServiceImplTest.java
@@ -1,6 +1,5 @@
 package greencity.service.notification;
 
-import greencity.ModelUtils;
 import greencity.constant.ErrorMessage;
 import greencity.dto.notification.NotificationTemplateDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsDto;
@@ -19,7 +18,14 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 import java.util.Optional;
 
+import static greencity.ModelUtils.TEST_NOTIFICATION_TEMPLATE;
+import static greencity.ModelUtils.TEST_NOTIFICATION_PAGEABLE;
+import static greencity.ModelUtils.TEMPLATE_PAGE;
+import static greencity.ModelUtils.TEST_NOTIFICATION_TEMPLATE_WITH_PLATFORMS_DTO;
+import static greencity.ModelUtils.TEST_NOTIFICATION_TEMPLATE_DTO;
+import static greencity.ModelUtils.TEST_NOTIFICATION_TEMPLATE_UPDATE_DTO;
 import static greencity.constant.ErrorMessage.NOTIFICATION_TEMPLATE_NOT_FOUND;
+import static greencity.enums.NotificationStatus.INACTIVE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -38,10 +44,10 @@ class NotificationTemplateServiceImplTest {
 
     @Test
     void findAll() {
-        Pageable pageable = ModelUtils.TEST_NOTIFICATION_PAGEABLE;
-        Page<NotificationTemplate> page = ModelUtils.TEMPLATE_PAGE;
-        var notification = ModelUtils.TEST_NOTIFICATION_TEMPLATE;
-        var notificationDto = ModelUtils.TEST_NOTIFICATION_TEMPLATE_DTO;
+        Pageable pageable = TEST_NOTIFICATION_PAGEABLE;
+        Page<NotificationTemplate> page = TEMPLATE_PAGE;
+        var notification = TEST_NOTIFICATION_TEMPLATE;
+        var notificationDto = TEST_NOTIFICATION_TEMPLATE_DTO;
 
         when(templateRepository.findAll(pageable)).thenReturn(page);
         when(modelMapper.map(notification, NotificationTemplateDto.class)).thenReturn(notificationDto);
@@ -60,10 +66,10 @@ class NotificationTemplateServiceImplTest {
     void updateTest() {
         Long id = 1L;
 
-        var dto = ModelUtils.TEST_NOTIFICATION_TEMPLATE_UPDATE_DTO;
+        var dto = TEST_NOTIFICATION_TEMPLATE_UPDATE_DTO;
         var platformDto = dto.getPlatforms().get(0);
 
-        var notification = ModelUtils.TEST_NOTIFICATION_TEMPLATE;
+        var notification = TEST_NOTIFICATION_TEMPLATE;
         var platform = notification.getNotificationPlatforms().get(0);
 
         when(templateRepository.findById(id)).thenReturn(Optional.of(notification));
@@ -88,7 +94,7 @@ class NotificationTemplateServiceImplTest {
     void updateThrowNotFoundExceptionForNotificationTemplateTest() {
         Long id = 1L;
 
-        var dto = ModelUtils.TEST_NOTIFICATION_TEMPLATE_UPDATE_DTO;
+        var dto = TEST_NOTIFICATION_TEMPLATE_UPDATE_DTO;
 
         when(templateRepository.findById(id)).thenReturn(Optional.empty());
 
@@ -102,10 +108,10 @@ class NotificationTemplateServiceImplTest {
     void updateThrowNotFoundExceptionForNotificationPlatform() {
         Long id = 1L;
 
-        var dto = ModelUtils.TEST_NOTIFICATION_TEMPLATE_UPDATE_DTO;
+        var dto = TEST_NOTIFICATION_TEMPLATE_UPDATE_DTO;
         dto.getPlatforms().get(0).setId(100L);
 
-        var notification = ModelUtils.TEST_NOTIFICATION_TEMPLATE;
+        var notification = TEST_NOTIFICATION_TEMPLATE;
 
         when(templateRepository.findById(id)).thenReturn(Optional.of(notification));
 
@@ -118,12 +124,12 @@ class NotificationTemplateServiceImplTest {
     @Test
     void findByIdTest() {
         Long id = 1L;
-        var notification = ModelUtils.TEST_NOTIFICATION_TEMPLATE;
+        var notification = TEST_NOTIFICATION_TEMPLATE;
 
         when(templateRepository.findById(id))
             .thenReturn(Optional.of(notification));
         when(modelMapper.map(notification, NotificationTemplateWithPlatformsDto.class))
-            .thenReturn(ModelUtils.TEST_NOTIFICATION_TEMPLATE_WITH_PLATFORMS_DTO);
+            .thenReturn(TEST_NOTIFICATION_TEMPLATE_WITH_PLATFORMS_DTO);
 
         notificationService.findById(id);
 
@@ -143,5 +149,34 @@ class NotificationTemplateServiceImplTest {
 
         verify(templateRepository).findById(id);
         verify(modelMapper, never()).map(any(), any());
+    }
+
+    @Test
+    void deactivateNotificationByIdTest() {
+        Long id = 1L;
+        var notificationTemplate = TEST_NOTIFICATION_TEMPLATE;
+
+        when(templateRepository.findById(id)).thenReturn(Optional.of(notificationTemplate));
+
+        notificationService.deactivateNotificationById(id);
+
+        assertEquals(INACTIVE, notificationTemplate.getNotificationStatus());
+        notificationTemplate.getNotificationPlatforms()
+            .forEach(platform -> assertEquals(INACTIVE, platform.getNotificationStatus()));
+
+        verify(templateRepository).findById(id);
+    }
+
+    @Test
+    void deactivateNotificationByIdThrowNotFoundExceptionTest() {
+        Long id = 1L;
+
+        when(templateRepository.findById(id)).thenReturn(Optional.empty());
+
+        var exception = assertThrows(
+            NotFoundException.class, () -> notificationService.deactivateNotificationById(id));
+        assertEquals(NOTIFICATION_TEMPLATE_NOT_FOUND, exception.getMessage());
+
+        verify(templateRepository).findById(id);
     }
 }


### PR DESCRIPTION
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)

## Code reviewers

- [x] @ABbondar 
- [x] @juseti 
- [x] @OlegVat 
- [x] @Markiro1 

## Summary of issue

Admin must be able to disable notifications for all platforms

## Summary of change

1) added new endpoint PUT "/deactivate-template/{id}" for deactivating notification
2) added new method deactivateNotificationById() in NotificationTemplateService 
3) added implementation of deactivateNotificationById() in NotificationTemplateServiceImpl 
4) added new endpoint in SecurityConfig
5) added test methods in NotificationTemplateServiceImplTest and ManagementNotificationControllerTest classes

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions