### PR TITLE
Add payment details to the order without the mandatory information fix #4719

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -91,6 +91,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang.StringUtils;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -1295,7 +1296,8 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     @Override
     public ManualPaymentResponseDto saveNewManualPayment(Long orderId, ManualPaymentRequestDto paymentRequestDto,
         MultipartFile image, String email) {
-        if (paymentRequestDto.getImagePath().isBlank() && paymentRequestDto.getReceiptLink().isBlank()) {
+        if (StringUtils.isBlank(paymentRequestDto.getImagePath())
+            && StringUtils.isBlank(paymentRequestDto.getReceiptLink())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Receipt link or image must be present");
         }
         Order order = orderRepository.findById(orderId)

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1295,6 +1295,9 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     @Override
     public ManualPaymentResponseDto saveNewManualPayment(Long orderId, ManualPaymentRequestDto paymentRequestDto,
         MultipartFile image, String email) {
+        if(paymentRequestDto.getImagePath().isBlank() && paymentRequestDto.getReceiptLink().isBlank()){
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Receipt link or image must be present");
+        }
         Order order = orderRepository.findById(orderId)
             .orElseThrow(() -> new NotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST + orderId));
         checkAvailableOrderForEmployee(order, email);

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1295,7 +1295,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     @Override
     public ManualPaymentResponseDto saveNewManualPayment(Long orderId, ManualPaymentRequestDto paymentRequestDto,
         MultipartFile image, String email) {
-        if(paymentRequestDto.getImagePath().isBlank() && paymentRequestDto.getReceiptLink().isBlank()){
+        if (paymentRequestDto.getImagePath().isBlank() && paymentRequestDto.getReceiptLink().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Receipt link or image must be present");
         }
         Order order = orderRepository.findById(orderId)

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -30,7 +30,6 @@ import greencity.dto.order.UpdateOrderPageAdminDto;
 import greencity.dto.pageble.PageableDto;
 import greencity.dto.payment.ManualPaymentRequestDto;
 import greencity.dto.payment.PaymentInfoDto;
-import greencity.dto.payment.PaymentRequestDto;
 import greencity.dto.user.AddBonusesToUserDto;
 import greencity.dto.user.AddingPointsToUserDto;
 import greencity.dto.violation.ViolationsInfoDto;

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -2254,4 +2254,12 @@ class UBSManagementServiceImplTest {
         assertThrows(NotFoundException.class, () -> ubsManagementService.getNotTakenOrderReason(1L));
         verify(orderRepository).findById(1L);
     }
+
+    @Test
+    void saveNewManualPaymentWithoutLinkAndImageTest() {
+        ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
+            .settlementdate("02-08-2021").amount(500L).paymentId("1").build();
+        assertThrows(ResponseStatusException.class,
+            () -> ubsManagementService.saveNewManualPayment(1L, paymentDetails, null, "test@gmail.com"));
+    }
 }


### PR DESCRIPTION
# GreenCityUBS PR
_&lt;Add payment details to the order without the mandatory information fix #4719&gt;_

## Summary Of Changes :fire:
_&lt;Added checks for existing receipt link or image path in ManualPaymenetRequestDto for adding new manual payment by administrator&gt;_

## Issue Link :clipboard:
_&lt;[Link to the issue](https://github.com/ita-social-projects/GreenCity/issues/4719)&gt;_

## Added
* _&lt;conditions for checking the existence of the receipt link or/and image path&gt;_
* _&lt;Added new test cases&gt;_

## Changed
* _&lt;Existed tests&gt;_

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
