### PR TITLE
#5927 [UBS] endpoint that returns deactivated locations

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -99,6 +99,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 SUPER_ADMIN_LINK + "/get-all-receiving-station",
                 SUPER_ADMIN_LINK + "/getLocations",
                 SUPER_ADMIN_LINK + "/getActiveLocations",
+                SUPER_ADMIN_LINK + "/getDeactivatedLocations",
                 SUPER_ADMIN_LINK + "/getCouriers",
                 SUPER_ADMIN_LINK + "/tariffs",
                 SUPER_ADMIN_LINK + "/{tariffId}/getTariffService",

--- a/core/src/main/java/greencity/controller/SuperAdminController.java
+++ b/core/src/main/java/greencity/controller/SuperAdminController.java
@@ -24,6 +24,7 @@ import greencity.dto.tariff.GetTariffLimitsDto;
 import greencity.dto.tariff.GetTariffsInfoDto;
 import greencity.dto.tariff.SetTariffLimitsDto;
 import greencity.entity.order.Courier;
+import greencity.enums.LocationStatus;
 import greencity.exceptions.BadRequestException;
 import greencity.filters.TariffsInfoFilterCriteria;
 import greencity.service.SuperAdminService;
@@ -282,21 +283,42 @@ class SuperAdminController {
     }
 
     /**
-     * Get all info about active locations, and min amount of bag for locations.
+     * Get all info about active locations.
      *
      * @return {@link LocationInfoDto}
      * @author Safarov Renat
      */
-    @ApiOperation(value = "Get info about active locations and min amount of bags for every location")
+    @ApiOperation(value = "Get all active locations")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = HttpStatuses.OK, response = LocationInfoDto.class),
         @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN)
+        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
     })
     @PreAuthorize("@preAuthorizer.hasAuthority('SEE_TARIFFS', authentication)")
     @GetMapping("/getActiveLocations")
     public ResponseEntity<List<LocationInfoDto>> getActiveLocations() {
-        return ResponseEntity.status(HttpStatus.OK).body(superAdminService.getActiveLocations());
+        return ResponseEntity.status(HttpStatus.OK).body(superAdminService.getLocationsByStatus(LocationStatus.ACTIVE));
+    }
+
+    /**
+     * Get all deactivated locations.
+     *
+     * @return {@link LocationInfoDto}
+     * @author Maksym Lenets
+     */
+    @ApiOperation(value = "Get all deactivated locations")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = HttpStatuses.OK, response = LocationInfoDto.class),
+        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+    })
+    @PreAuthorize("@preAuthorizer.hasAuthority('SEE_TARIFFS', authentication)")
+    @GetMapping("/getDeactivatedLocations")
+    public ResponseEntity<List<LocationInfoDto>> getDeactivatedLocations() {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(superAdminService.getLocationsByStatus(LocationStatus.DEACTIVATED));
     }
 
     /**

--- a/core/src/main/java/greencity/controller/SuperAdminController.java
+++ b/core/src/main/java/greencity/controller/SuperAdminController.java
@@ -298,7 +298,8 @@ class SuperAdminController {
     @PreAuthorize("@preAuthorizer.hasAuthority('SEE_TARIFFS', authentication)")
     @GetMapping("/getActiveLocations")
     public ResponseEntity<List<LocationInfoDto>> getActiveLocations() {
-        return ResponseEntity.status(HttpStatus.OK).body(superAdminService.getLocationsByStatus(LocationStatus.ACTIVE));
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(superAdminService.getLocationsByStatus(LocationStatus.ACTIVE));
     }
 
     /**

--- a/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
+++ b/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
@@ -21,6 +21,7 @@ import greencity.dto.service.TariffServiceDto;
 import greencity.dto.tariff.EditTariffDto;
 import greencity.dto.tariff.GetTariffsInfoDto;
 import greencity.dto.tariff.SetTariffLimitsDto;
+import greencity.enums.LocationStatus;
 import greencity.exception.handler.CustomExceptionHandler;
 import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
@@ -517,7 +518,53 @@ class SuperAdminControllerTest {
     void getActiveLocations() throws Exception {
         mockMvc.perform(get((ubsLink + "/getActiveLocations"))).andExpect(status().isOk());
 
-        verify(superAdminService).getActiveLocations();
+        verify(superAdminService).getLocationsByStatus(LocationStatus.ACTIVE);
+        verifyNoMoreInteractions(superAdminService);
+    }
+
+    @Test
+    void getActiveLocationsNotFoundTest() throws Exception {
+        String message = "ErrorMessage";
+
+        doThrow(new NotFoundException(message))
+            .when(superAdminService)
+            .getLocationsByStatus(LocationStatus.ACTIVE);
+
+        mockMvc.perform(get(ubsLink + "/getActiveLocations")
+            .principal(principal))
+            .andExpect(status().isNotFound())
+            .andExpect(result -> assertTrue(result.getResolvedException() instanceof NotFoundException))
+            .andExpect(
+                result -> assertEquals(message, Objects.requireNonNull(result.getResolvedException()).getMessage()));
+
+        verify(superAdminService).getLocationsByStatus(LocationStatus.ACTIVE);
+        verifyNoMoreInteractions(superAdminService);
+    }
+
+    @Test
+    void getDeactivatedLocationsTest() throws Exception {
+        mockMvc.perform(get(ubsLink + "/getDeactivatedLocations").principal(principal)).andExpect(status().isOk());
+
+        verify(superAdminService).getLocationsByStatus(LocationStatus.DEACTIVATED);
+        verifyNoMoreInteractions(superAdminService);
+    }
+
+    @Test
+    void getDeactivatedLocationsNotFoundTest() throws Exception {
+        String message = "ErrorMessage";
+
+        doThrow(new NotFoundException(message))
+            .when(superAdminService)
+            .getLocationsByStatus(LocationStatus.DEACTIVATED);
+
+        mockMvc.perform(get(ubsLink + "/getDeactivatedLocations")
+            .principal(principal))
+            .andExpect(status().isNotFound())
+            .andExpect(result -> assertTrue(result.getResolvedException() instanceof NotFoundException))
+            .andExpect(
+                result -> assertEquals(message, Objects.requireNonNull(result.getResolvedException()).getMessage()));
+
+        verify(superAdminService).getLocationsByStatus(LocationStatus.DEACTIVATED);
         verifyNoMoreInteractions(superAdminService);
     }
 

--- a/dao/src/main/java/greencity/repository/RegionRepository.java
+++ b/dao/src/main/java/greencity/repository/RegionRepository.java
@@ -1,8 +1,9 @@
 package greencity.repository;
 
 import greencity.entity.user.Region;
+import greencity.enums.LocationStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -22,17 +23,15 @@ public interface RegionRepository extends JpaRepository<Region, Long> {
         @Param("UkrName") String nameUk);
 
     /**
-     * Method for get regions with only active locations.
-     * 
-     * @return List of {@link Region} if at least one region exists
-     * @author Safarov Renat
+     * Method that retrieves regions with locations specified by LocationStatus
+     * type.
+     *
+     * @param locationStatus {@link LocationStatus} - status of searched locations.
+     * @return List of {@link Region} if at least one region exists.
+     * @author Maksym Lenets
      */
-    @Query(nativeQuery = true,
-        value = "select * from regions r "
-            + "join locations l on r.id = l.region_id "
-            + "where l.location_status = 'ACTIVE' "
-            + "group by r.id, l.id")
-    List<Region> findRegionsWithActiveLocations();
+    @EntityGraph(attributePaths = "locations")
+    Optional<List<Region>> findAllByLocationsLocationStatus(LocationStatus locationStatus);
 
     /**
      * Method to check if the region exists by regionId.

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -148,6 +148,8 @@ public final class ErrorMessage {
         "Date of export not specified for the order with ID: ";
     public static final String EMPTY_ORDERS_ID_COLLECTION = "Request should contain at least one order ID";
     public static final String ORDER_IS_BLOCKED = "The order has been blocked by employee with ID: ";
+    public static final String REGIONS_NOT_FOUND_BY_LOCATION_STATUS =
+        "Regions containing locations with a status: %s, not found";
 
     /**
      * Constructor.

--- a/service-api/src/main/java/greencity/service/SuperAdminService.java
+++ b/service-api/src/main/java/greencity/service/SuperAdminService.java
@@ -16,6 +16,7 @@ import greencity.dto.service.GetServiceDto;
 import greencity.dto.tariff.*;
 import greencity.dto.service.GetTariffServiceDto;
 import greencity.entity.order.Courier;
+import greencity.enums.LocationStatus;
 import greencity.filters.TariffsInfoFilterCriteria;
 
 import java.util.List;
@@ -114,12 +115,13 @@ public interface SuperAdminService {
     List<LocationInfoDto> getAllLocation();
 
     /**
-     * Method for get all info about active locations.
+     * Method for getting info about locations by LocationStatus.
      *
+     * @param locationStatus {@link LocationStatus} - status of searched locations.
      * @return {@link LocationInfoDto}.
-     * @author Safarov Renat.
+     * @author Maksym Lenets.
      */
-    List<LocationInfoDto> getActiveLocations();
+    List<LocationInfoDto> getLocationsByStatus(LocationStatus locationStatus);
 
     /**
      * Method for adding location.

--- a/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/SuperAdminServiceImpl.java
@@ -271,9 +271,12 @@ public class SuperAdminServiceImpl implements SuperAdminService {
     }
 
     @Override
-    public List<LocationInfoDto> getActiveLocations() {
-        return regionRepository.findRegionsWithActiveLocations().stream()
-            .distinct()
+    public List<LocationInfoDto> getLocationsByStatus(LocationStatus locationStatus) {
+        List<Region> regionWithDeactivatedLocations = regionRepository
+            .findAllByLocationsLocationStatus(locationStatus)
+            .orElseThrow(() -> new NotFoundException(
+                String.format(ErrorMessage.REGIONS_NOT_FOUND_BY_LOCATION_STATUS, locationStatus.name())));
+        return regionWithDeactivatedLocations.stream()
             .map(region -> modelMapper.map(region, LocationInfoDto.class))
             .collect(Collectors.toList());
     }

--- a/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/SuperAdminServiceImplTest.java
@@ -559,15 +559,32 @@ class SuperAdminServiceImplTest {
     }
 
     @Test
-    void getActiveLocationsTest() {
+    void getLocationsByStatusTest() {
         List<Region> regionList = ModelUtils.getAllRegion();
 
-        when(regionRepository.findRegionsWithActiveLocations()).thenReturn(regionList);
+        when(regionRepository.findAllByLocationsLocationStatus(LocationStatus.ACTIVE))
+            .thenReturn(Optional.of(regionList));
 
-        superAdminService.getActiveLocations();
+        var result = superAdminService.getLocationsByStatus(LocationStatus.ACTIVE);
 
-        verify(regionRepository).findRegionsWithActiveLocations();
+        verify(regionRepository).findAllByLocationsLocationStatus(LocationStatus.ACTIVE);
         regionList.forEach(region -> verify(modelMapper).map(region, LocationInfoDto.class));
+        verify(modelMapper, times(regionList.size())).map(any(Region.class), eq(LocationInfoDto.class));
+        assertEquals(regionList.size(), result.size());
+    }
+
+    @Test
+    void getLocationsByStatusNotFoundExceptionTest() {
+        when(regionRepository.findAllByLocationsLocationStatus(LocationStatus.ACTIVE))
+            .thenReturn(Optional.empty());
+
+        NotFoundException notFoundException = assertThrows(NotFoundException.class,
+            () -> superAdminService.getLocationsByStatus(LocationStatus.ACTIVE));
+
+        assertEquals(String.format(ErrorMessage.REGIONS_NOT_FOUND_BY_LOCATION_STATUS, LocationStatus.ACTIVE.name()),
+            notFoundException.getMessage());
+
+        verify(regionRepository).findAllByLocationsLocationStatus(LocationStatus.ACTIVE);
     }
 
     @Test


### PR DESCRIPTION
## Summary Of Issue :
Requires an endpoint that returns deactivated locations.

**Issue Link**
https://github.com/ita-social-projects/GreenCity/issues/5927

## Summary Of Changes :
1) Added new endpoint SuperAdminController getDeactivatedLocations (/ubs/superAdmin/getDeactivatedLocations);
2) Updated SuperAdminController getActiveLocations  (/ubs/superAdmin/getActiveLocations);
3) Updated service and repository layers;
4) Added new tests and updated previous ones.

## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] All files reviewed before sending to reviewers
