### PR TITLE
[Admin. Orders] Missing of the option "Без менеджера/логіста/штурмана/водія" in the relevant filters #4239

### DIFF
--- a/dao/src/main/java/greencity/filters/OrderPage.java
+++ b/dao/src/main/java/greencity/filters/OrderPage.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Sort;
 @Data
 public class OrderPage {
     private int pageNumber = 0;
-    private int pageSize = 10;
+    private int pageSize = 200;
     private Sort.Direction sortDirection = Sort.Direction.DESC;
     private String sortBy = "id";
 }

--- a/dao/src/main/java/greencity/filters/OrderPage.java
+++ b/dao/src/main/java/greencity/filters/OrderPage.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Sort;
 @Data
 public class OrderPage {
     private int pageNumber = 0;
-    private int pageSize = 200;
+    private int pageSize = 10;
     private Sort.Direction sortDirection = Sort.Direction.DESC;
     private String sortBy = "id";
 }

--- a/dao/src/main/java/greencity/repository/BigOrderTableRepository.java
+++ b/dao/src/main/java/greencity/repository/BigOrderTableRepository.java
@@ -16,6 +16,7 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Objects.nonNull;
@@ -105,7 +106,16 @@ public class BigOrderTableRepository {
         Root<BigOrderTableViews> orderRoot) {
         orderFilterDataProvider.getFiltersLong().entrySet().stream()
             .filter(e -> e.getValue().apply(sc) != null)
-            .map(e -> criteriaPredicate.filter(e.getValue().apply(sc), orderRoot, e.getKey()))
+            .map(e -> {
+                Long[] values = e.getValue().apply(sc);
+                Predicate predicate;
+                if (Arrays.stream(values).anyMatch(value -> value != null && value != -1L)) {
+                    predicate = criteriaPredicate.filter(values, orderRoot, e.getKey());
+                } else {
+                    predicate = criteriaPredicate.filter(orderRoot, e.getKey());
+                }
+                return predicate;
+            })
             .forEach(predicates::add);
     }
 

--- a/dao/src/main/java/greencity/repository/CustomCriteriaPredicate.java
+++ b/dao/src/main/java/greencity/repository/CustomCriteriaPredicate.java
@@ -66,6 +66,10 @@ public class CustomCriteriaPredicate {
         return predicate;
     }
 
+    Predicate filter(Root<?> root, String nameColumn) {
+        return criteriaBuilder.isNull(root.<Long>get(nameColumn));
+    }
+
     Predicate filter(List<Long> ids, Root<?> root, String nameColumn) {
         List<Predicate> predicateList = new ArrayList<>();
         for (Long id : ids) {


### PR DESCRIPTION
# GreenCityUBS PR
https://github.com/ita-social-projects/GreenCity/issues/4239

## Summary Of Changes :fire:
Added predicate for filtering items by null ids.

## Added
* Added predicate for filtering items by null ids. Predicate will filter by a column in which there are no ids (without responsible caller, without responsible driver, without responsible navigator, without responsible logic man etc). For getting such items we expect -1L as a parameter for responsibleCallerId, responsibleDriverId, responsibleNavigatorId, responsibleLogicManId etc.

## How to test :clipboard:
In can be test via swagger:
[/ubs/management/bigOrderTable]

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
