### PR TITLE
[UBS] - add new field to OrderStatusPageDto

### DIFF
--- a/service-api/src/main/java/greencity/dto/order/OrderStatusPageDto.java
+++ b/service-api/src/main/java/greencity/dto/order/OrderStatusPageDto.java
@@ -41,4 +41,5 @@ public class OrderStatusPageDto {
     private String comment;
     private Integer courierPricePerPackage;
     private CourierInfoDto courierInfo;
+    private Long writeOffStationSum;
 }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -382,6 +382,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             .comment(order.getComment())
             .courierPricePerPackage(servicePrice)
             .courierInfo(modelMapper.map(order.getTariffsInfo(), CourierInfoDto.class))
+            .writeOffStationSum(order.getWriteOffStationSum())
             .build();
     }
 


### PR DESCRIPTION
## Summary of issue

add one extra field "getWriteOffStationSum" and return it on endpoint [/ubs/management/get-data-for-order/{id}]

## Summary of change

- add new field in OrderStatusPageDto

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions