### PR TITLE
#5881 half paid orders autonotations failure

### DIFF
--- a/dao/src/main/java/greencity/repository/UserNotificationRepository.java
+++ b/dao/src/main/java/greencity/repository/UserNotificationRepository.java
@@ -23,18 +23,12 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
     Page<UserNotification> findAllByUser(User user, Pageable pageable);
 
     /**
-     * The method returns last notification by {@link NotificationType} and
-     * orderNumber from
-     * {@link greencity.entity.notifications.NotificationParameter}.
+     * The method returns last notification by {@link NotificationType} and orderId.
      *
      * @return {@link Optional} of {@link UserNotification}.
      */
-    @Query(nativeQuery = true, value = "select * from user_notifications "
-        + "join notification_parameters np on user_notifications.id = np.notification_id "
-        + "where notification_type = :type and np.key = 'orderNumber' and np.value = :orderNumber "
-        + "order by notification_time desc "
-        + "limit 1;")
-    Optional<UserNotification> findLastNotificationByNotificationTypeAndOrderNumber(String type, String orderNumber);
+    Optional<UserNotification> findFirstByOrderIdAndNotificationTypeInOrderByNotificationTimeDesc(Long orderId,
+        NotificationType... notificationType);
 
     /**
      * Method that returns amount unread notifications.

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -83,8 +83,8 @@ public class NotificationServiceImpl implements NotificationService {
     public void notifyUnpaidOrders() {
         for (Order order : orderRepository.findAllByOrderPaymentStatus(OrderPaymentStatus.UNPAID)) {
             Optional<UserNotification> lastNotification = userNotificationRepository
-                .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
-                    order.getId().toString());
+                .findFirstByOrderIdAndNotificationTypeInOrderByNotificationTimeDesc(order.getId(),
+                    NotificationType.UNPAID_ORDER);
             if (checkIfUnpaidOrderNeedsNewNotification(order, lastNotification)) {
                 UserNotification userNotification = new UserNotification();
                 userNotification.setUser(order.getUser());
@@ -271,9 +271,11 @@ public class NotificationServiceImpl implements NotificationService {
     public void notifyAllHalfPaidPackages() {
         for (Order order : orderRepository.findAllByOrderPaymentStatus(OrderPaymentStatus.HALF_PAID)) {
             Optional<UserNotification> lastNotification = userNotificationRepository
-                .findLastNotificationByNotificationTypeAndOrderNumber(
-                    NotificationType.UNPAID_PACKAGE.toString(),
-                    order.getId().toString());
+                .findFirstByOrderIdAndNotificationTypeInOrderByNotificationTimeDesc(
+                    order.getId(),
+                    NotificationType.UNPAID_PACKAGE,
+                    NotificationType.HALF_PAID_ORDER_WITH_STATUS_BROUGHT_BY_HIMSELF,
+                    NotificationType.DONE_OR_CANCELED_UNPAID_ORDER);
             if (checkIfHalfPaidPackageNeedsNotification(order, lastNotification)) {
                 notifyHalfPaidPackage(order);
             }

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -124,20 +124,20 @@ class NotificationServiceImplTest {
                 .thenReturn(orders);
 
             doReturn(Optional.empty()).when(userNotificationRepository)
-                .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
-                    orders.get(0).getId().toString());
+                .findFirstByOrderIdAndNotificationTypeInOrderByNotificationTimeDesc(orders.get(0).getId(),
+                    NotificationType.UNPAID_ORDER);
 
             doReturn(Optional.empty()).when(userNotificationRepository)
-                .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
-                    orders.get(1).getId().toString());
+                .findFirstByOrderIdAndNotificationTypeInOrderByNotificationTimeDesc(orders.get(1).getId(),
+                    NotificationType.UNPAID_ORDER);
 
             UserNotification thirdOrderLastNotification = new UserNotification();
             thirdOrderLastNotification.setNotificationType(NotificationType.UNPAID_ORDER);
             thirdOrderLastNotification.setNotificationTime(LocalDateTime.now(fixedClock).minusWeeks(1));
 
             doReturn(Optional.of(thirdOrderLastNotification)).when(userNotificationRepository)
-                .findLastNotificationByNotificationTypeAndOrderNumber(NotificationType.UNPAID_ORDER.toString(),
-                    orders.get(2).getId().toString());
+                .findFirstByOrderIdAndNotificationTypeInOrderByNotificationTimeDesc(orders.get(2).getId(),
+                    NotificationType.UNPAID_ORDER);
 
             UserNotification created = new UserNotification();
             created.setNotificationType(NotificationType.UNPAID_ORDER);
@@ -366,17 +366,23 @@ class NotificationServiceImplTest {
             notification.setOrder(orders.get(0));
             notification.setNotificationTime(LocalDateTime.now(fixedClock).minusWeeks(2));
 
-            when(userNotificationRepository.findLastNotificationByNotificationTypeAndOrderNumber(
-                NotificationType.UNPAID_PACKAGE.toString(),
-                orders.get(0).getId().toString())).thenReturn(Optional.of(notification));
+            when(userNotificationRepository.findFirstByOrderIdAndNotificationTypeInOrderByNotificationTimeDesc(
+                orders.get(0).getId(),
+                NotificationType.UNPAID_PACKAGE,
+                NotificationType.HALF_PAID_ORDER_WITH_STATUS_BROUGHT_BY_HIMSELF,
+                NotificationType.DONE_OR_CANCELED_UNPAID_ORDER)).thenReturn(Optional.of(notification));
 
-            when(userNotificationRepository.findLastNotificationByNotificationTypeAndOrderNumber(
-                NotificationType.UNPAID_PACKAGE.toString(),
-                orders.get(1).getId().toString())).thenReturn(Optional.empty());
+            when(userNotificationRepository.findFirstByOrderIdAndNotificationTypeInOrderByNotificationTimeDesc(
+                orders.get(1).getId(),
+                NotificationType.UNPAID_PACKAGE,
+                NotificationType.HALF_PAID_ORDER_WITH_STATUS_BROUGHT_BY_HIMSELF,
+                NotificationType.DONE_OR_CANCELED_UNPAID_ORDER)).thenReturn(Optional.empty());
 
-            when(userNotificationRepository.findLastNotificationByNotificationTypeAndOrderNumber(
-                NotificationType.UNPAID_PACKAGE.toString(),
-                orders.get(2).getId().toString())).thenReturn(Optional.empty());
+            when(userNotificationRepository.findFirstByOrderIdAndNotificationTypeInOrderByNotificationTimeDesc(
+                orders.get(2).getId(),
+                NotificationType.UNPAID_PACKAGE,
+                NotificationType.HALF_PAID_ORDER_WITH_STATUS_BROUGHT_BY_HIMSELF,
+                NotificationType.DONE_OR_CANCELED_UNPAID_ORDER)).thenReturn(Optional.empty());
 
             Set<NotificationParameter> parameters = new HashSet<>();
 


### PR DESCRIPTION
## Summary Of Issue :
Autonotifications for half paid orders that should be sent weekly but are actually sent daily, if the half paid order has any of the following conditions: 
1) Order status BROUGHT_IT_HIMSELF.
2) Order satus DONE or CANCELED and any three of the next statuses in the order history: ORDER_ADJUSTMENT, ORDER_ON_THE_ROUTE, ORDER_NOT_TAKEN_OUT, ORDER_CONFIRMED.

**Issue Link**
https://github.com/ita-social-projects/GreenCity/issues/5881

## Summary Of Changes :
1) Updated method that retreive last notification for order by it types.
2) Added new notification types to the condition for retrieving the last notification for a half paid order.
2) Updated tests.

## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] All files reviewed before sending to reviewers