### PR TITLE
Change url for updating notification status in SecurityConfig

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -132,7 +132,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 UBS_MANAG_LINK + "/save-reason/{id}",
                 ADMIN_EMPL_LINK + "/**",
                 ADMIN_LINK + "/notification/update-template/{id}",
-                ADMIN_LINK + "/notification/deactivate-template/{id}",
+                ADMIN_LINK + "/notification/change-template-status/{id}",
                 SUPER_ADMIN_LINK + "/update-courier",
                 SUPER_ADMIN_LINK + "/update-receiving-station",
                 SUPER_ADMIN_LINK + "/editTariffService/{id}",


### PR DESCRIPTION
## Code reviewers

- [ ] @Maksym-Lenets 
- [ ] @MaksymGolik 
- [ ] @Markiro1 
- [ ] @LiliaMokhnatska 
- [ ] @sergoliarnik 
- [ ] @BranetE 
- [ ] @ABbondar 

## Summary of issue

We have outdated url for changing notification status in SecurityConfig class

## Summary of change

url '/notification/deactivate-template/{id}' has been replaced with '/notification/change-template-status/{id}'

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions