### PR TITLE
[UBS Tariffs Page] fix bug with tariff card activation when service is not defined #5743

### DIFF
--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -137,8 +137,6 @@ public final class ErrorMessage {
         + "deactivated.";
     public static final String BAG_FOR_TARIFF_NOT_EXIST = "Could not find bag with id %d for tariff with id %d";
     public static final String TARIFF_ALREADY_HAS_THIS_STATUS = "Tariff with id %d already has status: %s";
-    public static final String TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_SERVICE =
-        "Tariff has not been activated. Please add service for tariff.";
     public static final String TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_LIMITS =
         "Tariff has not been activated. Please set limits for tariff.";
     public static final String TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_BAGS =

--- a/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
@@ -746,9 +746,6 @@ public class SuperAdminServiceImpl implements SuperAdminService {
         if (tariffsInfo.getMin() == null && tariffsInfo.getMax() == null) {
             throw new BadRequestException(ErrorMessage.TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_LIMITS);
         }
-        if (tariffsInfo.getService() == null) {
-            throw new BadRequestException(ErrorMessage.TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_SERVICE);
-        }
     }
 
     @Override

--- a/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
@@ -1516,19 +1516,17 @@ class SuperAdminServiceImplTest {
     }
 
     @Test
-    void switchTariffStatusToActiveWithoutServiceThrowBadRequestException() {
+    void switchTariffStatusToActiveWithoutService() {
         TariffsInfo tariffInfo = ModelUtils.getTariffsInfoDeactivated();
         tariffInfo.setService(null);
 
         when(tariffsInfoRepository.findById(1L)).thenReturn(Optional.of(tariffInfo));
+        when(tariffsInfoRepository.save(tariffInfo)).thenReturn(tariffInfo);
 
-        Throwable t = assertThrows(BadRequestException.class,
-            () -> superAdminService.switchTariffStatus(1L, "Active"));
-        assertEquals(ErrorMessage.TARIFF_ACTIVATION_RESTRICTION_DUE_TO_UNSPECIFIED_SERVICE,
-            t.getMessage());
+        superAdminService.switchTariffStatus(1L, "Active");
 
         verify(tariffsInfoRepository).findById(1L);
-        verify(tariffsInfoRepository, never()).save(tariffInfo);
+        verify(tariffsInfoRepository).save(tariffInfo);
     }
 
     @Test


### PR DESCRIPTION
## Summary of issue

When the service is not defined for the tariff, a 400 response status appears with the error message: 'Tariff has not been activated. Please add service to tariff'.

Links to issues:
https://github.com/ita-social-projects/GreenCity/issues/5743
https://github.com/ita-social-projects/GreenCity/issues/5729

## Summary of change

Changed switchTariffStatus() in service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
Removed final field from service-api/src/main/java/greencity/constant/ErrorMessage.java
Changed test method in service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java

## Testing approach

1. Service is not defined for tariff.
2. Bags are defined for tariff.
3. Test switching status to active by endpoint /ubs/superAdmin/switchTariffStatus/{tariffId} in swagger.