### PR TITLE
[UBS Tariffs Page] The tariff card status isn't changed from active to blank when all the tariff services are deleted #5745

### DIFF
--- a/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
@@ -146,8 +146,20 @@ public class SuperAdminServiceImpl implements SuperAdminService {
     }
 
     @Override
-    public void deleteTariffService(Integer id) {
-        bagRepository.delete(tryToFindBagById(id));
+    public void deleteTariffService(Integer bagId) {
+        Bag bag = tryToFindBagById(bagId);
+        TariffsInfo tariffsInfo = bag.getTariffsInfo();
+        bagRepository.delete(bag);
+        List<Bag> bags = bagRepository.findBagsByTariffsInfoId(tariffsInfo.getId());
+        if (bags.isEmpty() || bags.stream().noneMatch(Bag::getLimitIncluded)) {
+            tariffsInfo.setTariffStatus(TariffStatus.NEW);
+            tariffsInfo.setBags(bags);
+            tariffsInfo.setMax(null);
+            tariffsInfo.setMin(null);
+            tariffsInfo.setLimitDescription(null);
+            tariffsInfo.setCourierLimit(CourierLimit.LIMIT_BY_SUM_OF_ORDER);
+            tariffsInfoRepository.save(tariffsInfo);
+        }
     }
 
     @Override

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2447,7 +2447,7 @@ public class ModelUtils {
             .build();
     }
 
-    public static Optional<Bag> getBag() {
+    public static Optional<Bag> getOptionalBag() {
         return Optional.of(Bag.builder()
             .id(1)
             .capacity(120)
@@ -2461,6 +2461,22 @@ public class ModelUtils {
             .descriptionEng("DescriptionEng")
             .limitIncluded(false)
             .build());
+    }
+
+    public static Bag getBag() {
+        return Bag.builder()
+            .id(1)
+            .capacity(120)
+            .commission(50)
+            .price(120)
+            .fullPrice(170)
+            .createdAt(LocalDate.now())
+            .createdBy(getEmployee())
+            .editedBy(getEmployee())
+            .description("Description")
+            .descriptionEng("DescriptionEng")
+            .limitIncluded(true)
+            .build();
     }
 
     public static TariffServiceDto getTariffServiceDto() {
@@ -3836,6 +3852,31 @@ public class ModelUtils {
             .createdAt(LocalDate.of(2022, 10, 20))
             .max(6000L)
             .min(500L)
+            .orders(Collections.emptyList())
+            .receivingStationList(Set.of(ReceivingStation.builder()
+                .id(1L)
+                .name("Петрівка")
+                .createdBy(ModelUtils.createEmployee())
+                .build()))
+            .build();
+    }
+
+    public static TariffsInfo getTariffsInfoWithStatusNew() {
+        return TariffsInfo.builder()
+            .id(1L)
+            .courierLimit(CourierLimit.LIMIT_BY_SUM_OF_ORDER)
+            .tariffLocations(Set.of(TariffLocation.builder()
+                .tariffsInfo(ModelUtils.getTariffInfoWithLimitOfBags())
+                .location(Location.builder().id(1L)
+                    .region(ModelUtils.getRegion())
+                    .nameUk("Київ")
+                    .nameEn("Kyiv")
+                    .coordinates(ModelUtils.getCoordinates())
+                    .build())
+                .build()))
+            .tariffStatus(TariffStatus.NEW)
+            .creator(ModelUtils.getEmployee())
+            .createdAt(LocalDate.of(2022, 10, 20))
             .orders(Collections.emptyList())
             .receivingStationList(Set.of(ReceivingStation.builder()
                 .id(1L)

--- a/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
@@ -188,7 +188,7 @@ class SuperAdminServiceImplTest {
 
     @Test
     void getTariffServiceTest() {
-        List<Bag> bags = List.of(ModelUtils.getBag().get());
+        List<Bag> bags = List.of(ModelUtils.getOptionalBag().get());
         GetTariffServiceDto dto = ModelUtils.getGetTariffServiceDto();
 
         when(tariffsInfoRepository.existsById(1L)).thenReturn(true);
@@ -214,15 +214,65 @@ class SuperAdminServiceImplTest {
     }
 
     @Test
-    void deleteTariffServiceTest() {
-        Optional<Bag> bag = ModelUtils.getBag();
-        when(bagRepository.findById(1)).thenReturn(bag);
+    void deleteTariffServiceWhenTariffBagsWithLimits() {
+        Bag bag = ModelUtils.getBag();
+        TariffsInfo tariffsInfo = ModelUtils.getTariffInfo();
+        bag.setTariffsInfo(tariffsInfo);
+
+        when(bagRepository.findById(1)).thenReturn(Optional.of(bag));
+        doNothing().when(bagRepository).delete(bag);
+        when(bagRepository.findBagsByTariffsInfoId(1L)).thenReturn(List.of(bag));
         superAdminService.deleteTariffService(1);
-        verify(bagRepository).delete(bag.get());
+        assertEquals(TariffStatus.ACTIVE, tariffsInfo.getTariffStatus());
+        verify(bagRepository).findById(1);
+        verify(bagRepository).delete(bag);
+        verify(bagRepository).findBagsByTariffsInfoId(1L);
+        verify(tariffsInfoRepository, never()).save(tariffsInfo);
     }
 
     @Test
-    void deleteTariffServiceThrowException() {
+    void deleteTariffServiceWhenTariffBagsListIsEmpty() {
+        Bag bag = ModelUtils.getBag();
+        TariffsInfo tariffsInfo = ModelUtils.getTariffInfo();
+        bag.setTariffsInfo(tariffsInfo);
+        TariffsInfo tariffsInfoNew = ModelUtils.getTariffsInfoWithStatusNew();
+        tariffsInfoNew.setBags(Collections.emptyList());
+
+        when(bagRepository.findById(1)).thenReturn(Optional.of(bag));
+        doNothing().when(bagRepository).delete(bag);
+        when(bagRepository.findBagsByTariffsInfoId(1L)).thenReturn(Collections.emptyList());
+        when(tariffsInfoRepository.save(tariffsInfo)).thenReturn(tariffsInfo);
+        superAdminService.deleteTariffService(1);
+        assertEquals(TariffStatus.NEW, tariffsInfoNew.getTariffStatus());
+        verify(bagRepository).findById(1);
+        verify(bagRepository).delete(bag);
+        verify(bagRepository).findBagsByTariffsInfoId(1L);
+        verify(tariffsInfoRepository).save(tariffsInfo);
+    }
+
+    @Test
+    void deleteTariffServiceWhenTariffBagsWithoutLimits() {
+        Bag bag = ModelUtils.getBag();
+        TariffsInfo tariffsInfo = ModelUtils.getTariffInfo();
+        bag.setLimitIncluded(false);
+        bag.setTariffsInfo(tariffsInfo);
+        TariffsInfo tariffsInfoNew = ModelUtils.getTariffsInfoWithStatusNew();
+        tariffsInfoNew.setBags(Collections.emptyList());
+
+        when(bagRepository.findById(1)).thenReturn(Optional.of(bag));
+        doNothing().when(bagRepository).delete(bag);
+        when(bagRepository.findBagsByTariffsInfoId(1L)).thenReturn(List.of(bag));
+        when(tariffsInfoRepository.save(tariffsInfo)).thenReturn(tariffsInfoNew);
+        superAdminService.deleteTariffService(1);
+        assertEquals(TariffStatus.NEW, tariffsInfoNew.getTariffStatus());
+        verify(bagRepository).findById(1);
+        verify(bagRepository).delete(bag);
+        verify(bagRepository).findBagsByTariffsInfoId(1L);
+        verify(tariffsInfoRepository).save(tariffsInfoNew);
+    }
+
+    @Test
+    void deleteTariffServiceThrowNotFoundException() {
         when(bagRepository.findById(1)).thenReturn(Optional.empty());
         assertThrows(NotFoundException.class,
             () -> superAdminService.deleteTariffService(1));
@@ -232,7 +282,7 @@ class SuperAdminServiceImplTest {
 
     @Test
     void editTariffService() {
-        Bag bag = ModelUtils.getBag().get();
+        Bag bag = ModelUtils.getBag();
         Employee employee = ModelUtils.getEmployee();
         TariffServiceDto dto = ModelUtils.getTariffServiceDto();
         GetTariffServiceDto editedDto = ModelUtils.getGetTariffServiceDto();
@@ -254,7 +304,7 @@ class SuperAdminServiceImplTest {
     @Test
     void editTariffServiceIfEmployeeNotFoundException() {
         TariffServiceDto dto = ModelUtils.getTariffServiceDto();
-        Optional<Bag> bag = ModelUtils.getBag();
+        Optional<Bag> bag = ModelUtils.getOptionalBag();
         String uuid = UUID.randomUUID().toString();
 
         when(bagRepository.findById(1)).thenReturn(bag);


### PR DESCRIPTION
## Summary of issue

The tariff card status isn't changed to blank but stays active when all the tariff services are deleted or tariff limits are not set.
Link to issue: https://github.com/ita-social-projects/GreenCity/issues/5745

## Summary of change

Changed deleteTariffService() in service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
Test methods added to service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java

## Testing approach

You should be authorized as Admin in  swagger.
Testing with endpoint /ubs/superAdmin/deleteTariffService/{id} in test cases: a) all the tariff services are deleted; b)  one service is deleted, and other services have no set limits; с)  one service is deleted and at least one of the other services has limits.