### PR TITLE
[UBS] Create endpoint to activate statuses by chosen parameters #5892

### DIFF
--- a/core/src/main/java/greencity/controller/SuperAdminController.java
+++ b/core/src/main/java/greencity/controller/SuperAdminController.java
@@ -724,7 +724,7 @@ class SuperAdminController {
      * @author Nikita Korzh, Julia Seti.
      */
     @ApiOperation(value = "Switch activation status by chosen parameters. "
-        + "In case of deactivation, the tariff is deactivated")
+        + "If the deactivation status is selected, the tariff will be deactivated")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK),
         @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),

--- a/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
+++ b/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
@@ -955,7 +955,7 @@ class SuperAdminControllerTest {
     }
 
     @Test
-    void deactivateTariffForChosenParamBadRequest() throws Exception {
+    void switchActivationStatusByChosenParamsBadRequest() throws Exception {
         mockMvc.perform(post(ubsLink + "/deactivate"))
             .andExpect(status().isBadRequest());
     }
@@ -971,11 +971,33 @@ class SuperAdminControllerTest {
             .citiesIds(citiesIds)
             .stationsIds(stationsIds)
             .courierId(courierId)
+            .activationStatus("Deactivated")
             .build();
 
-        mockMvc.perform(post(ubsLink + "/deactivate/")
-            .param("regionsIds", "1")).andExpect(status().isOk());
-        verify(superAdminService).deactivateTariffForChosenParam(details);
+        mockMvc.perform(post(ubsLink + "/deactivate")
+            .param("regionsIds", "1")
+            .param("status", "Deactivated")).andExpect(status().isOk());
+        verify(superAdminService).switchActivationStatusByChosenParams(details);
+    }
+
+    @Test
+    void activateTariffFotChosenParam() throws Exception {
+        Optional<List<Long>> regionsIds = Optional.of(List.of(1L));
+        Optional<List<Long>> citiesIds = Optional.empty();
+        Optional<List<Long>> stationsIds = Optional.empty();
+        Optional<Long> courierId = Optional.empty();
+        DetailsOfDeactivateTariffsDto details = DetailsOfDeactivateTariffsDto.builder()
+            .regionsIds(regionsIds)
+            .citiesIds(citiesIds)
+            .stationsIds(stationsIds)
+            .courierId(courierId)
+            .activationStatus("Active")
+            .build();
+
+        mockMvc.perform(post(ubsLink + "/deactivate")
+            .param("regionsIds", "1")
+            .param("status", "Active")).andExpect(status().isOk());
+        verify(superAdminService).switchActivationStatusByChosenParams(details);
     }
 
     @Test

--- a/dao/src/main/java/greencity/dto/DetailsOfDeactivateTariffsDto.java
+++ b/dao/src/main/java/greencity/dto/DetailsOfDeactivateTariffsDto.java
@@ -3,13 +3,12 @@ package greencity.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 import java.util.List;
 import java.util.Optional;
 
 @Data
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class DetailsOfDeactivateTariffsDto {
@@ -17,4 +16,6 @@ public class DetailsOfDeactivateTariffsDto {
     private Optional<List<Long>> citiesIds;
     private Optional<List<Long>> stationsIds;
     private Optional<Long> courierId;
+    @NonNull
+    private String activationStatus;
 }

--- a/dao/src/main/java/greencity/repository/LocationRepository.java
+++ b/dao/src/main/java/greencity/repository/LocationRepository.java
@@ -55,6 +55,18 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
     List<Location> findAllByIdAndRegionId(@Param("locIds") List<Long> locIds, @Param("regionId") Long regionId);
 
     /**
+     * Method for getting list of locations by region.
+     *
+     * @param regionId {@link Long} - id of region
+     * @return list of {@link Location}
+     * @author Julia Seti
+     */
+    @Query(nativeQuery = true,
+        value = "SELECT * from locations "
+            + "WHERE region_id = :regionId")
+    List<Location> findLocationsByRegionId(@Param("regionId") Long regionId);
+
+    /**
      * Method for finding out if the location already exists in the specified
      * region.
      *

--- a/dao/src/main/java/greencity/repository/LocationRepository.java
+++ b/dao/src/main/java/greencity/repository/LocationRepository.java
@@ -55,6 +55,21 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
     List<Location> findAllByIdAndRegionId(@Param("locIds") List<Long> locIds, @Param("regionId") Long regionId);
 
     /**
+     * Method for getting location from region.
+     *
+     * @param locationId - location id
+     * @param regionId   - region id
+     * @return {@link Optional} of {@link Location}
+     * @author Julia Seti
+     */
+    @Query(nativeQuery = true,
+        value = "SELECT * from locations "
+            + "WHERE region_id = :regionId "
+            + "AND id = :locationId")
+    Optional<Location> findLocationByIdAndRegionId(@Param("locationId") Long locationId,
+        @Param("regionId") Long regionId);
+
+    /**
      * Method for getting list of locations by region.
      *
      * @param regionId {@link Long} - id of region

--- a/dao/src/main/java/greencity/repository/TariffLocationRepository.java
+++ b/dao/src/main/java/greencity/repository/TariffLocationRepository.java
@@ -29,6 +29,20 @@ public interface TariffLocationRepository extends JpaRepository<TariffLocation, 
         @Param("status") String status);
 
     /**
+     * Method for updating tariffsLocation status by location ids.
+     *
+     * @param locationIds - list of location ids where status would be changed
+     * @param status      - status to set
+     * @author - Julia Seti
+     */
+    @Modifying
+    @Query(nativeQuery = true,
+        value = "UPDATE tariffs_locations SET location_status = :status "
+            + "WHERE location_id IN :locationIds ")
+    void changeTariffsLocationStatusByLocationIds(@Param("locationIds") List<Long> locationIds,
+        @Param("status") String status);
+
+    /**
      * Method for finding all TariffLocations where courier already works.
      *
      * @param courierId   - courier id

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -44,6 +44,7 @@ public final class ErrorMessage {
     public static final String POSITION_NOT_FOUND = "Position doesn't exist";
     public static final String RECEIVING_STATION_ALREADY_EXISTS = "Receiving station already exists: ";
     public static final String RECEIVING_STATION_NOT_FOUND_BY_ID = "Receiving station with current id doesn't exist: ";
+    public static final String REGION_NOT_FOUND_BY_ID = "Region with current id doesn't exist: ";
     public static final String RECEIVING_STATION_NOT_FOUND = "Receiving station doesn't exist.";
     public static final String EMPLOYEES_ASSIGNED_POSITION = "There are employees assigned to this position.";
     public static final String EMPLOYEE_WAS_NOT_SUCCESSFULLY_SAVED = "Employee was not successfully saved";
@@ -138,6 +139,8 @@ public final class ErrorMessage {
     public static final String TARIFF_EDIT_RESTRICTION_DUE_TO_DEACTIVATED_COURIER =
         "Tariff has not been edited. Courier deactivated with id: ";
     public static final String UNRESOLVABLE_TARIFF_STATUS = "Unresolvable tariff status. Please choose Active "
+        + "or Deactivated.";
+    public static final String UNRESOLVABLE_ACTIVATION_STATUS = "Unresolvable activation status. Please choose Active "
         + "or Deactivated.";
     public static final String COLUMN_WIDTH_INFO_NOT_FOUND =
         "There is no saved column width configuration for current employee";

--- a/service-api/src/main/java/greencity/service/SuperAdminService.java
+++ b/service-api/src/main/java/greencity/service/SuperAdminService.java
@@ -284,11 +284,11 @@ public interface SuperAdminService {
     void changeTariffLocationsStatus(Long tariffId, ChangeTariffLocationStatusDto dto, String param);
 
     /**
-     * Method that deactivate tariffs for chosen parameters.
+     * Method that switch activation status by chosen parameters.
      *
      * @param detailsOfDeactivateTariffsDto - contains list of regionsId, list of
-     *                                      citiesId, list of stationsId and
-     *                                      courierId.
+     *                                      citiesId, list of stationsId, courierId
+     *                                      and activation status.
      */
-    void deactivateTariffForChosenParam(DetailsOfDeactivateTariffsDto detailsOfDeactivateTariffsDto);
+    void switchActivationStatusByChosenParams(DetailsOfDeactivateTariffsDto detailsOfDeactivateTariffsDto);
 }

--- a/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
@@ -1248,12 +1248,6 @@ public class SuperAdminServiceImpl implements SuperAdminService {
         return false;
     }
 
-    private void checkIfReceivingStationsExist(List<Long> stationsIds) {
-        if (!deactivateTariffsForChosenParamRepository.isReceivingStationsExists(stationsIds)) {
-            throw new NotFoundException(String.format(RECEIVING_STATIONS_NOT_EXIST_MESSAGE, stationsIds));
-        }
-    }
-
     private void checkIfRegionsExist(List<Long> regionsIds) {
         if (!deactivateTariffsForChosenParamRepository.isRegionsExists(regionsIds)) {
             throw new NotFoundException(String.format(REGIONS_NOT_EXIST_MESSAGE, regionsIds));

--- a/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
@@ -834,29 +834,33 @@ public class SuperAdminServiceImpl implements SuperAdminService {
     }
 
     private void activateByChosenParam(DetailsOfDeactivateTariffsDto details) {
-        if (shouldActivateCourier(details)) {
+        if (details.getCourierId().isPresent() && shouldActivateCourier(details.getCourierId().get())) {
             Courier courier = tryToFindCourierById(details.getCourierId().get());
             courier.setCourierStatus(CourierStatus.ACTIVE);
             courierRepository.save(courier);
         }
 
-        if (shouldActivateReceivingStations(details)) {
+        if (details.getStationsIds().isPresent() && shouldActivateReceivingStations(details.getStationsIds().get())) {
             Set<ReceivingStation> stations = tryToFindReceivingStations(details.getStationsIds().get());
             receivingStationRepository.saveAll(updateReceivingStationsStatusToActive(stations));
         }
 
-        if (shouldActivateAllLocationsInRegions(details)) {
+        if (details.getRegionsIds().isPresent() && details.getCitiesIds().isEmpty()
+            && shouldActivateAllLocationsInRegions(details.getRegionsIds().get())) {
             for (Long regionId : details.getRegionsIds().get()) {
                 List<Location> locations = locationRepository.findLocationsByRegionId(regionId);
                 if (!locations.isEmpty()) {
                     saveLocationsWithActiveStatus(locations);
                 }
             }
-        } else if (shouldActivateFewLocationsInRegion(details)) {
+        } else if (details.getCitiesIds().isPresent() && details.getRegionsIds().isPresent()
+            && shouldActivateFewLocationsInRegion(details.getRegionsIds().get(), details.getCitiesIds().get())) {
             List<Location> locations = details.getCitiesIds().get().stream()
                 .map(this::tryToFindLocationById)
                 .collect(Collectors.toList());
             saveLocationsWithActiveStatus(locations);
+        } else if (details.getRegionsIds().isEmpty() && details.getCitiesIds().isPresent()) {
+            throw new BadRequestException(ENTER_A_REGION);
         }
     }
 
@@ -1199,7 +1203,19 @@ public class SuperAdminServiceImpl implements SuperAdminService {
     private boolean shouldDeactivateTariffsByRegionsAndCities(DetailsOfDeactivateTariffsDto details) {
         if (details.getRegionsIds().isPresent() && details.getCitiesIds().isPresent()
             && details.getStationsIds().isEmpty() && details.getCourierId().isEmpty()) {
-            return checkIfRegionAndCitiesExist(details.getRegionsIds().get(), details.getCitiesIds().get());
+            if (details.getRegionsIds().get().size() == 1) {
+                if (regionRepository.existsRegionById(details.getRegionsIds().get().get(0))
+                    && deactivateTariffsForChosenParamRepository.isCitiesExistForRegion(
+                        details.getCitiesIds().get(),
+                        details.getRegionsIds().get().get(0))) {
+                    return true;
+                } else {
+                    throw new NotFoundException(String.format(REGIONS_OR_CITIES_NOT_EXIST_MESSAGE,
+                        details.getRegionsIds().get(), details.getCitiesIds().get()));
+                }
+            } else {
+                throw new BadRequestException(BAD_SIZE_OF_REGIONS_MESSAGE);
+            }
         }
         return false;
     }
@@ -1225,53 +1241,29 @@ public class SuperAdminServiceImpl implements SuperAdminService {
         return false;
     }
 
-    private boolean shouldActivateCourier(DetailsOfDeactivateTariffsDto details) {
-        if (details.getCourierId().isPresent()) {
-            if (courierRepository.existsCourierById(details.getCourierId().get())) {
-                return true;
-            } else {
-                throw new NotFoundException(
-                    String.format(COURIER_NOT_EXISTS_MESSAGE, details.getCourierId().get()));
-            }
+    private boolean shouldActivateCourier(Long courierId) {
+        if (courierRepository.existsCourierById(courierId)) {
+            return true;
         }
-        return false;
+        throw new NotFoundException(String.format(COURIER_NOT_EXISTS_MESSAGE, courierId));
     }
 
-    private boolean shouldActivateReceivingStations(DetailsOfDeactivateTariffsDto details) {
-        if (details.getStationsIds().isPresent()) {
-            if (deactivateTariffsForChosenParamRepository
-                .isReceivingStationsExists(details.getStationsIds().get())) {
-                return true;
-            } else {
-                throw new NotFoundException(String.format(RECEIVING_STATIONS_NOT_EXIST_MESSAGE,
-                    details.getStationsIds().get()));
-            }
+    private boolean shouldActivateReceivingStations(List<Long> stationsIds) {
+        if (deactivateTariffsForChosenParamRepository
+            .isReceivingStationsExists(stationsIds)) {
+            return true;
         }
-        return false;
+        throw new NotFoundException(String.format(RECEIVING_STATIONS_NOT_EXIST_MESSAGE, stationsIds));
     }
 
-    private boolean shouldActivateAllLocationsInRegions(DetailsOfDeactivateTariffsDto details) {
-        if (details.getRegionsIds().isPresent() && details.getCitiesIds().isEmpty()) {
-            if (deactivateTariffsForChosenParamRepository.isRegionsExists(details.getRegionsIds().get())) {
-                return true;
-            } else {
-                throw new NotFoundException(String.format(
-                    REGIONS_NOT_EXIST_MESSAGE, details.getRegionsIds().get()));
-            }
+    private boolean shouldActivateAllLocationsInRegions(List<Long> regionsIds) {
+        if (deactivateTariffsForChosenParamRepository.isRegionsExists(regionsIds)) {
+            return true;
         }
-        return false;
+        throw new NotFoundException(String.format(REGIONS_NOT_EXIST_MESSAGE, regionsIds));
     }
 
-    private boolean shouldActivateFewLocationsInRegion(DetailsOfDeactivateTariffsDto details) {
-        if (details.getRegionsIds().isPresent() && details.getCitiesIds().isPresent()) {
-            return checkIfRegionAndCitiesExist(details.getRegionsIds().get(), details.getCitiesIds().get());
-        } else if (details.getRegionsIds().isEmpty() && details.getCitiesIds().isPresent()) {
-            throw new BadRequestException(ENTER_A_REGION);
-        }
-        return false;
-    }
-
-    private boolean checkIfRegionAndCitiesExist(List<Long> regionsIds, List<Long> citiesIds) {
+    private boolean shouldActivateFewLocationsInRegion(List<Long> regionsIds, List<Long> citiesIds) {
         if (regionsIds.size() == 1) {
             if (regionRepository.existsRegionById(regionsIds.get(0))
                 && deactivateTariffsForChosenParamRepository.isCitiesExistForRegion(citiesIds, regionsIds.get(0))) {

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2525,6 +2525,20 @@ public class ModelUtils {
             .build();
     }
 
+    public static Location getLocationDeactivated() {
+        return Location.builder()
+            .id(1L)
+            .locationStatus(LocationStatus.DEACTIVATED)
+            .nameEn("Kyiv")
+            .nameUk("Київ")
+            .coordinates(Coordinates.builder()
+                .longitude(3.34d)
+                .latitude(1.32d).build())
+            .region(getRegionForMapper())
+            .orderAddresses(new ArrayList<>())
+            .build();
+    }
+
     public static Courier getCourier() {
         return Courier.builder()
             .id(1L)
@@ -4141,6 +4155,7 @@ public class ModelUtils {
             .citiesIds(Optional.empty())
             .stationsIds(Optional.empty())
             .courierId(Optional.empty())
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4150,6 +4165,7 @@ public class ModelUtils {
             .citiesIds(Optional.empty())
             .stationsIds(Optional.empty())
             .courierId(Optional.empty())
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4159,6 +4175,7 @@ public class ModelUtils {
             .citiesIds(Optional.of(List.of(1L, 11L)))
             .stationsIds(Optional.empty())
             .courierId(Optional.empty())
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4168,6 +4185,7 @@ public class ModelUtils {
             .citiesIds(Optional.empty())
             .stationsIds(Optional.empty())
             .courierId(Optional.of(1L))
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4177,6 +4195,7 @@ public class ModelUtils {
             .citiesIds(Optional.empty())
             .stationsIds(Optional.of(List.of(1L, 12L)))
             .courierId(Optional.empty())
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4186,6 +4205,7 @@ public class ModelUtils {
             .citiesIds(Optional.empty())
             .stationsIds(Optional.of(List.of(1L, 12L)))
             .courierId(Optional.of(1L))
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4195,6 +4215,7 @@ public class ModelUtils {
             .citiesIds(Optional.empty())
             .stationsIds(Optional.empty())
             .courierId(Optional.of(1L))
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4204,6 +4225,7 @@ public class ModelUtils {
             .citiesIds(Optional.of(List.of(1L, 11L)))
             .stationsIds(Optional.of(List.of(1L, 12L)))
             .courierId(Optional.empty())
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4213,6 +4235,17 @@ public class ModelUtils {
             .citiesIds(Optional.of(List.of(1L, 11L)))
             .stationsIds(Optional.of(List.of(1L, 12L)))
             .courierId(Optional.of(1L))
+            .activationStatus("Deactivated")
+            .build();
+    }
+
+    public static DetailsOfDeactivateTariffsDto getDetailsOfDeactivateTariffsDtoWithStatusActive() {
+        return DetailsOfDeactivateTariffsDto.builder()
+            .regionsIds(Optional.of(List.of(1L)))
+            .citiesIds(Optional.of(List.of(1L)))
+            .stationsIds(Optional.of(List.of(1L)))
+            .courierId(Optional.of(1L))
+            .activationStatus("Active")
             .build();
     }
 
@@ -4222,6 +4255,7 @@ public class ModelUtils {
             .citiesIds(Optional.empty())
             .stationsIds(Optional.of(List.of(1L, 12L)))
             .courierId(Optional.empty())
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4231,6 +4265,7 @@ public class ModelUtils {
             .citiesIds(Optional.of(List.of(1L, 11L)))
             .stationsIds(Optional.empty())
             .courierId(Optional.of(1L))
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4240,6 +4275,7 @@ public class ModelUtils {
             .citiesIds(Optional.empty())
             .stationsIds(Optional.of(List.of(1L, 12L)))
             .courierId(Optional.of(1L))
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4249,6 +4285,7 @@ public class ModelUtils {
             .citiesIds(Optional.of(List.of(1L, 11L)))
             .stationsIds(Optional.empty())
             .courierId(Optional.empty())
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4258,6 +4295,7 @@ public class ModelUtils {
             .citiesIds(Optional.of(List.of(1L, 11L)))
             .stationsIds(Optional.empty())
             .courierId(Optional.of(1L))
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4267,6 +4305,7 @@ public class ModelUtils {
             .citiesIds(Optional.of(List.of(1L, 11L)))
             .stationsIds(Optional.of(List.of(1L, 12L)))
             .courierId(Optional.empty())
+            .activationStatus("Deactivated")
             .build();
     }
 
@@ -4276,6 +4315,7 @@ public class ModelUtils {
             .citiesIds(Optional.of(List.of(1L, 11L)))
             .stationsIds(Optional.of(List.of(1L, 12L)))
             .courierId(Optional.of(1L))
+            .activationStatus("Deactivated")
             .build();
     }
 

--- a/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
@@ -1804,8 +1804,6 @@ class SuperAdminServiceImplTest {
 
         when(regionRepository.existsRegionById(anyLong())).thenReturn(true);
         when(deactivateTariffsForChosenParamRepository.isCitiesExistForRegion(anyList(), anyLong())).thenReturn(true);
-        when(courierRepository.existsCourierById(anyLong())).thenReturn(true);
-        when(deactivateTariffsForChosenParamRepository.isReceivingStationsExists(anyList())).thenReturn(true);
         when(locationRepository.findById(1L)).thenReturn(Optional.of(location));
         when(locationRepository.saveAll(List.of(location))).thenReturn(List.of(location));
         when(courierRepository.findById(1L)).thenReturn(Optional.of(courier));
@@ -1819,8 +1817,6 @@ class SuperAdminServiceImplTest {
 
         verify(regionRepository).existsRegionById(anyLong());
         verify(deactivateTariffsForChosenParamRepository).isCitiesExistForRegion(anyList(), anyLong());
-        verify(courierRepository).existsCourierById(1L);
-        verify(deactivateTariffsForChosenParamRepository).isReceivingStationsExists(anyList());
         verify(locationRepository).findById(anyLong());
         verify(locationRepository).saveAll(List.of(location));
         verify(tariffsLocationRepository)
@@ -2048,11 +2044,9 @@ class SuperAdminServiceImplTest {
         details.setActivationStatus("Active");
         Courier courier = ModelUtils.getCourier();
 
-        when(courierRepository.existsCourierById(anyLong())).thenReturn(true);
         when(courierRepository.findById(1L)).thenReturn(Optional.of(courier));
         when(courierRepository.save(courier)).thenReturn(courier);
         superAdminService.switchActivationStatusByChosenParams(details);
-        verify(courierRepository).existsCourierById(1L);
         verify(courierRepository).findById(1L);
         verify(courierRepository).save(courier);
     }
@@ -2073,22 +2067,9 @@ class SuperAdminServiceImplTest {
         DetailsOfDeactivateTariffsDto details = ModelUtils.getDetailsOfDeactivateTariffsDtoWithCourier();
         details.setActivationStatus("Active");
 
-        when(courierRepository.existsCourierById(anyLong())).thenReturn(false);
-        assertThrows(NotFoundException.class,
-            () -> superAdminService.switchActivationStatusByChosenParams(details));
-        verify(courierRepository).existsCourierById(1L);
-    }
-
-    @Test
-    void switchCourierStatusToActiveNotExistingCourierThrows2() {
-        DetailsOfDeactivateTariffsDto details = ModelUtils.getDetailsOfDeactivateTariffsDtoWithCourier();
-        details.setActivationStatus("Active");
-
-        when(courierRepository.existsCourierById(anyLong())).thenReturn(true);
         when(courierRepository.findById(anyLong())).thenReturn(Optional.empty());
         assertThrows(NotFoundException.class,
             () -> superAdminService.switchActivationStatusByChosenParams(details));
-        verify(courierRepository).existsCourierById(1L);
         verify(courierRepository).findById(anyLong());
     }
 
@@ -2110,13 +2091,11 @@ class SuperAdminServiceImplTest {
         ReceivingStation receivingStation2 = ModelUtils.getReceivingStation();
         receivingStation2.setId(12L);
 
-        when(deactivateTariffsForChosenParamRepository.isReceivingStationsExists(anyList())).thenReturn(true);
         when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(receivingStation1));
         when(receivingStationRepository.findById(12L)).thenReturn(Optional.of(receivingStation2));
         when(receivingStationRepository.saveAll(List.of(receivingStation1, receivingStation2)))
             .thenReturn(List.of(receivingStation1, receivingStation2));
         superAdminService.switchActivationStatusByChosenParams(details);
-        verify(deactivateTariffsForChosenParamRepository).isReceivingStationsExists(List.of(1L, 12L));
         verify(receivingStationRepository, times(2)).findById(anyLong());
         verify(receivingStationRepository).saveAll(anyList());
     }
@@ -2137,22 +2116,9 @@ class SuperAdminServiceImplTest {
         DetailsOfDeactivateTariffsDto details = ModelUtils.getDetailsOfDeactivateTariffsDtoWithReceivingStations();
         details.setActivationStatus("Active");
 
-        when(deactivateTariffsForChosenParamRepository.isReceivingStationsExists(anyList())).thenReturn(false);
-        assertThrows(NotFoundException.class,
-            () -> superAdminService.switchActivationStatusByChosenParams(details));
-        verify(deactivateTariffsForChosenParamRepository).isReceivingStationsExists(List.of(1L, 12L));
-    }
-
-    @Test
-    void switchReceivingStationsStatusToActiveNotExistingReceivingStationsThrows2() {
-        DetailsOfDeactivateTariffsDto details = ModelUtils.getDetailsOfDeactivateTariffsDtoWithReceivingStations();
-        details.setActivationStatus("Active");
-
-        when(deactivateTariffsForChosenParamRepository.isReceivingStationsExists(anyList())).thenReturn(true);
         when(receivingStationRepository.findById(anyLong())).thenReturn(Optional.empty());
         assertThrows(NotFoundException.class,
             () -> superAdminService.switchActivationStatusByChosenParams(details));
-        verify(deactivateTariffsForChosenParamRepository).isReceivingStationsExists(List.of(1L, 12L));
         verify(receivingStationRepository).findById(anyLong());
     }
 

--- a/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
@@ -1892,6 +1892,19 @@ class SuperAdminServiceImplTest {
     }
 
     @Test
+    void switchLocationStatusToActiveByRegionWithoutLocation() {
+        DetailsOfDeactivateTariffsDto details = ModelUtils.getDetailsOfDeactivateTariffsDtoWithRegion();
+        details.setActivationStatus("Active");
+
+        when(deactivateTariffsForChosenParamRepository.isRegionsExists(anyList())).thenReturn(true);
+        when(locationRepository.findLocationsByRegionId(1L)).thenReturn(Collections.emptyList());
+        superAdminService.switchActivationStatusByChosenParams(details);
+        verify(deactivateTariffsForChosenParamRepository).isRegionsExists(anyList());
+        verify(locationRepository).findLocationsByRegionId(1L);
+        verify(locationRepository, never()).saveAll(anyList());
+    }
+
+    @Test
     void deactivateTariffByNotExistingRegionThrows() {
         DetailsOfDeactivateTariffsDto details = ModelUtils.getDetailsOfDeactivateTariffsDtoWithRegion();
 
@@ -1999,6 +2012,16 @@ class SuperAdminServiceImplTest {
     void switchLocationStatusToActiveByCitiesAndNotExistingRegionBadRequestException() {
         DetailsOfDeactivateTariffsDto details = ModelUtils.getDetailsOfDeactivateTariffsDtoWithRegionAndCities();
         details.setRegionsIds(Optional.empty());
+        details.setActivationStatus("Active");
+
+        assertThrows(BadRequestException.class,
+            () -> superAdminService.switchActivationStatusByChosenParams(details));
+    }
+
+    @Test
+    void switchLocationStatusToActiveByCitiesAndTwoRegionsBadRequestException() {
+        DetailsOfDeactivateTariffsDto details = ModelUtils.getDetailsOfDeactivateTariffsDtoWithRegionAndCities();
+        details.setRegionsIds(Optional.of(List.of(1L, 2L)));
         details.setActivationStatus("Active");
 
         assertThrows(BadRequestException.class,

--- a/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
@@ -1802,9 +1802,8 @@ class SuperAdminServiceImplTest {
         Courier courier = ModelUtils.getCourier();
         ReceivingStation receivingStation = ModelUtils.getReceivingStation();
 
-        when(regionRepository.existsRegionById(anyLong())).thenReturn(true);
-        when(deactivateTariffsForChosenParamRepository.isCitiesExistForRegion(anyList(), anyLong())).thenReturn(true);
-        when(locationRepository.findById(1L)).thenReturn(Optional.of(location));
+        when(deactivateTariffsForChosenParamRepository.isRegionsExists(anyList())).thenReturn(true);
+        when(locationRepository.findLocationByIdAndRegionId(1L, 1L)).thenReturn(Optional.of(location));
         when(locationRepository.saveAll(List.of(location))).thenReturn(List.of(location));
         when(courierRepository.findById(1L)).thenReturn(Optional.of(courier));
         when(courierRepository.save(courier)).thenReturn(courier);
@@ -1815,9 +1814,8 @@ class SuperAdminServiceImplTest {
 
         superAdminService.switchActivationStatusByChosenParams(details);
 
-        verify(regionRepository).existsRegionById(anyLong());
-        verify(deactivateTariffsForChosenParamRepository).isCitiesExistForRegion(anyList(), anyLong());
-        verify(locationRepository).findById(anyLong());
+        verify(deactivateTariffsForChosenParamRepository).isRegionsExists(anyList());
+        verify(locationRepository).findLocationByIdAndRegionId(1L, 1L);
         verify(locationRepository).saveAll(List.of(location));
         verify(tariffsLocationRepository)
             .changeTariffsLocationStatusByLocationIds(List.of(1L), LocationStatus.ACTIVE.name());
@@ -1949,18 +1947,18 @@ class SuperAdminServiceImplTest {
         Location locationActive2 = ModelUtils.getLocation();
         locationActive2.setId(11L);
 
-        when(regionRepository.existsRegionById(anyLong())).thenReturn(true);
-        when(deactivateTariffsForChosenParamRepository.isCitiesExistForRegion(anyList(), anyLong())).thenReturn(true);
-        when(locationRepository.findById(1L)).thenReturn(Optional.of(locationDeactivated1));
-        when(locationRepository.findById(11L)).thenReturn(Optional.of(locationDeactivated2));
+        when(deactivateTariffsForChosenParamRepository.isRegionsExists(anyList())).thenReturn(true);
+        when(locationRepository.findLocationByIdAndRegionId(1L, 1L))
+            .thenReturn(Optional.of(locationDeactivated1));
+        when(locationRepository.findLocationByIdAndRegionId(11L, 1L))
+            .thenReturn(Optional.of(locationDeactivated2));
         when(locationRepository.saveAll(List.of(locationActive1, locationActive2)))
             .thenReturn(List.of(locationActive1, locationActive2));
         doNothing().when(tariffsLocationRepository)
             .changeTariffsLocationStatusByLocationIds(List.of(1L, 11L), LocationStatus.ACTIVE.name());
         superAdminService.switchActivationStatusByChosenParams(details);
-        verify(regionRepository).existsRegionById(anyLong());
-        verify(deactivateTariffsForChosenParamRepository).isCitiesExistForRegion(anyList(), anyLong());
-        verify(locationRepository, times(2)).findById(anyLong());
+        verify(deactivateTariffsForChosenParamRepository).isRegionsExists(anyList());
+        verify(locationRepository, times(2)).findLocationByIdAndRegionId(anyLong(), anyLong());
         verify(locationRepository).saveAll(List.of(locationActive1, locationActive2));
         verify(tariffsLocationRepository)
             .changeTariffsLocationStatusByLocationIds(List.of(1L, 11L), LocationStatus.ACTIVE.name());
@@ -1985,27 +1983,12 @@ class SuperAdminServiceImplTest {
         DetailsOfDeactivateTariffsDto details = ModelUtils.getDetailsOfDeactivateTariffsDtoWithRegionAndCities();
         details.setActivationStatus("Active");
 
-        when(regionRepository.existsRegionById(anyLong())).thenReturn(true);
-        when(deactivateTariffsForChosenParamRepository.isCitiesExistForRegion(anyList(), anyLong())).thenReturn(false);
+        when(deactivateTariffsForChosenParamRepository.isRegionsExists(anyList())).thenReturn(true);
+        when(locationRepository.findLocationByIdAndRegionId(anyLong(), anyLong())).thenReturn(Optional.empty());
         assertThrows(NotFoundException.class,
             () -> superAdminService.switchActivationStatusByChosenParams(details));
-        verify(regionRepository).existsRegionById(1L);
-        verify(deactivateTariffsForChosenParamRepository).isCitiesExistForRegion(List.of(1L, 11L), 1L);
-    }
-
-    @Test
-    void switchLocationStatusToActiveByRegionAndNotExistingCitiesThrows2() {
-        DetailsOfDeactivateTariffsDto details = ModelUtils.getDetailsOfDeactivateTariffsDtoWithRegionAndCities();
-        details.setActivationStatus("Active");
-
-        when(regionRepository.existsRegionById(anyLong())).thenReturn(true);
-        when(deactivateTariffsForChosenParamRepository.isCitiesExistForRegion(anyList(), anyLong())).thenReturn(true);
-        when(locationRepository.findById(anyLong())).thenReturn(Optional.empty());
-        assertThrows(NotFoundException.class,
-            () -> superAdminService.switchActivationStatusByChosenParams(details));
-        verify(regionRepository).existsRegionById(1L);
-        verify(deactivateTariffsForChosenParamRepository).isCitiesExistForRegion(List.of(1L, 11L), 1L);
-        verify(locationRepository).findById(anyLong());
+        verify(deactivateTariffsForChosenParamRepository).isRegionsExists(anyList());
+        verify(locationRepository).findLocationByIdAndRegionId(anyLong(), anyLong());
     }
 
     @Test
@@ -2045,10 +2028,10 @@ class SuperAdminServiceImplTest {
         DetailsOfDeactivateTariffsDto details = ModelUtils.getDetailsOfDeactivateTariffsDtoWithRegionAndCities();
         details.setActivationStatus("Active");
 
-        when(regionRepository.existsRegionById(anyLong())).thenReturn(false);
+        when(deactivateTariffsForChosenParamRepository.isRegionsExists(anyList())).thenReturn(false);
         assertThrows(NotFoundException.class,
             () -> superAdminService.switchActivationStatusByChosenParams(details));
-        verify(regionRepository).existsRegionById(1L);
+        verify(deactivateTariffsForChosenParamRepository).isRegionsExists(anyList());
     }
 
     @Test


### PR DESCRIPTION
## Summary of issue

The endpoint should be created to activate courier, locations and receiving stations by ids.

## Link to issue

https://github.com/ita-social-projects/GreenCity/issues/5892

## Changed

- deactivateTariffForChosenParam() renamed to switchActivationStatusByChosenParams() in SuperAdminController
- some test methods

## Added

- activationStatus field to DetailsOfDeactivateTariffsDto
- findLocationsByRegionId() and findLocationByIdAndRegionId() methods to LocationRepository
- changeTariffsLocationStatusByLocationIds() method to TariffLocationRepository
- error message to ErrorMessage
- switchActivationStatusByChosenParams() method to SuperAdminService and its implementation to SuperAdminServiceImpl
- test methods

## Testing approach
Tested with different params in swagger by /ubs/superAdmin/deactivate endpoint
