### PR TITLE
[API] [Notifications] Removed status 403 Forbidden when ADMIN try to get /notifications

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -224,7 +224,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 "/notifications",
                 "/notifications/**",
                 "/notifications/quantityUnreadenNotifications")
-            .hasAnyRole(USER, ADMIN)
+            .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE)
             .antMatchers(HttpMethod.PUT,
                 UBS_LINK + "/userProfile/**",
                 UBS_LINK + "/update-order-address")


### PR DESCRIPTION
[API] [Notifications] Response status 403 Forbidden appears but in the documentation does not specify this status 
https://github.com/ita-social-projects/GreenCity/issues/5936

Added UBS_EMPLOYEE to access notifications

Actual result
403 status Forbidden is missing

Now admin have access to apply the GET method by using the request url https://greencity-ubs.greencity.social/notifications