### PR TITLE
Bug #5973 ubs admin tariffs receiving station

### DIFF
--- a/service-api/src/main/java/greencity/dto/AddNewTariffDto.java
+++ b/service-api/src/main/java/greencity/dto/AddNewTariffDto.java
@@ -26,5 +26,6 @@ public class AddNewTariffDto {
     private Long courierId;
     @NotEmpty
     private List<@Min(1) Long> locationIdList;
+    @NotEmpty
     private List<@Min(1) Long> receivingStationsIdList;
 }

--- a/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
@@ -59,7 +59,11 @@ class AddNewTariffDtoTest {
         Set<ConstraintViolation<AddNewTariffDto>> constraintViolations =
             validator.validate(dto);
 
-        assertThat(constraintViolations).hasSize(1);
+        assertThat(constraintViolations)
+            .hasSize(1)
+            .extracting(ConstraintViolation::getMessage)
+            .contains("не може бути порожнім");
+        ;
     }
 
     @SneakyThrows

--- a/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
@@ -47,8 +47,9 @@ class AddNewTariffDtoTest {
 
         assertThat(constraintViolations).isEmpty();
     }
+
     @Test
-    void addNewTariffDtoWithReceivingFieldIsEmpty(){
+    void addNewTariffDtoWithReceivingFieldIsEmpty() {
         var dto = ModelUtils.getAddNewTariffWithNullFieldsDto();
         dto.setReceivingStationsIdList(Collections.emptyList());
 
@@ -56,7 +57,7 @@ class AddNewTariffDtoTest {
         final Validator validator = factory.getValidator();
 
         Set<ConstraintViolation<AddNewTariffDto>> constraintViolations =
-                validator.validate(dto);
+            validator.validate(dto);
 
         assertThat(constraintViolations).hasSize(1);
     }

--- a/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
@@ -62,7 +62,7 @@ class AddNewTariffDtoTest {
         assertThat(constraintViolations)
             .hasSize(1)
             .extracting(ConstraintViolation::getMessage)
-            .contains("не може бути порожнім");
+            .contains("must not be empty");
     }
 
     @SneakyThrows

--- a/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
@@ -37,6 +37,7 @@ class AddNewTariffDtoTest {
     @Test
     void addNewTariffDtoWithValidNullFieldsTest() {
         var dto = ModelUtils.getAddNewTariffWithNullFieldsDto();
+        dto.setReceivingStationsIdList(Collections.singletonList(1L));
 
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         final Validator validator = factory.getValidator();

--- a/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
@@ -47,6 +47,19 @@ class AddNewTariffDtoTest {
 
         assertThat(constraintViolations).isEmpty();
     }
+    @Test
+    void addNewTariffDtoWithReceivingFieldIsEmpty(){
+        var dto = ModelUtils.getAddNewTariffWithNullFieldsDto();
+        dto.setReceivingStationsIdList(Collections.emptyList());
+
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        final Validator validator = factory.getValidator();
+
+        Set<ConstraintViolation<AddNewTariffDto>> constraintViolations =
+                validator.validate(dto);
+
+        assertThat(constraintViolations).hasSize(1);
+    }
 
     @SneakyThrows
     @ParameterizedTest

--- a/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
@@ -63,7 +63,6 @@ class AddNewTariffDtoTest {
             .hasSize(1)
             .extracting(ConstraintViolation::getMessage)
             .contains("не може бути порожнім");
-        ;
     }
 
     @SneakyThrows


### PR DESCRIPTION

## Summary of issue

The message about mandatory filling in the "receiving station" field is not displayed when only the location and the courier tags are selected when creating a new pricing card #5973

## Summary of change

Add validation for receivingStation
