### PR TITLE
[Pick up city UBS] - Wrong presentation of bags amount in the ‘Orders’ table when admin has changed the Confirmed amount

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -602,10 +602,8 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                 if (Boolean.TRUE
                     .equals(orderDetailRepository.ifRecordExist(orderId, entry.getKey().longValue()) <= 0)
                     && entry.getValue() != 0) {
-
                     orderDetailRepository.insertNewRecord(orderId, entry.getKey().longValue());
                     orderDetailRepository.updateAmount(0, orderId, entry.getKey().longValue());
-
                 }
                 orderDetailRepository
                     .updateConfirm(entry.getValue(), orderId,

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -601,8 +601,10 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             for (Map.Entry<Integer, Integer> entry : confirmed.entrySet()) {
                 if (Boolean.TRUE
                     .equals(orderDetailRepository.ifRecordExist(orderId, entry.getKey().longValue()) <= 0)) {
-                    orderDetailRepository.insertNewRecord(orderId, entry.getKey().longValue());
-                    orderDetailRepository.updateAmount(0, orderId, entry.getKey().longValue());
+                    if (entry.getValue() != 0) {
+                        orderDetailRepository.insertNewRecord(orderId, entry.getKey().longValue());
+                        orderDetailRepository.updateAmount(0, orderId, entry.getKey().longValue());
+                    }
                 }
                 orderDetailRepository
                     .updateConfirm(entry.getValue(), orderId,

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -600,11 +600,12 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         if (nonNull(confirmed)) {
             for (Map.Entry<Integer, Integer> entry : confirmed.entrySet()) {
                 if (Boolean.TRUE
-                    .equals(orderDetailRepository.ifRecordExist(orderId, entry.getKey().longValue()) <= 0)) {
-                    if (entry.getValue() != 0) {
-                        orderDetailRepository.insertNewRecord(orderId, entry.getKey().longValue());
-                        orderDetailRepository.updateAmount(0, orderId, entry.getKey().longValue());
-                    }
+                    .equals(orderDetailRepository.ifRecordExist(orderId, entry.getKey().longValue()) <= 0)
+                    && entry.getValue() != 0) {
+
+                    orderDetailRepository.insertNewRecord(orderId, entry.getKey().longValue());
+                    orderDetailRepository.updateAmount(0, orderId, entry.getKey().longValue());
+
                 }
                 orderDetailRepository
                     .updateConfirm(entry.getValue(), orderId,

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -1331,6 +1331,24 @@ class UBSManagementServiceImplTest {
     }
 
     @Test
+    void testSetOrderDetailWithBagConfirmedHasValueZero() {
+        when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+        when(bagRepository.findCapacityById(1)).thenReturn(1);
+        when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
+        when(bagRepository.findById(1)).thenReturn(Optional.empty());
+
+        UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().setAmountOfBagsConfirmed(Map.of(1, 0));
+
+        ubsManagementService.setOrderDetail(1L,
+            UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsConfirmed(),
+            UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(), "test@gmail.com");
+
+        verify(orderDetailRepository, times(0)).updateExporter(anyInt(), anyLong(), anyLong());
+        verify(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
+
+    }
+
+    @Test
     void testSetOrderDetailNotTakenOut() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusNotTakenOutDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);


### PR DESCRIPTION
dev
## Main ticket

* [Main ticket](https://github.com/ita-social-projects/GreenCity/issues/5458)

## Summary of issue

fix a bug that when you set the amountof packages to 0, it is shown in the table according to the example "60л - 0шт"

## Summary of change

- added 1 check

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions