### PR TITLE
#6005[UBS] changed repetitive strings on constants

### DIFF
--- a/dao/src/main/java/greencity/enums/OrderStatus.java
+++ b/dao/src/main/java/greencity/enums/OrderStatus.java
@@ -3,16 +3,25 @@ package greencity.enums;
 import java.util.Arrays;
 
 public enum OrderStatus {
-    FORMED(1, "ADJUSTMENT", "BROUGHT_IT_HIMSELF", OrderStatus.CANCELED_STR),
-    ADJUSTMENT(2, "FORMED", "BROUGHT_IT_HIMSELF", "CONFIRMED", OrderStatus.CANCELED_STR),
-    BROUGHT_IT_HIMSELF(3, "DONE", OrderStatus.CANCELED_STR),
-    CONFIRMED(4, "FORMED", "ON_THE_ROUTE", "BROUGHT_IT_HIMSELF", OrderStatus.CANCELED_STR),
-    ON_THE_ROUTE(5, "DONE", "NOT_TAKEN_OUT", OrderStatus.CANCELED_STR),
-    DONE(6, "DONE"),
-    NOT_TAKEN_OUT(7, "ADJUSTMENT", "BROUGHT_IT_HIMSELF", OrderStatus.CANCELED_STR),
+    FORMED(1, OrderStatus.ADJUSTMENT_STR, OrderStatus.BROUGHT_IT_HIMSELF_STR, OrderStatus.CANCELED_STR),
+    ADJUSTMENT(2, OrderStatus.FORMED_STR, OrderStatus.BROUGHT_IT_HIMSELF_STR, OrderStatus.CONFIRMED_STR,
+            OrderStatus.CANCELED_STR),
+    BROUGHT_IT_HIMSELF(3, OrderStatus.DONE_STR, OrderStatus.CANCELED_STR),
+    CONFIRMED(4, OrderStatus.FORMED_STR, OrderStatus.ON_THE_ROUTE_STR, OrderStatus.BROUGHT_IT_HIMSELF_STR,
+            OrderStatus.CANCELED_STR),
+    ON_THE_ROUTE(5, OrderStatus.DONE_STR, OrderStatus.NOT_TAKEN_OUT_STR, OrderStatus.CANCELED_STR),
+    DONE(6, OrderStatus.DONE_STR),
+    NOT_TAKEN_OUT(7, OrderStatus.ADJUSTMENT_STR, OrderStatus.BROUGHT_IT_HIMSELF_STR, OrderStatus.CANCELED_STR),
     CANCELED(8, OrderStatus.CANCELED_STR);
 
     private static final String CANCELED_STR = "CANCELED";
+    private static final String BROUGHT_IT_HIMSELF_STR = "BROUGHT_IT_HIMSELF";
+    private static final String ADJUSTMENT_STR = "ADJUSTMENT";
+    private static final String DONE_STR = "DONE";
+    private static final String FORMED_STR = "FORMED";
+    private static final String CONFIRMED_STR = "CONFIRMED";
+    private static final String ON_THE_ROUTE_STR = "ON_THE_ROUTE";
+    private static final String NOT_TAKEN_OUT_STR = "NOT_TAKEN_OUT";
     private final int statusValue;
     private final String[] possibleStatus;
 


### PR DESCRIPTION
## Summary of issue

SonarCloud found code smell in dao/src/main/java/greencity/enums/OrderStatus.java. Constants should be used instead of duplicating literals

## Summary of change

All Strings in enum were changed to constants.
