### PR TITLE
Add validation for AddNewTariffDto

### DIFF
--- a/service-api/src/main/java/greencity/dto/AddNewTariffDto.java
+++ b/service-api/src/main/java/greencity/dto/AddNewTariffDto.java
@@ -26,5 +26,6 @@ public class AddNewTariffDto {
     private Long courierId;
     @NotEmpty
     private List<@Min(1) Long> locationIdList;
+    @NotEmpty
     private List<@Min(1) Long> receivingStationsIdList;
 }


### PR DESCRIPTION

## Summary of issue
 The message about mandatory filling in the "receiving station" field is not displayed when only the location and the courier tags are selected when creating a new pricing card

## Summary of change

Add @NotEmpty for receivingStation

