### PR TITLE
[Admin cabinet] Add to the "Position" names division in Ukrainian and English #5972

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementEmployeeController.java
+++ b/core/src/main/java/greencity/controller/ManagementEmployeeController.java
@@ -10,6 +10,7 @@ import greencity.dto.employee.UserEmployeeAuthorityDto;
 import greencity.dto.pageble.PageableAdvancedDto;
 import greencity.dto.position.PositionAuthoritiesDto;
 import greencity.dto.position.PositionDto;
+import greencity.dto.position.PositionWithTranslateDto;
 import greencity.dto.tariff.GetTariffInfoForEmployeeDto;
 import greencity.filters.EmployeeFilterCriteria;
 import greencity.filters.EmployeePage;
@@ -152,7 +153,7 @@ public class ManagementEmployeeController {
     })
     @PreAuthorize("@preAuthorizer.hasAuthority('SEE_EMPLOYEES_PAGE', authentication)")
     @GetMapping("/get-all-positions")
-    public ResponseEntity<List<PositionDto>> getAllPositions() {
+    public ResponseEntity<List<PositionWithTranslateDto>> getAllPositions() {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.getAllPositions());
     }
 

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -243,6 +243,7 @@ public class ModelUtils {
         return PositionDto.builder()
             .id(1L)
             .name("Водій")
+            .nameEN("Driver")
             .build();
     }
 

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -1,5 +1,6 @@
 package greencity;
 
+//отут протестити дто
 import greencity.configuration.RedirectionConfigProp;
 import greencity.dto.AddNewTariffDto;
 import greencity.dto.CreateAddressRequestDto;

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -1,6 +1,5 @@
 package greencity;
 
-//отут протестити дто
 import greencity.configuration.RedirectionConfigProp;
 import greencity.dto.AddNewTariffDto;
 import greencity.dto.CreateAddressRequestDto;

--- a/dao/src/main/java/greencity/entity/user/employee/EmployeeFilterView.java
+++ b/dao/src/main/java/greencity/entity/user/employee/EmployeeFilterView.java
@@ -47,6 +47,9 @@ public class EmployeeFilterView {
     @Column(name = "position_name")
     private String positionName;
 
+    @Column(name = "position_name_en")
+    private String positionNameEn;
+
     @Column(name = "region_id")
     private Long regionId;
 

--- a/dao/src/main/java/greencity/entity/user/employee/Position.java
+++ b/dao/src/main/java/greencity/entity/user/employee/Position.java
@@ -22,8 +22,8 @@ public class Position {
     @Column(nullable = false, length = 30, unique = true)
     private String name;
 
-    @Column(nullable = false, length = 30, unique = true)
-    private String name_eng;
+    @Column(nullable = false, length = 30, unique = true, name = "name_eng")
+    private String nameEN;
 
     @ManyToMany(mappedBy = "employeePosition")
     private Set<Employee> employees;

--- a/dao/src/main/java/greencity/entity/user/employee/Position.java
+++ b/dao/src/main/java/greencity/entity/user/employee/Position.java
@@ -22,6 +22,9 @@ public class Position {
     @Column(nullable = false, length = 30, unique = true)
     private String name;
 
+    @Column(nullable = true, length = 30, unique = true)
+    private String name_eng;
+
     @ManyToMany(mappedBy = "employeePosition")
     private Set<Employee> employees;
 

--- a/dao/src/main/java/greencity/entity/user/employee/Position.java
+++ b/dao/src/main/java/greencity/entity/user/employee/Position.java
@@ -22,7 +22,7 @@ public class Position {
     @Column(nullable = false, length = 30, unique = true)
     private String name;
 
-    @Column(nullable = true, length = 30, unique = true)
+    @Column(nullable = false, length = 30, unique = true)
     private String name_eng;
 
     @ManyToMany(mappedBy = "employeePosition")

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -207,4 +207,5 @@
     <include file="db/changelog/logs/ch-update-service-price-Seti.xml"/>
     <include file="db/changelog/logs/ch-update_big_order_table_view-Seti.xml"/>
     <include file="/db/changelog/logs/ch-modify-columns-name-name-eng-in-bag-and-service-tables.xml"/>
+    <include file="/db/changelog/logs/ch-add-column-position-Spodaryk.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -208,4 +208,5 @@
     <include file="db/changelog/logs/ch-update_big_order_table_view-Seti.xml"/>
     <include file="/db/changelog/logs/ch-modify-columns-name-name-eng-in-bag-and-service-tables.xml"/>
     <include file="/db/changelog/logs/ch-add-column-position-Spodaryk.xml"/>
+    <include file="/db/changelog/logs/ch-add-column-employee_filter_view-Spodaryk.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-add-column-position-Spodaryk.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-column-position-Spodaryk.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet id="Spodaryk-1" author="Oksana Spodaryk">
+        <addColumn tableName="positions">
+            <column name="name_eng" type="varchar(30)" defaultValue="name_eng">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="Spodaryk-2" author="Oksana Spodaryk">
+        <update tableName="positions">
+            <column name="name_eng" value="Service Manager"/>
+            <where>name='Менеджер послуги'</where>
+        </update>
+        <update tableName="positions">
+            <column name="name_eng" value="Call Manager"/>
+            <where>name='Менеджер обдзвону'</where>
+        </update>
+        <update tableName="positions">
+            <column name="name_eng" value="Logistician"/>
+            <where>name='Логіст'</where>
+        </update>
+        <update tableName="positions">
+            <column name="name_eng" value="Navigator"/>
+            <where>name='Штурман'</where>
+        </update>
+        <update tableName="positions">
+            <column name="name_eng" value="Driver"/>
+            <where>name='Водій'</where>
+        </update>
+        <update tableName="positions">
+            <column name="name_eng" value="Super Admin"/>
+            <where>name='Супер адмін'</where>
+        </update>
+        <update tableName="positions">
+            <column name="name_eng" value="Admin"/>
+            <where>name='Адмін'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/service-api/src/main/java/greencity/dto/position/AddingPositionDto.java
+++ b/service-api/src/main/java/greencity/dto/position/AddingPositionDto.java
@@ -15,4 +15,6 @@ public class AddingPositionDto {
     @NotNull
     @Pattern(regexp = "[ЁёІіЇїҐґЄєА-Яа-яA-Za-z-'\\s.]{1,30}")
     private String name;
+    @Pattern(regexp = "[A-Za-z-'\\s.]{1,30}")
+    private String name_eng;
 }

--- a/service-api/src/main/java/greencity/dto/position/AddingPositionDto.java
+++ b/service-api/src/main/java/greencity/dto/position/AddingPositionDto.java
@@ -16,5 +16,5 @@ public class AddingPositionDto {
     @Pattern(regexp = "[ЁёІіЇїҐґЄєА-Яа-яA-Za-z-'\\s.]{1,30}")
     private String name;
     @Pattern(regexp = "[A-Za-z-'\\s.]{1,30}")
-    private String name_eng;
+    private String nameEN;
 }

--- a/service-api/src/main/java/greencity/dto/position/PositionDto.java
+++ b/service-api/src/main/java/greencity/dto/position/PositionDto.java
@@ -2,6 +2,7 @@ package greencity.dto.position;
 
 import lombok.*;
 
+import javax.persistence.Column;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;
 
@@ -18,5 +19,5 @@ public class PositionDto {
     @Pattern(regexp = "[ЁёІіЇїҐґЄєА-Яа-яA-Za-z-'\\s.]{1,30}")
     private String name;
     @Pattern(regexp = "[A-Za-z-'\\s.]{1,30}")
-    private String name_eng;
+    private String nameEN;
 }

--- a/service-api/src/main/java/greencity/dto/position/PositionDto.java
+++ b/service-api/src/main/java/greencity/dto/position/PositionDto.java
@@ -17,4 +17,6 @@ public class PositionDto {
     private Long id;
     @Pattern(regexp = "[ЁёІіЇїҐґЄєА-Яа-яA-Za-z-'\\s.]{1,30}")
     private String name;
+    @Pattern(regexp = "[A-Za-z-'\\s.]{1,30}")
+    private String name_eng;
 }

--- a/service-api/src/main/java/greencity/dto/position/PositionWithTranslateDto.java
+++ b/service-api/src/main/java/greencity/dto/position/PositionWithTranslateDto.java
@@ -1,0 +1,20 @@
+package greencity.dto.position;
+
+import lombok.*;
+
+import javax.validation.constraints.Min;
+import java.util.Map;
+//
+//@Getter
+//@Setter
+//@NoArgsConstructor
+//@AllArgsConstructor
+//@Builder
+//@EqualsAndHashCode
+//@ToString
+//public class PositionWithTranslateDto {
+//    @Min(1)
+//    private Long id;
+//
+//    private Map<String, String> name;
+//}

--- a/service-api/src/main/java/greencity/dto/position/PositionWithTranslateDto.java
+++ b/service-api/src/main/java/greencity/dto/position/PositionWithTranslateDto.java
@@ -4,17 +4,17 @@ import lombok.*;
 
 import javax.validation.constraints.Min;
 import java.util.Map;
-//
-//@Getter
-//@Setter
-//@NoArgsConstructor
-//@AllArgsConstructor
-//@Builder
-//@EqualsAndHashCode
-//@ToString
-//public class PositionWithTranslateDto {
-//    @Min(1)
-//    private Long id;
-//
-//    private Map<String, String> name;
-//}
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode
+@ToString
+public class PositionWithTranslateDto {
+    @Min(1)
+    private Long id;
+
+    private Map<String, String> name;
+}

--- a/service-api/src/main/java/greencity/service/ubs/UBSManagementEmployeeService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSManagementEmployeeService.java
@@ -5,6 +5,7 @@ import greencity.dto.employee.GetEmployeeDto;
 import greencity.dto.employee.EmployeeWithTariffsIdDto;
 import greencity.dto.position.AddingPositionDto;
 import greencity.dto.position.PositionDto;
+import greencity.dto.position.PositionWithTranslateDto;
 import greencity.dto.tariff.GetTariffInfoForEmployeeDto;
 import greencity.filters.EmployeeFilterCriteria;
 import greencity.filters.EmployeePage;
@@ -73,7 +74,7 @@ public interface UBSManagementEmployeeService {
      * @return {@link PositionDto}
      * @author Mykola Danylko
      */
-    List<PositionDto> getAllPositions();
+    List<PositionWithTranslateDto> getAllPositions();
 
     /**
      * Method deletes position by id.

--- a/service/src/main/java/greencity/mapping/employee/AddEmployeeDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/employee/AddEmployeeDtoMapper.java
@@ -33,7 +33,7 @@ public class AddEmployeeDtoMapper extends AbstractConverter<AddEmployeeDto, Empl
                 .map(p -> Position.builder()
                     .id(p.getId())
                     .name(p.getName())
-                    .name_eng(p.getName_eng())
+                    .nameEN(p.getNameEN())
                     .build())
                 .collect(Collectors.toSet()))
             .build();

--- a/service/src/main/java/greencity/mapping/employee/AddEmployeeDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/employee/AddEmployeeDtoMapper.java
@@ -33,6 +33,7 @@ public class AddEmployeeDtoMapper extends AbstractConverter<AddEmployeeDto, Empl
                 .map(p -> Position.builder()
                     .id(p.getId())
                     .name(p.getName())
+                    .name_eng(p.getName_eng())
                     .build())
                 .collect(Collectors.toSet()))
             .build();

--- a/service/src/main/java/greencity/mapping/employee/EmployeeUpdateDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/employee/EmployeeUpdateDtoMapper.java
@@ -26,6 +26,7 @@ public class EmployeeUpdateDtoMapper extends AbstractConverter<Employee, Employe
                     .map(position -> PositionDto.builder()
                         .id(position.getId())
                         .name(position.getName())
+                        .nameEN(position.getNameEN())
                         .build())
                     .collect(Collectors.toList()))
                 .build())

--- a/service/src/main/java/greencity/mapping/employee/EmployeeWithTariffsDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/employee/EmployeeWithTariffsDtoMapper.java
@@ -30,6 +30,7 @@ public class EmployeeWithTariffsDtoMapper extends AbstractConverter<Employee, Em
                     .map(position -> PositionDto.builder()
                         .id(position.getId())
                         .name(position.getName())
+                        .nameEN(position.getNameEN())
                         .build())
                     .collect(Collectors.toList()))
                 .build())

--- a/service/src/main/java/greencity/mapping/employee/PositionDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/employee/PositionDtoMapper.java
@@ -20,9 +20,9 @@ public class PositionDtoMapper extends AbstractConverter<Position, PositionDto> 
     @Override
     protected PositionDto convert(Position position) {
         return PositionDto.builder()
-                .id(position.getId())
-                .name(position.getName())
-                .name_eng(position.getName_eng())
-                .build();
+            .id(position.getId())
+            .name(position.getName())
+            .nameEN(position.getNameEN())
+            .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/employee/PositionDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/employee/PositionDtoMapper.java
@@ -20,8 +20,9 @@ public class PositionDtoMapper extends AbstractConverter<Position, PositionDto> 
     @Override
     protected PositionDto convert(Position position) {
         return PositionDto.builder()
-            .id(position.getId())
-            .name(position.getName())
-            .build();
+                .id(position.getId())
+                .name(position.getName())
+                .name_eng(position.getName_eng())
+                .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/employee/PositionDtoWithTranslateMapper.java
+++ b/service/src/main/java/greencity/mapping/employee/PositionDtoWithTranslateMapper.java
@@ -12,24 +12,24 @@ import java.util.Map;
 
 /**
  * Class that used by {@link ModelMapper} to map {@link Position} into
- * {@link PositionDto}.
+ * {@link PositionDtoWithTranslateMapper}.
  */
 @Component
 public class PositionDtoWithTranslateMapper extends AbstractConverter<Position, PositionWithTranslateDto> {
     /**
      * Method convert {@link Position} to {@link PositionWithTranslateDto}.
      *
-     * @return {@link PositionDto}
+     * @return {@link PositionDtoWithTranslateMapper}
      */
     @Override
     protected PositionWithTranslateDto convert(Position position) {
         Map<String, String> nameTranslations = new HashMap<>();
         nameTranslations.put("ua", position.getName());
-        nameTranslations.put("en", position.getName_eng());
+        nameTranslations.put("en", position.getNameEN());
 
         return PositionWithTranslateDto.builder()
-                .id(position.getId())
-                .name(nameTranslations)
-                .build();
+            .id(position.getId())
+            .name(nameTranslations)
+            .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/employee/PositionDtoWithTranslateMapper.java
+++ b/service/src/main/java/greencity/mapping/employee/PositionDtoWithTranslateMapper.java
@@ -1,0 +1,35 @@
+//package greencity.mapping.employee;
+//
+//import greencity.dto.position.PositionDto;
+//import greencity.dto.position.PositionWithTranslateDto;
+//import greencity.entity.user.employee.Position;
+//import org.modelmapper.AbstractConverter;
+//import org.modelmapper.ModelMapper;
+//import org.springframework.stereotype.Component;
+//
+//import java.util.HashMap;
+//import java.util.Map;
+//
+///**
+// * Class that used by {@link ModelMapper} to map {@link Position} into
+// * {@link PositionDto}.
+// */
+//@Component
+//public class PositionDtoWithTranslateMapper extends AbstractConverter<PositionDto, PositionWithTranslateDto> {
+//    /**
+//     * Method convert {@link Position} to {@link PositionDto}.
+//     *
+//     * @return {@link PositionDto}
+//     */
+//    @Override
+//    protected PositionWithTranslateDto convert(PositionDto position) {
+//        Map<String, String> nameTranslations = new HashMap<>();
+//        nameTranslations.put("ua", position.getName());
+//        nameTranslations.put("en", position.getName_eng());
+//
+//        return PositionWithTranslateDto.builder()
+//                .id(position.getId())
+//                .name(nameTranslations)
+//                .build();
+//    }
+//}

--- a/service/src/main/java/greencity/mapping/employee/PositionDtoWithTranslateMapper.java
+++ b/service/src/main/java/greencity/mapping/employee/PositionDtoWithTranslateMapper.java
@@ -1,35 +1,35 @@
-//package greencity.mapping.employee;
-//
-//import greencity.dto.position.PositionDto;
-//import greencity.dto.position.PositionWithTranslateDto;
-//import greencity.entity.user.employee.Position;
-//import org.modelmapper.AbstractConverter;
-//import org.modelmapper.ModelMapper;
-//import org.springframework.stereotype.Component;
-//
-//import java.util.HashMap;
-//import java.util.Map;
-//
-///**
-// * Class that used by {@link ModelMapper} to map {@link Position} into
-// * {@link PositionDto}.
-// */
-//@Component
-//public class PositionDtoWithTranslateMapper extends AbstractConverter<PositionDto, PositionWithTranslateDto> {
-//    /**
-//     * Method convert {@link Position} to {@link PositionDto}.
-//     *
-//     * @return {@link PositionDto}
-//     */
-//    @Override
-//    protected PositionWithTranslateDto convert(PositionDto position) {
-//        Map<String, String> nameTranslations = new HashMap<>();
-//        nameTranslations.put("ua", position.getName());
-//        nameTranslations.put("en", position.getName_eng());
-//
-//        return PositionWithTranslateDto.builder()
-//                .id(position.getId())
-//                .name(nameTranslations)
-//                .build();
-//    }
-//}
+package greencity.mapping.employee;
+
+import greencity.dto.position.PositionDto;
+import greencity.dto.position.PositionWithTranslateDto;
+import greencity.entity.user.employee.Position;
+import org.modelmapper.AbstractConverter;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class that used by {@link ModelMapper} to map {@link Position} into
+ * {@link PositionDto}.
+ */
+@Component
+public class PositionDtoWithTranslateMapper extends AbstractConverter<Position, PositionWithTranslateDto> {
+    /**
+     * Method convert {@link Position} to {@link PositionWithTranslateDto}.
+     *
+     * @return {@link PositionDto}
+     */
+    @Override
+    protected PositionWithTranslateDto convert(Position position) {
+        Map<String, String> nameTranslations = new HashMap<>();
+        nameTranslations.put("ua", position.getName());
+        nameTranslations.put("en", position.getName_eng());
+
+        return PositionWithTranslateDto.builder()
+                .id(position.getId())
+                .name(nameTranslations)
+                .build();
+    }
+}

--- a/service/src/main/java/greencity/mapping/employee/PositionMapper.java
+++ b/service/src/main/java/greencity/mapping/employee/PositionMapper.java
@@ -20,9 +20,9 @@ public class PositionMapper extends AbstractConverter<PositionDto, Position> {
     @Override
     protected Position convert(PositionDto positionDto) {
         return Position.builder()
-                .id(positionDto.getId())
-                .name(positionDto.getName())
-                .name_eng(positionDto.getName_eng())
-                .build();
+            .id(positionDto.getId())
+            .name(positionDto.getName())
+            .nameEN(positionDto.getNameEN())
+            .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/employee/PositionMapper.java
+++ b/service/src/main/java/greencity/mapping/employee/PositionMapper.java
@@ -20,8 +20,9 @@ public class PositionMapper extends AbstractConverter<PositionDto, Position> {
     @Override
     protected Position convert(PositionDto positionDto) {
         return Position.builder()
-            .id(positionDto.getId())
-            .name(positionDto.getName())
-            .build();
+                .id(positionDto.getId())
+                .name(positionDto.getName())
+                .name_eng(positionDto.getName_eng())
+                .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/employee/UpdateEmployeeDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/employee/UpdateEmployeeDtoMapper.java
@@ -13,18 +13,18 @@ public class UpdateEmployeeDtoMapper extends AbstractConverter<EmployeeWithTarif
     @Override
     protected Employee convert(EmployeeWithTariffsIdDto employeeWithTariffsIdDto) {
         return Employee.builder()
-                .id(employeeWithTariffsIdDto.getEmployeeDto().getId())
-                .firstName(employeeWithTariffsIdDto.getEmployeeDto().getFirstName())
-                .lastName(employeeWithTariffsIdDto.getEmployeeDto().getLastName())
-                .email(employeeWithTariffsIdDto.getEmployeeDto().getEmail())
-                .phoneNumber(employeeWithTariffsIdDto.getEmployeeDto().getPhoneNumber())
-                .employeePosition(employeeWithTariffsIdDto.getEmployeeDto().getEmployeePositions().stream().map(
-                                positionDto -> Position.builder()
-                                        .id(positionDto.getId())
-                                        .name(positionDto.getName())
-                                        .name_eng(positionDto.getName_eng())
-                                        .build())
-                        .collect(Collectors.toSet()))
-                .build();
+            .id(employeeWithTariffsIdDto.getEmployeeDto().getId())
+            .firstName(employeeWithTariffsIdDto.getEmployeeDto().getFirstName())
+            .lastName(employeeWithTariffsIdDto.getEmployeeDto().getLastName())
+            .email(employeeWithTariffsIdDto.getEmployeeDto().getEmail())
+            .phoneNumber(employeeWithTariffsIdDto.getEmployeeDto().getPhoneNumber())
+            .employeePosition(employeeWithTariffsIdDto.getEmployeeDto().getEmployeePositions().stream()
+                .map(positionDto -> Position.builder()
+                    .id(positionDto.getId())
+                    .name(positionDto.getName())
+                    .nameEN(positionDto.getNameEN())
+                    .build())
+                .collect(Collectors.toSet()))
+            .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/employee/UpdateEmployeeDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/employee/UpdateEmployeeDtoMapper.java
@@ -13,17 +13,18 @@ public class UpdateEmployeeDtoMapper extends AbstractConverter<EmployeeWithTarif
     @Override
     protected Employee convert(EmployeeWithTariffsIdDto employeeWithTariffsIdDto) {
         return Employee.builder()
-            .id(employeeWithTariffsIdDto.getEmployeeDto().getId())
-            .firstName(employeeWithTariffsIdDto.getEmployeeDto().getFirstName())
-            .lastName(employeeWithTariffsIdDto.getEmployeeDto().getLastName())
-            .email(employeeWithTariffsIdDto.getEmployeeDto().getEmail())
-            .phoneNumber(employeeWithTariffsIdDto.getEmployeeDto().getPhoneNumber())
-            .employeePosition(employeeWithTariffsIdDto.getEmployeeDto().getEmployeePositions().stream().map(
-                positionDto -> Position.builder()
-                    .id(positionDto.getId())
-                    .name(positionDto.getName())
-                    .build())
-                .collect(Collectors.toSet()))
-            .build();
+                .id(employeeWithTariffsIdDto.getEmployeeDto().getId())
+                .firstName(employeeWithTariffsIdDto.getEmployeeDto().getFirstName())
+                .lastName(employeeWithTariffsIdDto.getEmployeeDto().getLastName())
+                .email(employeeWithTariffsIdDto.getEmployeeDto().getEmail())
+                .phoneNumber(employeeWithTariffsIdDto.getEmployeeDto().getPhoneNumber())
+                .employeePosition(employeeWithTariffsIdDto.getEmployeeDto().getEmployeePositions().stream().map(
+                                positionDto -> Position.builder()
+                                        .id(positionDto.getId())
+                                        .name(positionDto.getName())
+                                        .name_eng(positionDto.getName_eng())
+                                        .build())
+                        .collect(Collectors.toSet()))
+                .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/employeefilterview/EmployeeFilterViewToPositionDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/employeefilterview/EmployeeFilterViewToPositionDtoMapper.java
@@ -12,6 +12,7 @@ public class EmployeeFilterViewToPositionDtoMapper extends AbstractConverter<Emp
         return PositionDto.builder()
             .id(employeeFilterView.getPositionId())
             .name(employeeFilterView.getPositionName())
+            .nameEN(employeeFilterView.getPositionNameEn())
             .build();
     }
 }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -13,6 +13,7 @@ import greencity.dto.employee.GetEmployeeDto;
 import greencity.dto.employee.EmployeePositionsDto;
 import greencity.dto.position.AddingPositionDto;
 import greencity.dto.position.PositionDto;
+import greencity.dto.position.PositionWithTranslateDto;
 import greencity.dto.tariff.GetTariffInfoForEmployeeDto;
 import greencity.entity.order.TariffsInfo;
 import greencity.entity.user.employee.Employee;
@@ -95,6 +96,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
                 .map(position -> PositionDto.builder()
                     .id(position.getId())
                     .name(position.getName())
+                        .name_eng(position.getName_eng())
                     .build())
                 .collect(Collectors.toList()))
             .isUbs(true)
@@ -327,9 +329,9 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
      * {@inheritDoc}
      */
     @Override
-    public List<PositionDto> getAllPositions() {
+    public List<PositionWithTranslateDto> getAllPositions() {
         return positionRepository.findAll().stream()
-            .map(p -> modelMapper.map(p, PositionDto.class))
+            .map(p -> modelMapper.map(p, PositionWithTranslateDto.class))
             .collect(Collectors.toList());
     }
 

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -318,7 +318,8 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
 
     private Position buildPosition(AddingPositionDto dto) {
         return Position.builder()
-            .name(dto.getName())
+                .name(dto.getName())
+                .name_eng(dto.getName_eng())
             .build();
     }
 

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -96,7 +96,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
                 .map(position -> PositionDto.builder()
                     .id(position.getId())
                     .name(position.getName())
-                        .name_eng(position.getName_eng())
+                    .nameEN(position.getNameEN())
                     .build())
                 .collect(Collectors.toList()))
             .isUbs(true)
@@ -320,8 +320,8 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
 
     private Position buildPosition(AddingPositionDto dto) {
         return Position.builder()
-                .name(dto.getName())
-                .name_eng(dto.getName_eng())
+            .name(dto.getName())
+            .nameEN(dto.getNameEN())
             .build();
     }
 

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1468,7 +1468,11 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         List<Position> positions = positionRepository.findAll();
         Map<PositionDto, List<EmployeeNameIdDto>> allPositionEmployee = new HashMap<>();
         for (Position position : positions) {
-            PositionDto positionDto = PositionDto.builder().id(position.getId()).name(position.getName()).build();
+            PositionDto positionDto = PositionDto.builder()
+                    .id(position.getId())
+                    .name(position.getName())
+                    .name_eng(position.getName_eng())
+                    .build();
             allPositionEmployee.put(positionDto, listAvailableEmployeeWithPosition(order, position)
                 .stream().map(employee -> EmployeeNameIdDto.builder()
                     .id(employee.getId())

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1461,7 +1461,11 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         if (!newList.isEmpty()) {
             Map<PositionDto, String> currentPositionEmployee = new HashMap<>();
             newList.forEach(x -> currentPositionEmployee.put(
-                PositionDto.builder().id(x.getPosition().getId()).name(x.getPosition().getName()).build(),
+                PositionDto.builder()
+                    .id(x.getPosition().getId())
+                    .name(x.getPosition().getName())
+                    .nameEN(x.getPosition().getNameEN())
+                    .build(),
                 x.getEmployee().getFirstName().concat(" ").concat(x.getEmployee().getLastName())));
             dto.setCurrentPositionEmployees(currentPositionEmployee);
         }
@@ -1469,10 +1473,10 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         Map<PositionDto, List<EmployeeNameIdDto>> allPositionEmployee = new HashMap<>();
         for (Position position : positions) {
             PositionDto positionDto = PositionDto.builder()
-                    .id(position.getId())
-                    .name(position.getName())
-                    .name_eng(position.getName_eng())
-                    .build();
+                .id(position.getId())
+                .name(position.getName())
+                .nameEN(position.getNameEN())
+                .build();
             allPositionEmployee.put(positionDto, listAvailableEmployeeWithPosition(order, position)
                 .stream().map(employee -> EmployeeNameIdDto.builder()
                     .id(employee.getId())

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -66,6 +66,7 @@ import greencity.dto.payment.PaymentResponseDto;
 import greencity.dto.payment.PaymentTableInfoDto;
 import greencity.dto.position.PositionAuthoritiesDto;
 import greencity.dto.position.PositionDto;
+import greencity.dto.position.PositionWithTranslateDto;
 import greencity.dto.service.GetServiceDto;
 import greencity.dto.service.GetTariffServiceDto;
 import greencity.dto.service.ServiceDto;
@@ -1664,6 +1665,7 @@ public class ModelUtils {
         return Position.builder()
             .id(1L)
             .name("Водій")
+            .nameEN("Driver")
             .build();
     }
 
@@ -1671,6 +1673,7 @@ public class ModelUtils {
         return PositionDto.builder()
             .id(id)
             .name("Водій")
+            .nameEN("Driver")
             .build();
     }
 
@@ -4614,6 +4617,17 @@ public class ModelUtils {
         return PositionAuthoritiesDto.builder()
             .positionId(List.of(1L))
             .authorities(List.of("Auth"))
+            .build();
+    }
+
+    public static PositionWithTranslateDto getPositionWithTranslateDto(Long id) {
+        Map<String, String> nameTranslations = new HashMap<>();
+        nameTranslations.put("ua", "Водій");
+        nameTranslations.put("en", "Driver");
+
+        return PositionWithTranslateDto.builder()
+            .id(id)
+            .name(nameTranslations)
             .build();
     }
 }

--- a/service/src/test/java/greencity/mapping/employee/PositionDtoWithTranslateMapperTest.java
+++ b/service/src/test/java/greencity/mapping/employee/PositionDtoWithTranslateMapperTest.java
@@ -1,0 +1,27 @@
+package greencity.mapping.employee;
+
+import greencity.ModelUtils;
+import greencity.dto.position.PositionDto;
+import greencity.dto.position.PositionWithTranslateDto;
+import greencity.entity.user.employee.Position;
+import greencity.mapping.employee.PositionMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+class PositionDtoWithTranslateMapperTest {
+    @InjectMocks
+    PositionDtoWithTranslateMapper positionDtoWithTranslateMapper;
+
+    @Test
+    void convert() {
+        PositionWithTranslateDto expected = ModelUtils.getPositionWithTranslateDto(1L);
+        PositionWithTranslateDto actual = positionDtoWithTranslateMapper.convert(ModelUtils.getPosition());
+
+        assertEquals(expected, actual);
+    }
+}

--- a/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
@@ -10,6 +10,7 @@ import greencity.dto.employee.EmployeeWithTariffsIdDto;
 import greencity.dto.employee.GetEmployeeDto;
 import greencity.dto.position.AddingPositionDto;
 import greencity.dto.position.PositionDto;
+import greencity.dto.position.PositionWithTranslateDto;
 import greencity.dto.tariff.GetTariffInfoForEmployeeDto;
 import greencity.entity.order.TariffsInfo;
 import greencity.entity.user.employee.Employee;
@@ -354,9 +355,9 @@ class UBSManagementEmployeeServiceImplTest {
         when(positionRepository.findAll()).thenReturn(List.of(getPosition()));
         when(modelMapper.map(any(), any())).thenReturn(getPositionDto(1L));
 
-        List<PositionDto> positionDtos = employeeService.getAllPositions();
+        List<PositionWithTranslateDto> positionWithTranslateDtos = employeeService.getAllPositions();
 
-        assertEquals(1, positionDtos.size());
+        assertEquals(1, positionWithTranslateDtos.size());
 
         verify(positionRepository, times(1)).findAll();
     }


### PR DESCRIPTION
[[Admin cabinet] Add to the "Position" names division in Ukrainian and English #5972]
(https://github.com/ita-social-projects/GreenCity/issues/5972)


Now Position have names division in Ukrainian and English

Added new Dto: PositionWithTranslateDto which returns map: <language code>: <name>

Changed: New field in Position, PositionDto: "nameEN"

