### PR TITLE
Fix code smell in table column width for employee test

### DIFF
--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -41,6 +41,11 @@
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dao/src/test/java/greencity/entity/table/TableColumnWidthForEmployeeTest.java
+++ b/dao/src/test/java/greencity/entity/table/TableColumnWidthForEmployeeTest.java
@@ -12,16 +12,8 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 
 class TableColumnWidthForEmployeeTest {
-    private static Employee employee;
-    private static TableColumnWidthForEmployee tableColumnWidth;
-    static int defaultWidth;
-
-    @BeforeAll
-    public static void setup() {
-        employee = Employee.builder().build();
-        tableColumnWidth = new TableColumnWidthForEmployee(employee);
-        defaultWidth = 120;
-    }
+    private static final Employee employee = Employee.builder().build();
+    private static final TableColumnWidthForEmployee tableColumnWidth = new TableColumnWidthForEmployee(employee);
 
     @Test
     void checkTableColumnWidthEmployee() {
@@ -29,6 +21,7 @@ class TableColumnWidthForEmployeeTest {
     }
 
     static Stream<Arguments> testArguments() {
+        int defaultWidth = 120;
         return Stream.of(
             Arguments.of(defaultWidth, tableColumnWidth.getAddress()),
             Arguments.of(defaultWidth, tableColumnWidth.getAmountDue()),
@@ -68,7 +61,7 @@ class TableColumnWidthForEmployeeTest {
 
     @ParameterizedTest
     @MethodSource("testArguments")
-    void TableColumnWidthForEmployeeWithDefaultWidthTest(int expected, int actual) {
+    void tableColumnWidthForEmployeeWithDefaultWidthTest(int expected, int actual) {
         assertEquals(expected, actual);
     }
 

--- a/dao/src/test/java/greencity/entity/table/TableColumnWidthForEmployeeTest.java
+++ b/dao/src/test/java/greencity/entity/table/TableColumnWidthForEmployeeTest.java
@@ -1,14 +1,11 @@
 package greencity.entity.table;
 
 import greencity.entity.user.employee.Employee;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
 import java.util.stream.Stream;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 class TableColumnWidthForEmployeeTest {

--- a/dao/src/test/java/greencity/entity/table/TableColumnWidthForEmployeeTest.java
+++ b/dao/src/test/java/greencity/entity/table/TableColumnWidthForEmployeeTest.java
@@ -1,50 +1,97 @@
 package greencity.entity.table;
 
 import greencity.entity.user.employee.Employee;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 class TableColumnWidthForEmployeeTest {
+    private static Employee employee;
+    private static TableColumnWidthForEmployee tableColumnWidth;
+    static int defaultWidth;
+
+    @BeforeAll
+    public static void setup() {
+        employee = Employee.builder().build();
+        tableColumnWidth = new TableColumnWidthForEmployee(employee);
+        defaultWidth = 120;
+    }
+
     @Test
-    void TableColumnWidthForEmployeeWithDefaultWidthTest() {
-        Employee employee = Employee.builder().build();
-        TableColumnWidthForEmployee tableColumnWidth = new TableColumnWidthForEmployee(employee);
-        int defaultWidth = 120;
+    void checkTableColumnWidthEmployee() {
         assertEquals(employee, tableColumnWidth.getEmployee());
-        assertEquals(defaultWidth, tableColumnWidth.getAddress());
-        assertEquals(defaultWidth, tableColumnWidth.getAmountDue());
-        assertEquals(defaultWidth, tableColumnWidth.getBagsAmount());
-        assertEquals(defaultWidth, tableColumnWidth.getBlockedBy());
-        assertEquals(defaultWidth, tableColumnWidth.getCity());
-        assertEquals(defaultWidth, tableColumnWidth.getClientEmail());
-        assertEquals(defaultWidth, tableColumnWidth.getClientName());
-        assertEquals(defaultWidth, tableColumnWidth.getClientPhone());
-        assertEquals(defaultWidth, tableColumnWidth.getCommentForOrderByClient());
-        assertEquals(defaultWidth, tableColumnWidth.getCommentToAddressForClient());
-        assertEquals(defaultWidth, tableColumnWidth.getCommentsForOrder());
-        assertEquals(defaultWidth, tableColumnWidth.getDateOfExport());
-        assertEquals(defaultWidth, tableColumnWidth.getDistrict());
-        assertEquals(defaultWidth, tableColumnWidth.getGeneralDiscount());
-        assertEquals(defaultWidth, tableColumnWidth.getOrderId());
-        assertEquals(defaultWidth, tableColumnWidth.getIdOrderFromShop());
-        assertEquals(defaultWidth, tableColumnWidth.getOrderCertificateCode());
-        assertEquals(defaultWidth, tableColumnWidth.getOrderDate());
-        assertEquals(defaultWidth, tableColumnWidth.getOrderPaymentStatus());
-        assertEquals(defaultWidth, tableColumnWidth.getOrderStatus());
-        assertEquals(defaultWidth, tableColumnWidth.getPaymentDate());
-        assertEquals(defaultWidth, tableColumnWidth.getReceivingStatus());
-        assertEquals(defaultWidth, tableColumnWidth.getRegion());
-        assertEquals(defaultWidth, tableColumnWidth.getResponsibleCaller());
-        assertEquals(defaultWidth, tableColumnWidth.getResponsibleDriver());
-        assertEquals(defaultWidth, tableColumnWidth.getResponsibleLogicMan());
-        assertEquals(defaultWidth, tableColumnWidth.getResponsibleNavigator());
-        assertEquals(defaultWidth, tableColumnWidth.getSenderEmail());
-        assertEquals(defaultWidth, tableColumnWidth.getSenderName());
-        assertEquals(defaultWidth, tableColumnWidth.getSenderPhone());
-        assertEquals(defaultWidth, tableColumnWidth.getTimeOfExport());
-        assertEquals(defaultWidth, tableColumnWidth.getTotalOrderSum());
-        assertEquals(defaultWidth, tableColumnWidth.getTotalPayment());
-        assertEquals(defaultWidth, tableColumnWidth.getViolationsAmount());
+    }
+
+    static Stream<Arguments> testArguments() {
+        return Stream.of(
+            Arguments.of(defaultWidth, tableColumnWidth.getAddress()),
+            Arguments.of(defaultWidth, tableColumnWidth.getAmountDue()),
+            Arguments.of(defaultWidth, tableColumnWidth.getBagsAmount()),
+            Arguments.of(defaultWidth, tableColumnWidth.getBlockedBy()),
+            Arguments.of(defaultWidth, tableColumnWidth.getCity()),
+            Arguments.of(defaultWidth, tableColumnWidth.getClientEmail()),
+            Arguments.of(defaultWidth, tableColumnWidth.getClientName()),
+            Arguments.of(defaultWidth, tableColumnWidth.getClientPhone()),
+            Arguments.of(defaultWidth, tableColumnWidth.getCommentForOrderByClient()),
+            Arguments.of(defaultWidth, tableColumnWidth.getCommentToAddressForClient()),
+            Arguments.of(defaultWidth, tableColumnWidth.getCommentsForOrder()),
+            Arguments.of(defaultWidth, tableColumnWidth.getDateOfExport()),
+            Arguments.of(defaultWidth, tableColumnWidth.getDistrict()),
+            Arguments.of(defaultWidth, tableColumnWidth.getGeneralDiscount()),
+            Arguments.of(defaultWidth, tableColumnWidth.getOrderId()),
+            Arguments.of(defaultWidth, tableColumnWidth.getIdOrderFromShop()),
+            Arguments.of(defaultWidth, tableColumnWidth.getOrderCertificateCode()),
+            Arguments.of(defaultWidth, tableColumnWidth.getOrderDate()),
+            Arguments.of(defaultWidth, tableColumnWidth.getOrderPaymentStatus()),
+            Arguments.of(defaultWidth, tableColumnWidth.getOrderStatus()),
+            Arguments.of(defaultWidth, tableColumnWidth.getPaymentDate()),
+            Arguments.of(defaultWidth, tableColumnWidth.getReceivingStatus()),
+            Arguments.of(defaultWidth, tableColumnWidth.getRegion()),
+            Arguments.of(defaultWidth, tableColumnWidth.getResponsibleCaller()),
+            Arguments.of(defaultWidth, tableColumnWidth.getResponsibleDriver()),
+            Arguments.of(defaultWidth, tableColumnWidth.getResponsibleLogicMan()),
+            Arguments.of(defaultWidth, tableColumnWidth.getResponsibleNavigator()),
+            Arguments.of(defaultWidth, tableColumnWidth.getSenderEmail()),
+            Arguments.of(defaultWidth, tableColumnWidth.getSenderName()),
+            Arguments.of(defaultWidth, tableColumnWidth.getSenderPhone()),
+            Arguments.of(defaultWidth, tableColumnWidth.getTimeOfExport()),
+            Arguments.of(defaultWidth, tableColumnWidth.getTotalOrderSum()),
+            Arguments.of(defaultWidth, tableColumnWidth.getTotalPayment()),
+            Arguments.of(defaultWidth, tableColumnWidth.getViolationsAmount()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testArguments")
+    void TableColumnWidthForEmployeeWithDefaultWidthTest(int expected, int actual) {
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testNoArgsConstructor() {
+        TableColumnWidthForEmployee tableColumnWidth = new TableColumnWidthForEmployee();
+        assertNotNull(tableColumnWidth);
+        assertNull(tableColumnWidth.getId());
+        assertNull(tableColumnWidth.getEmployee());
+    }
+
+    @Test
+    void testBuilder() {
+        Employee newEmployee = Employee.builder().build();
+        TableColumnWidthForEmployee tableColumnWidth = TableColumnWidthForEmployee.builder()
+            .employee(newEmployee)
+            .address(100)
+            .amountDue(200)
+            .build();
+
+        assertNotNull(tableColumnWidth);
+        assertEquals(employee, tableColumnWidth.getEmployee());
+        assertEquals(100, tableColumnWidth.getAddress());
+        assertEquals(200, tableColumnWidth.getAmountDue());
     }
 }

--- a/dao/src/test/java/greencity/entity/table/TableColumnWidthForEmployeeTest.java
+++ b/dao/src/test/java/greencity/entity/table/TableColumnWidthForEmployeeTest.java
@@ -9,51 +9,51 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 
 class TableColumnWidthForEmployeeTest {
-    private static final Employee employee = Employee.builder().build();
-    private static final TableColumnWidthForEmployee tableColumnWidth = new TableColumnWidthForEmployee(employee);
+    private static final Employee EMPLOYEE = Employee.builder().build();
+    private static final TableColumnWidthForEmployee TABLE_COLUMN_WIDTH = new TableColumnWidthForEmployee(EMPLOYEE);
 
     @Test
     void checkTableColumnWidthEmployee() {
-        assertEquals(employee, tableColumnWidth.getEmployee());
+        assertEquals(EMPLOYEE, TABLE_COLUMN_WIDTH.getEmployee());
     }
 
     static Stream<Arguments> testArguments() {
         int defaultWidth = 120;
         return Stream.of(
-            Arguments.of(defaultWidth, tableColumnWidth.getAddress()),
-            Arguments.of(defaultWidth, tableColumnWidth.getAmountDue()),
-            Arguments.of(defaultWidth, tableColumnWidth.getBagsAmount()),
-            Arguments.of(defaultWidth, tableColumnWidth.getBlockedBy()),
-            Arguments.of(defaultWidth, tableColumnWidth.getCity()),
-            Arguments.of(defaultWidth, tableColumnWidth.getClientEmail()),
-            Arguments.of(defaultWidth, tableColumnWidth.getClientName()),
-            Arguments.of(defaultWidth, tableColumnWidth.getClientPhone()),
-            Arguments.of(defaultWidth, tableColumnWidth.getCommentForOrderByClient()),
-            Arguments.of(defaultWidth, tableColumnWidth.getCommentToAddressForClient()),
-            Arguments.of(defaultWidth, tableColumnWidth.getCommentsForOrder()),
-            Arguments.of(defaultWidth, tableColumnWidth.getDateOfExport()),
-            Arguments.of(defaultWidth, tableColumnWidth.getDistrict()),
-            Arguments.of(defaultWidth, tableColumnWidth.getGeneralDiscount()),
-            Arguments.of(defaultWidth, tableColumnWidth.getOrderId()),
-            Arguments.of(defaultWidth, tableColumnWidth.getIdOrderFromShop()),
-            Arguments.of(defaultWidth, tableColumnWidth.getOrderCertificateCode()),
-            Arguments.of(defaultWidth, tableColumnWidth.getOrderDate()),
-            Arguments.of(defaultWidth, tableColumnWidth.getOrderPaymentStatus()),
-            Arguments.of(defaultWidth, tableColumnWidth.getOrderStatus()),
-            Arguments.of(defaultWidth, tableColumnWidth.getPaymentDate()),
-            Arguments.of(defaultWidth, tableColumnWidth.getReceivingStatus()),
-            Arguments.of(defaultWidth, tableColumnWidth.getRegion()),
-            Arguments.of(defaultWidth, tableColumnWidth.getResponsibleCaller()),
-            Arguments.of(defaultWidth, tableColumnWidth.getResponsibleDriver()),
-            Arguments.of(defaultWidth, tableColumnWidth.getResponsibleLogicMan()),
-            Arguments.of(defaultWidth, tableColumnWidth.getResponsibleNavigator()),
-            Arguments.of(defaultWidth, tableColumnWidth.getSenderEmail()),
-            Arguments.of(defaultWidth, tableColumnWidth.getSenderName()),
-            Arguments.of(defaultWidth, tableColumnWidth.getSenderPhone()),
-            Arguments.of(defaultWidth, tableColumnWidth.getTimeOfExport()),
-            Arguments.of(defaultWidth, tableColumnWidth.getTotalOrderSum()),
-            Arguments.of(defaultWidth, tableColumnWidth.getTotalPayment()),
-            Arguments.of(defaultWidth, tableColumnWidth.getViolationsAmount()));
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getAddress()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getAmountDue()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getBagsAmount()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getBlockedBy()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getCity()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getClientEmail()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getClientName()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getClientPhone()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getCommentForOrderByClient()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getCommentToAddressForClient()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getCommentsForOrder()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getDateOfExport()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getDistrict()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getGeneralDiscount()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getOrderId()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getIdOrderFromShop()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getOrderCertificateCode()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getOrderDate()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getOrderPaymentStatus()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getOrderStatus()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getPaymentDate()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getReceivingStatus()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getRegion()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getResponsibleCaller()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getResponsibleDriver()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getResponsibleLogicMan()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getResponsibleNavigator()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getSenderEmail()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getSenderName()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getSenderPhone()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getTimeOfExport()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getTotalOrderSum()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getTotalPayment()),
+            Arguments.of(defaultWidth, TABLE_COLUMN_WIDTH.getViolationsAmount()));
     }
 
     @ParameterizedTest
@@ -80,7 +80,7 @@ class TableColumnWidthForEmployeeTest {
             .build();
 
         assertNotNull(tableColumnWidth);
-        assertEquals(employee, tableColumnWidth.getEmployee());
+        assertEquals(EMPLOYEE, tableColumnWidth.getEmployee());
         assertEquals(100, tableColumnWidth.getAddress());
         assertEquals(200, tableColumnWidth.getAmountDue());
     }

--- a/dao/src/test/java/greencity/entity/table/TableColumnWidthForEmployeeTest.java
+++ b/dao/src/test/java/greencity/entity/table/TableColumnWidthForEmployeeTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class TableColumnWidthForEmployeeTest {
     private static final Employee EMPLOYEE = Employee.builder().build();


### PR DESCRIPTION
## Summary of issue

SonarCloud found code smell in dao/src/test/java/greencity/entity/table/TableColumnWidthForEmployeeTest.java. Too many assertions in one method. 

## Summary of change

Added parameterized Test instead of default one and added more test coverage by creating tests for NoArgsConstructor and Builder. Also added junit-jupiter-params in the pom file for using mentioned parameterized Test.
