### PR TITLE
Resolved codeSmells in ViolationServiceImpl and UBSManagementEmployeeServiceImplTest

### DIFF
--- a/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
@@ -116,6 +116,7 @@ public class ViolationServiceImpl implements ViolationService {
         for (Long id : tariffsInfoIds) {
             if (id.equals(order.getTariffsInfo().getId())) {
                 status = true;
+                break;
             }
         }
         if (!status) {

--- a/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
@@ -114,7 +114,9 @@ public class ViolationServiceImpl implements ViolationService {
         boolean status = false;
         List<Long> tariffsInfoIds = employeeRepository.findTariffsInfoForEmployee(employeeId);
         for (Long id : tariffsInfoIds) {
-            status = id.equals(order.getTariffsInfo().getId()) ? true : status;
+            if (id.equals(order.getTariffsInfo().getId())) {
+                status = true;
+            }
         }
         if (!status) {
             throw new BadRequestException(ErrorMessage.CANNOT_ACCESS_ORDER_FOR_EMPLOYEE + orderId);

--- a/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
@@ -299,11 +299,12 @@ class UBSManagementEmployeeServiceImplTest {
     @Test
     void deactivateEmployeeHystrixRuntimeExceptionTest() {
         Employee employee = getEmployee();
+        long employeeId = employee.getId();
         employee.setImagePath("Pass");
         when(repository.findById(1L)).thenReturn(Optional.of(employee));
 
         doThrow(HystrixRuntimeException.class).when(userRemoteClient).deactivateEmployee("Test");
-        assertThrows(BadRequestException.class, () -> employeeService.deactivateEmployee(employee.getId()));
+        assertThrows(BadRequestException.class, () -> employeeService.deactivateEmployee(employeeId));
 
         verify(repository).findById(1L);
     }


### PR DESCRIPTION
## Summary of issue

In ViolationServiceImpl and UBSManagementEmployeeServiceImplTest code smells are found:
1.Remove the unnecessary boolean literal.
2.Refactor the code of the lambda to have only one invocation possibly throwing a runtime exception.

## Summary of change

In the file ViolationServiceImpl in the method checkAvailableOrderForEmployee unnecessary boolean literal was removed.
In the file UBSManagementEmployeeServiceImplTest in the method deactivateEmployeeHystrixRuntimeExceptionTest assertThrows was changed to take only method that can potentially throw an exception
##
issue link - [6037](https://github.com/ita-social-projects/GreenCity/issues/6037)