### PR TITLE
Changed regex in OrderResponseDto class for additionalOrders field to include 0 to 8 digits

### DIFF
--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -89,7 +89,7 @@ public class ModelUtils {
 
     public static OrderResponseDto getOrderResponseDto(boolean shouldBePaid) {
         return OrderResponseDto.builder()
-            .additionalOrders(new HashSet<>(List.of("232534634")))
+            .additionalOrders(new HashSet<>(List.of("12345678")))
             .bags(Collections.singletonList(new BagDto(3, 999)))
             .orderComment("comment")
             .certificates(Collections.emptySet())

--- a/service-api/src/main/java/greencity/dto/order/OrderResponseDto.java
+++ b/service-api/src/main/java/greencity/dto/order/OrderResponseDto.java
@@ -35,7 +35,7 @@ public class OrderResponseDto implements Serializable {
     private Set<@Pattern(regexp = "(\\d{4}-\\d{4})|(^$)",
         message = "This certificate code is not valid") String> certificates;
 
-    private Set<@Length(min = 3, max = 10) @Pattern(regexp = "[0-9]+") String> additionalOrders;
+    private Set<@Pattern(regexp = "\\d{0,8}") String> additionalOrders;
 
     @Length(max = 255)
     private String orderComment;


### PR DESCRIPTION
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)

## Code reviewers

- [ ] @Markiro1 
- [ ] @ABbondar 
- [ ] @Maksym-Lenets 
- [ ] @MaksymGolik 
- [ ] @juseti 
- [ ] @LiliaMokhnatska 
- [ ] @sergoliarnik 
- [ ] @BranetE 

### Second Level Review

- [ ] @github_username

## Summary of issue

Number of additional order must contains 0 to 8 digits

## Summary of change

Changed regex in PersonalDataDto class for additionalOrders field to include 0 to 8 digits

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions