### PR TITLE
Change endpoint for deactivating notification

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementNotificationController.java
+++ b/core/src/main/java/greencity/controller/ManagementNotificationController.java
@@ -6,6 +6,7 @@ import greencity.dto.notification.NotificationTemplateDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsUpdateDto;
 import greencity.dto.pageble.PageableDto;
+import greencity.enums.NotificationStatus;
 import greencity.service.notification.NotificationTemplateService;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -86,11 +87,12 @@ public class ManagementNotificationController {
     }
 
     /**
-     * Controller that deactivate notification template and all platforms by id.
+     * Controller that change status for notification template and all platforms by
+     * id.
      *
      * @author Safarov Renat.
      */
-    @ApiOperation(value = "Deactivate notification template by id")
+    @ApiOperation(value = "Change notification template status by id")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK),
         @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
@@ -98,9 +100,10 @@ public class ManagementNotificationController {
         @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
         @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
-    @PutMapping("/deactivate-template/{id}")
-    public ResponseEntity<HttpStatus> deactivateNotificationTemplate(@PathVariable Long id) {
-        notificationTemplateService.deactivateNotificationById(id);
+    @PutMapping("/change-template-status/{id}")
+    public ResponseEntity<HttpStatus> deactivateNotificationTemplate(
+        @PathVariable Long id, @RequestParam String status) {
+        notificationTemplateService.changeNotificationStatusById(id, status);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/core/src/main/java/greencity/controller/ManagementNotificationController.java
+++ b/core/src/main/java/greencity/controller/ManagementNotificationController.java
@@ -6,7 +6,6 @@ import greencity.dto.notification.NotificationTemplateDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsUpdateDto;
 import greencity.dto.pageble.PageableDto;
-import greencity.enums.NotificationStatus;
 import greencity.service.notification.NotificationTemplateService;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;

--- a/core/src/test/java/greencity/controller/ManagementNotificationControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementNotificationControllerTest.java
@@ -30,6 +30,7 @@ import java.security.Principal;
 import java.util.List;
 
 import static greencity.ModelUtils.getUuid;
+import static greencity.enums.NotificationStatus.INACTIVE;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -111,35 +112,43 @@ class ManagementNotificationControllerTest {
     @Test
     void deactivateNotificationTemplate() throws Exception {
         Long id = 1L;
-        mockMvc.perform(put(url + "/deactivate-template/{id}", id)
+        String status = INACTIVE.name();
+        mockMvc.perform(put(url + "/change-template-status/{id}", id)
+            .param("status", status)
             .principal(principal))
             .andExpect(status().isOk());
-        verify(notificationTemplateService).deactivateNotificationById(id);
+        verify(notificationTemplateService).changeNotificationStatusById(id, status);
     }
 
     @Test
     void deactivateNotificationTemplateBadRequestTest() throws Exception {
         Long id = 1L;
-        doThrow(BadRequestException.class)
-            .when(notificationTemplateService).deactivateNotificationById(id);
+        String status = INACTIVE.name();
 
-        mockMvc.perform(put(url + "/deactivate-template/{id}", id)
+        doThrow(BadRequestException.class)
+            .when(notificationTemplateService).changeNotificationStatusById(id, status);
+
+        mockMvc.perform(put(url + "/change-template-status/{id}", id)
+            .param("status", status)
             .principal(principal))
             .andExpect(status().isBadRequest());
 
-        verify(notificationTemplateService).deactivateNotificationById(id);
+        verify(notificationTemplateService).changeNotificationStatusById(id, status);
     }
 
     @Test
     void deactivateNotificationTemplateNotFoundTest() throws Exception {
         Long id = 1L;
-        doThrow(NotFoundException.class)
-            .when(notificationTemplateService).deactivateNotificationById(id);
+        String status = INACTIVE.name();
 
-        mockMvc.perform(MockMvcRequestBuilders.put(url + "/deactivate-template/{id}", id)
+        doThrow(NotFoundException.class)
+            .when(notificationTemplateService).changeNotificationStatusById(id, status);
+
+        mockMvc.perform(MockMvcRequestBuilders.put(url + "/change-template-status/{id}", id)
+            .param("status", status)
             .principal(principal))
             .andExpect(MockMvcResultMatchers.status().isNotFound());
 
-        verify(notificationTemplateService).deactivateNotificationById(id);
+        verify(notificationTemplateService).changeNotificationStatusById(id, status);
     }
 }

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -66,6 +66,7 @@ public final class ErrorMessage {
     public static final String EVENTS_NOT_FOUND_EXCEPTION = "Events didn't find in order id: ";
     public static final String NOT_ENOUGH_BIG_BAGS_EXCEPTION = "Not enough big bags, minimal amount is:";
     public static final String NOTIFICATION_DOES_NOT_EXIST = "Notification does not exist";
+    public static final String NOTIFICATION_STATUS_DOES_NOT_EXIST = "Notification status does not exist ";
     public static final String NOTIFICATION_DOES_NOT_BELONG_TO_USER = "This notification does not belong to user";
     public static final String EMPLOYEE_ALREADY_ASSIGNED = "Manager already assigned with id: ";
     public static final String EMPLOYEE_DOESNT_EXIST = "Employee doesn't exist";
@@ -89,8 +90,8 @@ public final class ErrorMessage {
     public static final String SOME_CERTIFICATES_ARE_INVALID =
         "SOME CERTIFICATES ARE INVALID. A valid certificate is listed here";
     public static final String CERTIFICATE_NOT_FOUND = "CERTIFICATE_NOT_FOUND";
-    public static final String NOTIFICATION_TEMPLATE_NOT_FOUND = "Notification template doesn't exist";
-    public static final String NOTIFICATION_PLATFORM_NOT_FOUND = "Notification platform doesn't exist";
+    public static final String NOTIFICATION_TEMPLATE_NOT_FOUND_BY_ID = "Notification template not found by id: ";
+    public static final String NOTIFICATION_PLATFORM_NOT_FOUND = "Notification platform not found";
     public static final String LOCATION_ALREADY_EXIST = " that you try to add was already created early";
     public static final String INCORRECT_ECO_NUMBER = "Incorrect format of Eco number";
     public static final String COURIER_ALREADY_EXISTS = "Courier with this name already exists";

--- a/service-api/src/main/java/greencity/service/notification/NotificationTemplateService.java
+++ b/service-api/src/main/java/greencity/service/notification/NotificationTemplateService.java
@@ -4,34 +4,35 @@ import greencity.dto.notification.NotificationTemplateDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsUpdateDto;
 import greencity.dto.pageble.PageableDto;
+import greencity.enums.NotificationStatus;
 import org.springframework.data.domain.Pageable;
 
 public interface NotificationTemplateService {
     /**
      * Method that update notification template.
      *
-     * @author Dima Sannytski
+     * @author Safarov Renat
      */
     void update(Long id, NotificationTemplateWithPlatformsUpdateDto notificationDto);
 
     /**
      * Method that returns page with all notification templates.
      *
-     * @author Dima Sannytski
+     * @author Safarov Renat
      */
     PageableDto<NotificationTemplateDto> findAll(Pageable pageable);
 
     /**
      * Method that finds and returns notification template by id.
      *
-     * @author Dima Sannytski
+     * @author Safarov Renat
      */
     NotificationTemplateWithPlatformsDto findById(Long id);
 
     /**
-     * Method that deactivate notification template and all platforms by id.
+     * Method that change status for notification template and all platforms by id.
      *
-     * @author Dima Sannytski
+     * @author Safarov Renat
      */
-    void deactivateNotificationById(Long id);
+    void changeNotificationStatusById(Long id, String status);
 }

--- a/service-api/src/main/java/greencity/service/notification/NotificationTemplateService.java
+++ b/service-api/src/main/java/greencity/service/notification/NotificationTemplateService.java
@@ -4,7 +4,6 @@ import greencity.dto.notification.NotificationTemplateDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsUpdateDto;
 import greencity.dto.pageble.PageableDto;
-import greencity.enums.NotificationStatus;
 import org.springframework.data.domain.Pageable;
 
 public interface NotificationTemplateService {

--- a/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
@@ -8,6 +8,8 @@ import greencity.dto.notification.NotificationTemplateWithPlatformsUpdateDto;
 import greencity.dto.pageble.PageableDto;
 import greencity.entity.notifications.NotificationPlatform;
 import greencity.entity.notifications.NotificationTemplate;
+import greencity.enums.NotificationStatus;
+import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
 import greencity.repository.NotificationTemplateRepository;
 import lombok.AllArgsConstructor;
@@ -19,10 +21,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static greencity.enums.NotificationStatus.INACTIVE;
 
 @Service
 @Transactional(readOnly = true)
@@ -99,11 +100,20 @@ public class NotificationTemplateServiceImpl implements NotificationTemplateServ
 
     @Override
     @Transactional
-    public void deactivateNotificationById(Long id) {
+    public void changeNotificationStatusById(Long id, String status) {
+        checkIfNotificationStatusExists(status);
         var notificationTemplate = getById(id);
-        notificationTemplate.setNotificationStatus(INACTIVE);
+        var newStatus = NotificationStatus.valueOf(status);
+        notificationTemplate.setNotificationStatus(newStatus);
         notificationTemplate.getNotificationPlatforms()
-            .forEach(platform -> platform.setNotificationStatus(INACTIVE));
+            .forEach(platform -> platform.setNotificationStatus(newStatus));
+    }
+
+    private void checkIfNotificationStatusExists(String status) {
+        Arrays.stream(NotificationStatus.values())
+            .filter(s -> s.name().equals(status))
+            .findAny()
+            .orElseThrow(() -> new BadRequestException(ErrorMessage.NOTIFICATION_STATUS_DOES_NOT_EXIST + status));
     }
 
     /**
@@ -111,6 +121,6 @@ public class NotificationTemplateServiceImpl implements NotificationTemplateServ
      */
     private NotificationTemplate getById(Long id) {
         return notificationTemplateRepository.findById(id)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.NOTIFICATION_TEMPLATE_NOT_FOUND));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.NOTIFICATION_TEMPLATE_NOT_FOUND_BY_ID + id));
     }
 }

--- a/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
@@ -101,16 +101,15 @@ public class NotificationTemplateServiceImpl implements NotificationTemplateServ
     @Override
     @Transactional
     public void changeNotificationStatusById(Long id, String status) {
-        checkIfNotificationStatusExists(status);
+        var newStatus = getValidNotificationStatusByNameOrThrow(status);
         var notificationTemplate = getById(id);
-        var newStatus = NotificationStatus.valueOf(status);
         notificationTemplate.setNotificationStatus(newStatus);
         notificationTemplate.getNotificationPlatforms()
             .forEach(platform -> platform.setNotificationStatus(newStatus));
     }
 
-    private void checkIfNotificationStatusExists(String status) {
-        Arrays.stream(NotificationStatus.values())
+    private NotificationStatus getValidNotificationStatusByNameOrThrow(String status) {
+        return Arrays.stream(NotificationStatus.values())
             .filter(s -> s.name().equals(status))
             .findAny()
             .orElseThrow(() -> new BadRequestException(ErrorMessage.NOTIFICATION_STATUS_DOES_NOT_EXIST + status));

--- a/service/src/test/java/greencity/service/notification/NotificationTemplateServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationTemplateServiceImplTest.java
@@ -182,11 +182,12 @@ class NotificationTemplateServiceImplTest {
     @Test
     void changeNotificationStatusByIdThrowNotFoundExceptionTest() {
         Long id = 1L;
+        String newStatus = INACTIVE.toString();
 
         when(templateRepository.findById(id)).thenReturn(Optional.empty());
 
         var exception = assertThrows(
-            NotFoundException.class, () -> notificationService.changeNotificationStatusById(id, INACTIVE.name()));
+            NotFoundException.class, () -> notificationService.changeNotificationStatusById(id, newStatus));
         assertEquals(NOTIFICATION_TEMPLATE_NOT_FOUND_BY_ID + id, exception.getMessage());
 
         verify(templateRepository).findById(id);


### PR DESCRIPTION
## Code reviewers

- [ ] @Markiro1 
- [ ] @juseti 
- [ ] @BranetE 
- [ ] @ABbondar 
- [ ] @sergoliarnik 
- [ ] @OlegVat 
- [ ] @Maksym-Lenets 
- [ ] @MaksymGolik 
- [ ] @LiliaMokhnatska 

## Summary of issue

Admin needs to use one endpoint for activating/deactivating notification

## Summary of change

1) changed endpoint for deactivating the notification to change the notification status to the value from the request parameter
2) added request parameter 'status' in ManagementNotificationController 
3) added parameter 'status' in NotificationTemplateService and NotificationTemplateServiceImpl 
4) added logic for checking if new status exist
5) added new test method in NotificationTemplateServiceImplTest 
6) changed test methods in ManagementNotificationControllerTest 
7) added new error message "Notification status does not exist " in ErrorMessage and changed existing for NOTIFICATION_TEMPLATE_NOT_FOUND_BY_ID

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions