### PR TITLE
[UBS. ORDER] - bug with big bags amount limit #5957

### DIFF
--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -65,7 +65,7 @@ public final class ErrorMessage {
     public static final String INCOMPATIBLE_ORDER_STATUS_FOR_VIOLATION =
         "Cannot add a violation to order with this status: ";
     public static final String EVENTS_NOT_FOUND_EXCEPTION = "Events didn't find in order id: ";
-    public static final String NOT_ENOUGH_BIG_BAGS_EXCEPTION = "Not enough big bags, minimal amount is:";
+    public static final String NOT_ENOUGH_BAGS_EXCEPTION = "Not enough bags, minimal amount is: ";
     public static final String NOTIFICATION_DOES_NOT_EXIST = "Notification does not exist";
     public static final String NOTIFICATION_STATUS_DOES_NOT_EXIST = "Notification status does not exist ";
     public static final String NOTIFICATION_DOES_NOT_BELONG_TO_USER = "This notification does not belong to user";
@@ -77,7 +77,7 @@ public final class ErrorMessage {
     public static final String LOCATION_IS_DEACTIVATED_FOR_TARIFF = "Location is deactivated for tariff: ";
     public static final String COURIER_IS_NOT_FOUND_BY_ID = "Couldn't found courier by id: ";
     public static final String CANNOT_DEACTIVATE_COURIER = "Courier is already deactivated with id: ";
-    public static final String TO_MUCH_BIG_BAG_EXCEPTION = "You choose to much big bag's max amount is: ";
+    public static final String TO_MUCH_BAG_EXCEPTION = "You choose to much bags, maximum amount is: ";
     public static final String PRICE_OF_ORDER_GREATER_THAN_LIMIT =
         "The price of you're order without discount is greater than allowable limit: ";
     public static final String PRICE_OF_ORDER_LOWER_THAN_LIMIT =

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -166,7 +166,7 @@ import static greencity.constant.ErrorMessage.EMPLOYEE_DOESNT_EXIST;
 import static greencity.constant.ErrorMessage.EVENTS_NOT_FOUND_EXCEPTION;
 import static greencity.constant.ErrorMessage.LOCATION_DOESNT_FOUND_BY_ID;
 import static greencity.constant.ErrorMessage.LOCATION_IS_DEACTIVATED_FOR_TARIFF;
-import static greencity.constant.ErrorMessage.NOT_ENOUGH_BIG_BAGS_EXCEPTION;
+import static greencity.constant.ErrorMessage.NOT_ENOUGH_BAGS_EXCEPTION;
 import static greencity.constant.ErrorMessage.NOT_FOUND_ADDRESS_ID_FOR_CURRENT_USER;
 import static greencity.constant.ErrorMessage.NUMBER_OF_ADDRESSES_EXCEEDED;
 import static greencity.constant.ErrorMessage.ORDER_ALREADY_PAID;
@@ -185,7 +185,7 @@ import static greencity.constant.ErrorMessage.TARIFF_OR_LOCATION_IS_DEACTIVATED;
 import static greencity.constant.ErrorMessage.THE_SET_OF_UBS_USER_DATA_DOES_NOT_EXIST;
 import static greencity.constant.ErrorMessage.TOO_MANY_CERTIFICATES;
 import static greencity.constant.ErrorMessage.TOO_MUCH_POINTS_FOR_ORDER;
-import static greencity.constant.ErrorMessage.TO_MUCH_BIG_BAG_EXCEPTION;
+import static greencity.constant.ErrorMessage.TO_MUCH_BAG_EXCEPTION;
 import static greencity.constant.ErrorMessage.USER_DONT_HAVE_ENOUGH_POINTS;
 import static greencity.constant.ErrorMessage.USER_WITH_CURRENT_ID_DOES_NOT_EXIST;
 import static greencity.constant.ErrorMessage.USER_WITH_CURRENT_UUID_DOES_NOT_EXIST;
@@ -242,7 +242,6 @@ public class UBSClientServiceImpl implements UBSClientService {
     private String resultUrlForPersonalCabinetOfUser;
     @Value("${greencity.redirect.result-url-fondy}")
     private String resultUrlFondy;
-    private static final Integer BAG_CAPACITY = 120;
     private static final String FAILED_STATUS = "failure";
     private static final String APPROVED_STATUS = "approved";
     private static final String TELEGRAM_PART_1_OF_LINK = "https://telegram.me/";
@@ -425,7 +424,6 @@ public class UBSClientServiceImpl implements UBSClientService {
 
         long sumToPayWithoutDiscountInCoins = formBagsToBeSavedAndCalculateOrderSum(amountOfBagsOrderedMap,
             dto.getBags(), tariffsInfo);
-        checkSumIfCourierLimitBySumOfOrder(tariffsInfo, sumToPayWithoutDiscountInCoins);
         checkIfUserHaveEnoughPoints(currentUser.getCurrentPoints(), dto.getPointsToUse());
         long sumToPayInCoins = reduceOrderSumDueToUsedPoints(sumToPayWithoutDiscountInCoins, dto.getPointsToUse());
 
@@ -1193,10 +1191,10 @@ public class UBSClientServiceImpl implements UBSClientService {
         if (CourierLimit.LIMIT_BY_AMOUNT_OF_BAG.equals(courierLocation.getCourierLimit())
             && courierLocation.getMin() > countOfBigBag) {
             throw new BadRequestException(
-                NOT_ENOUGH_BIG_BAGS_EXCEPTION + courierLocation.getMin());
+                NOT_ENOUGH_BAGS_EXCEPTION + courierLocation.getMin());
         } else if (CourierLimit.LIMIT_BY_AMOUNT_OF_BAG.equals(courierLocation.getCourierLimit())
             && courierLocation.getMax() < countOfBigBag) {
-            throw new BadRequestException(TO_MUCH_BIG_BAG_EXCEPTION + courierLocation.getMax());
+            throw new BadRequestException(TO_MUCH_BAG_EXCEPTION + courierLocation.getMax());
         }
     }
 
@@ -1216,18 +1214,16 @@ public class UBSClientServiceImpl implements UBSClientService {
     private long formBagsToBeSavedAndCalculateOrderSum(
         Map<Integer, Integer> map, List<BagDto> bags, TariffsInfo tariffsInfo) {
         long sumToPayInCoins = 0L;
-        int bigBagCounter = 0;
 
         for (BagDto temp : bags) {
             Bag bag = tryToGetBagById(temp.getId());
-            if (bag.getCapacity() >= BAG_CAPACITY) {
-                bigBagCounter += temp.getAmount();
+            if (bag.getLimitIncluded()) {
+                checkAmountOfBagsIfCourierLimitByAmountOfBag(tariffsInfo, temp.getAmount());
+                checkSumIfCourierLimitBySumOfOrder(tariffsInfo, bag.getFullPrice() * temp.getAmount());
             }
             sumToPayInCoins += bag.getFullPrice() * temp.getAmount();
             map.put(temp.getId(), temp.getAmount());
         }
-
-        checkAmountOfBagsIfCourierLimitByAmountOfBag(tariffsInfo, bigBagCounter);
         return sumToPayInCoins;
     }
 

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -1217,7 +1217,7 @@ public class UBSClientServiceImpl implements UBSClientService {
 
         for (BagDto temp : bags) {
             Bag bag = tryToGetBagById(temp.getId());
-            if (bag.getLimitIncluded()) {
+            if (bag.getLimitIncluded().booleanValue()) {
                 checkAmountOfBagsIfCourierLimitByAmountOfBag(tariffsInfo, temp.getAmount());
                 checkSumIfCourierLimitBySumOfOrder(tariffsInfo, bag.getFullPrice() * temp.getAmount());
             }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2556,6 +2556,23 @@ public class ModelUtils {
             .build();
     }
 
+    public static Bag getBagForOrder() {
+        return Bag.builder()
+            .id(3)
+            .capacity(120)
+            .commission(50_00L)
+            .price(350_00L)
+            .fullPrice(400_00L)
+            .createdAt(LocalDate.now())
+            .createdBy(getEmployee())
+            .editedBy(getEmployee())
+            .description("Description")
+            .descriptionEng("DescriptionEng")
+            .limitIncluded(true)
+            .tariffsInfo(getTariffInfo())
+            .build();
+    }
+
     public static TariffServiceDto getTariffServiceDto() {
         return TariffServiceDto.builder()
             .name("Бавовняна сумка")


### PR DESCRIPTION
## Summary of issue

When the user orders bags with a capacity of less than 120 l, an exception is received about the not enough amount of big bags

## Link to issue

https://github.com/ita-social-projects/GreenCity/issues/5957

## Changed

- saveFullOrderToDB() in service/src/main/java/greencity/service/ubs/UBSClientServiceImpl
- messages in service-api/src/main/java/greencity/constant/ErrorMessage
- test methods

## Testing approach

tested in swagger by endpoints /ubs/processOrder, /ubs/processOrder/{id}