### PR TITLE
refactored updateOrderAdminPageInfo to decrease its cognitive complexity

### DIFF
--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -1094,6 +1094,19 @@ class UBSManagementServiceImplTest {
     }
 
     @Test
+    void testSetOrderDetailIdNotFound() {
+        Long orderId = 123L;
+        when(orderRepository.findById(Mockito.eq(orderId))).thenReturn(Optional.empty());
+        assertThrows(NotFoundException.class, () -> {
+            ubsManagementService.setOrderDetail(orderId,
+                UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsConfirmed(),
+                UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(),
+                "testEmail@gmail.com");
+        });
+        verify(orderRepository).findById(anyLong());
+    }
+
+    @Test
     void testSetOrderDetailNeedToChangeStatusToHALF_PAID() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusDoneDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -1094,19 +1094,6 @@ class UBSManagementServiceImplTest {
     }
 
     @Test
-    void testSetOrderDetailIdNotFound() {
-        Long orderId = 123L;
-        when(orderRepository.findById(Mockito.eq(orderId))).thenReturn(Optional.empty());
-        assertThrows(NotFoundException.class, () -> {
-            ubsManagementService.setOrderDetail(orderId,
-                UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsConfirmed(),
-                UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsExported(),
-                "testEmail@gmail.com");
-        });
-        verify(orderRepository).findById(anyLong());
-    }
-
-    @Test
     void testSetOrderDetailNeedToChangeStatusToHALF_PAID() {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusDoneDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);


### PR DESCRIPTION
## Summary of issue

Cognitive complexity of the **_updateOrderAdminPageInfo_** method is too high.

## Summary of change

Added two methods: **_updateOrderPageFields_** and **_isOrderStatusCanceledOrDone_** that take some responsibility of **_updateOrderAdminPageInfo_** method.

##
Link on the issue [6029](https://github.com/ita-social-projects/GreenCity/issues/6029)