### PR TITLE
[Pick up city UBS.Admin Cabinet] “Return money” button in the "Order payment" section is disabled when admin cancels the order and selects the "Return money" option #5803

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -113,6 +113,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 UBS_MANAG_LINK + "/add-manual-payment/{id}",
                 UBS_MANAG_LINK + "/add-bonuses-user/{id}",
                 UBS_MANAG_LINK + "/order/{id}/cancellation",
+                UBS_MANAG_LINK + "/save-order-for-refund/{orderId}",
                 ADMIN_EMPL_LINK + "/**",
                 SUPER_ADMIN_LINK + "/add-new-tariff",
                 SUPER_ADMIN_LINK + "/check-if-tariff-exists",

--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -1041,4 +1041,27 @@ public class ManagementOrderController {
         @ApiIgnore @CurrentUserUuid String uuid) {
         return ResponseEntity.status(HttpStatus.OK).body(ubsClientService.updateOrderCancellationReason(id, dto, uuid));
     }
+
+    /**
+     * Controller saves order ID of order for which we need to make a refund.
+     *
+     * @param orderId {@link Long}.
+     * @return {@link HttpStatus} - http status.
+     *
+     * @author Anton Bondar
+     */
+    @ApiOperation(value = "saves order ID of order for which we need to make a refund")
+    @ApiResponses(value = {
+        @ApiResponse(code = 201, message = HttpStatuses.CREATED),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
+    })
+    @ResponseStatus(value = HttpStatus.CREATED)
+    @PostMapping("/save-order-for-refund/{orderId}")
+    public ResponseEntity<HttpStatus> saveOrderIdForRefund(
+        @Valid @PathVariable("orderId") Long orderId) {
+        ubsManagementService.saveOrderIdForRefund(orderId);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
 }

--- a/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
@@ -501,4 +501,10 @@ class ManagementOrderControllerTest {
             .content(objectMapper.writeValueAsString(dto)))
             .andExpect(status().isOk());
     }
+
+    @Test
+    void saveOrderIdForRefundTest() throws Exception {
+        mockMvc.perform(post(ubsLink + "/save-order-for-refund/{orderId}", 1L)
+            .principal(principal)).andExpect(status().isCreated());
+    }
 }

--- a/dao/src/main/java/greencity/entity/order/Refund.java
+++ b/dao/src/main/java/greencity/entity/order/Refund.java
@@ -1,0 +1,30 @@
+package greencity.entity.order;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "refunds")
+public class Refund {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "order_id")
+    @NotNull
+    private Long orderId;
+}

--- a/dao/src/main/java/greencity/repository/RefundRepository.java
+++ b/dao/src/main/java/greencity/repository/RefundRepository.java
@@ -1,0 +1,9 @@
+package greencity.repository;
+
+import greencity.entity.order.Refund;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefundRepository extends JpaRepository<Refund, Long> {
+}

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -213,4 +213,5 @@
     <include file="/db/changelog/logs/ch-upd-notification-platforms-body-body_eng-Lenets.xml"/>
     <include file="/db/changelog/logs/ch-update_big_order_table_view-with-bags-sorting-Lenets.xml"/>
     <include file="/db/changelog/logs/ch-upd-notification-templates-titles-Lenets.xml"/>
+    <include file="db/changelog/logs/ch-add-table-refunds-Bondar.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-add-table-refunds-Bondar.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-table-refunds-Bondar.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="Anton-3" author="Bondar Anton">
+        <createTable tableName="refunds">
+            <column name="id" autoIncrement="true" type="BIGINT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="order_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
@@ -4,7 +4,24 @@ import greencity.dto.bag.AdditionalBagInfoDto;
 import greencity.dto.bag.ReasonNotTakeBagDto;
 import greencity.dto.certificate.CertificateDtoForSearching;
 import greencity.dto.employee.EmployeePositionDtoRequest;
-import greencity.dto.order.*;
+import greencity.dto.order.AdminCommentDto;
+import greencity.dto.order.CounterOrderDetailsDto;
+import greencity.dto.order.DetailsOrderInfoDto;
+import greencity.dto.order.EcoNumberDto;
+import greencity.dto.order.ExportDetailsDto;
+import greencity.dto.order.ExportDetailsDtoUpdate;
+import greencity.dto.order.NotTakenOrderReasonDto;
+import greencity.dto.order.OrderAddressDtoResponse;
+import greencity.dto.order.OrderAddressExportDetailsDtoUpdate;
+import greencity.dto.order.OrderCancellationReasonDto;
+import greencity.dto.order.OrderDetailInfoDto;
+import greencity.dto.order.OrderDetailStatusDto;
+import greencity.dto.order.OrderDetailStatusRequestDto;
+import greencity.dto.order.OrderInfoDto;
+import greencity.dto.order.OrderStatusPageDto;
+import greencity.dto.order.ReadAddressByOrderDto;
+import greencity.dto.order.UpdateAllOrderPageDto;
+import greencity.dto.order.UpdateOrderPageAdminDto;
 import greencity.dto.pageble.PageableDto;
 import greencity.dto.payment.ManualPaymentRequestDto;
 import greencity.dto.payment.ManualPaymentResponseDto;
@@ -301,4 +318,13 @@ public interface UBSManagementService {
      * @author Kharchenko Volodymyr.
      */
     NotTakenOrderReasonDto getNotTakenOrderReason(Long orderId);
+
+    /**
+     * Method saves order ID of order for which we need to make a refund.
+     *
+     * @param orderId {@link Long}.
+     *
+     * @author Anton Bondar.
+     */
+    void saveOrderIdForRefund(Long orderId);
 }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -129,13 +129,13 @@ import static greencity.constant.ErrorMessage.BAG_NOT_FOUND;
 import static greencity.constant.ErrorMessage.EMPLOYEE_NOT_FOUND;
 import static greencity.constant.ErrorMessage.INCORRECT_ECO_NUMBER;
 import static greencity.constant.ErrorMessage.NOT_FOUND_ADDRESS_BY_ORDER_ID;
+import static greencity.constant.ErrorMessage.ORDER_CAN_NOT_BE_UPDATED;
 import static greencity.constant.ErrorMessage.ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST;
 import static greencity.constant.ErrorMessage.PAYMENT_NOT_FOUND;
 import static greencity.constant.ErrorMessage.RECEIVING_STATION_NOT_FOUND;
 import static greencity.constant.ErrorMessage.RECEIVING_STATION_NOT_FOUND_BY_ID;
 import static greencity.constant.ErrorMessage.USER_HAS_NO_OVERPAYMENT;
 import static greencity.constant.ErrorMessage.USER_WITH_CURRENT_UUID_DOES_NOT_EXIST;
-import static greencity.constant.ErrorMessage.ORDER_CAN_NOT_BE_UPDATED;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
@@ -1837,8 +1837,8 @@ public class UBSManagementServiceImpl implements UBSManagementService {
 
     @Override
     public void saveOrderIdForRefund(Long orderId) {
-        orderRepository.findById(orderId)
+        Order order = orderRepository.findById(orderId)
             .orElseThrow(() -> new NotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST + orderId));
-        refundRepository.save(Refund.builder().orderId(orderId).build());
+        refundRepository.save(Refund.builder().orderId(order.getId()).build());
     }
 }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -55,6 +55,7 @@ import greencity.entity.order.Order;
 import greencity.entity.order.OrderPaymentStatusTranslation;
 import greencity.entity.order.OrderStatusTranslation;
 import greencity.entity.order.Payment;
+import greencity.entity.order.Refund;
 import greencity.entity.order.TariffsInfo;
 import greencity.entity.user.User;
 import greencity.entity.user.employee.Employee;
@@ -83,6 +84,7 @@ import greencity.repository.OrderStatusTranslationRepository;
 import greencity.repository.PaymentRepository;
 import greencity.repository.PositionRepository;
 import greencity.repository.ReceivingStationRepository;
+import greencity.repository.RefundRepository;
 import greencity.repository.ServiceRepository;
 import greencity.repository.TariffsInfoRepository;
 import greencity.repository.UserRepository;
@@ -163,6 +165,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     private final OrderPaymentStatusTranslationRepository orderPaymentStatusTranslationRepository;
     private final ServiceRepository serviceRepository;
     private final OrdersAdminsPageService ordersAdminsPageService;
+    private final RefundRepository refundRepository;
 
     private static final String DEFAULT_IMAGE_PATH = AppConstant.DEFAULT_IMAGE;
 
@@ -1830,5 +1833,12 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             .description(order.getReasonNotTakingBagDescription())
             .images(order.getImageReasonNotTakingBags())
             .build();
+    }
+
+    @Override
+    public void saveOrderIdForRefund(Long orderId) {
+        orderRepository.findById(orderId)
+            .orElseThrow(() -> new NotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST + orderId));
+        refundRepository.save(Refund.builder().orderId(orderId).build());
     }
 }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -102,6 +102,7 @@ import greencity.entity.order.Order;
 import greencity.entity.order.OrderPaymentStatusTranslation;
 import greencity.entity.order.OrderStatusTranslation;
 import greencity.entity.order.Payment;
+import greencity.entity.order.Refund;
 import greencity.entity.order.Service;
 import greencity.entity.order.TariffLocation;
 import greencity.entity.order.TariffsInfo;
@@ -4643,5 +4644,9 @@ public class ModelUtils {
             .id(id)
             .name(nameTranslations)
             .build();
+    }
+
+    public static Refund getRefund(Long id) {
+        return Refund.builder().orderId(id).build();
     }
 }

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -39,6 +39,7 @@ import greencity.entity.order.Order;
 import greencity.entity.order.OrderPaymentStatusTranslation;
 import greencity.entity.order.OrderStatusTranslation;
 import greencity.entity.order.Payment;
+import greencity.entity.order.Refund;
 import greencity.entity.order.TariffsInfo;
 import greencity.entity.user.User;
 import greencity.entity.user.employee.Employee;
@@ -63,6 +64,7 @@ import greencity.repository.OrderStatusTranslationRepository;
 import greencity.repository.PaymentRepository;
 import greencity.repository.PositionRepository;
 import greencity.repository.ReceivingStationRepository;
+import greencity.repository.RefundRepository;
 import greencity.repository.ServiceRepository;
 import greencity.repository.TariffsInfoRepository;
 import greencity.repository.UserRepository;
@@ -103,7 +105,66 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static greencity.ModelUtils.*;
+import static greencity.ModelUtils.ORDER_DETAIL_STATUS_DTO;
+import static greencity.ModelUtils.TEST_ADDITIONAL_BAG_INFO_DTO;
+import static greencity.ModelUtils.TEST_ADDITIONAL_BAG_INFO_DTO_LIST;
+import static greencity.ModelUtils.TEST_BAG;
+import static greencity.ModelUtils.TEST_BAG_INFO_DTO;
+import static greencity.ModelUtils.TEST_BAG_LIST;
+import static greencity.ModelUtils.TEST_BAG_MAPPING_DTO_LIST;
+import static greencity.ModelUtils.TEST_MAP_ADDITIONAL_BAG_LIST;
+import static greencity.ModelUtils.TEST_ORDER;
+import static greencity.ModelUtils.TEST_ORDER_ADDRESS_DTO_RESPONSE;
+import static greencity.ModelUtils.TEST_ORDER_ADDRESS_DTO_UPDATE;
+import static greencity.ModelUtils.TEST_ORDER_DETAILS_INFO_DTO_LIST;
+import static greencity.ModelUtils.TEST_PAYMENT_LIST;
+import static greencity.ModelUtils.TEST_USER;
+import static greencity.ModelUtils.UPDATE_ORDER_PAGE_ADMIN_DTO;
+import static greencity.ModelUtils.getAddBonusesToUserDto;
+import static greencity.ModelUtils.getAdminCommentDto;
+import static greencity.ModelUtils.getBag1list;
+import static greencity.ModelUtils.getBag2list;
+import static greencity.ModelUtils.getBag3list;
+import static greencity.ModelUtils.getBagInfoDto;
+import static greencity.ModelUtils.getBaglist;
+import static greencity.ModelUtils.getCertificateList;
+import static greencity.ModelUtils.getEcoNumberDto;
+import static greencity.ModelUtils.getEmployee;
+import static greencity.ModelUtils.getExportDetailsRequest;
+import static greencity.ModelUtils.getExportDetailsRequestToday;
+import static greencity.ModelUtils.getFormedOrder;
+import static greencity.ModelUtils.getInfoPayment;
+import static greencity.ModelUtils.getManualPayment;
+import static greencity.ModelUtils.getManualPaymentRequestDto;
+import static greencity.ModelUtils.getOrder;
+import static greencity.ModelUtils.getOrderAddress;
+import static greencity.ModelUtils.getOrderDoneByUser;
+import static greencity.ModelUtils.getOrderExportDetails;
+import static greencity.ModelUtils.getOrderExportDetailsWithDeliverFromTo;
+import static greencity.ModelUtils.getOrderExportDetailsWithExportDate;
+import static greencity.ModelUtils.getOrderExportDetailsWithExportDateDeliverFrom;
+import static greencity.ModelUtils.getOrderExportDetailsWithExportDateDeliverFromTo;
+import static greencity.ModelUtils.getOrderExportDetailsWithNullValues;
+import static greencity.ModelUtils.getOrderForGetOrderStatusData2Test;
+import static greencity.ModelUtils.getOrderForGetOrderStatusEmptyPriceDetails;
+import static greencity.ModelUtils.getOrderStatusPaymentTranslations;
+import static greencity.ModelUtils.getOrderStatusTranslation;
+import static greencity.ModelUtils.getOrderStatusTranslations;
+import static greencity.ModelUtils.getOrderUserFirst;
+import static greencity.ModelUtils.getOrderWithoutPayment;
+import static greencity.ModelUtils.getOrdersStatusFormedDto;
+import static greencity.ModelUtils.getPayment;
+import static greencity.ModelUtils.getReceivingList;
+import static greencity.ModelUtils.getReceivingStation;
+import static greencity.ModelUtils.getRefund;
+import static greencity.ModelUtils.getService;
+import static greencity.ModelUtils.getStatusTranslation;
+import static greencity.ModelUtils.getTariffsInfo;
+import static greencity.ModelUtils.getTestDetailsOrderInfoDto;
+import static greencity.ModelUtils.getTestOrderDetailStatusRequestDto;
+import static greencity.ModelUtils.getTestUser;
+import static greencity.ModelUtils.updateAllOrderPageDto;
+import static greencity.ModelUtils.updateOrderPageAdminDto;
 import static greencity.constant.ErrorMessage.EMPLOYEE_NOT_FOUND;
 import static greencity.constant.ErrorMessage.ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST;
 import static greencity.constant.ErrorMessage.ORDER_CAN_NOT_BE_UPDATED;
@@ -200,6 +261,9 @@ class UBSManagementServiceImplTest {
     @Mock
     TariffsInfoRepository tariffsInfoRepository;
 
+    @Mock
+    RefundRepository refundRepository;
+
     @Test
     void getAllCertificates() {
         Pageable pageable =
@@ -228,7 +292,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void getAddressByOrderId() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         ReadAddressByOrderDto readAddressByOrderDto = ModelUtils.getReadAddressByOrderDto();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(ubsManagementService.getAddressByOrderId(1L)).thenReturn(readAddressByOrderDto);
@@ -243,7 +307,7 @@ class UBSManagementServiceImplTest {
     @Test
     void returnExportDetailsByOrderId() {
         ExportDetailsDto expected = ModelUtils.getExportDetails();
-        Order order = ModelUtils.getOrderExportDetails();
+        Order order = getOrderExportDetails();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
 
         List<ReceivingStation> stations =
@@ -255,10 +319,10 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateExportDetailsByOrderId() {
-        ExportDetailsDtoUpdate dto = ModelUtils.getExportDetailsRequest();
-        Order order = ModelUtils.getOrderExportDetails();
+        ExportDetailsDtoUpdate dto = getExportDetailsRequest();
+        Order order = getOrderExportDetails();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
-        var receivingStation = ModelUtils.getReceivingStation();
+        var receivingStation = getReceivingStation();
         when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(receivingStation));
 
         List<ReceivingStation> stations = List.of(new ReceivingStation());
@@ -271,10 +335,10 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateExportDetailsNotSuccessfulByOrderId() {
-        ExportDetailsDtoUpdate dto = ModelUtils.getExportDetailsRequest();
-        Order order = ModelUtils.getOrderExportDetailsWithNullValues();
+        ExportDetailsDtoUpdate dto = getExportDetailsRequest();
+        Order order = getOrderExportDetailsWithNullValues();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
-        var receivingStation = ModelUtils.getReceivingStation();
+        var receivingStation = getReceivingStation();
         when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(receivingStation));
         List<ReceivingStation> stations = List.of(new ReceivingStation());
         when(receivingStationRepository.findAll()).thenReturn(stations);
@@ -292,14 +356,14 @@ class UBSManagementServiceImplTest {
     @ParameterizedTest
     @MethodSource("provideManualPaymentRequestDto")
     void saveNewManualPayment(ManualPaymentRequestDto paymentDetails, MultipartFile image) {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setRecipientName("Петро");
         user.setRecipientSurname("Петренко");
-        Order order = ModelUtils.getFormedOrder();
+        Order order = getFormedOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
-        Payment payment = ModelUtils.getManualPayment();
-        Employee employee = ModelUtils.getEmployee();
+        Payment payment = getManualPayment();
+        Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -345,7 +409,7 @@ class UBSManagementServiceImplTest {
     @Test
     void checkUpdateManualPayment() {
         Employee employee = getEmployee();
-        Order order = ModelUtils.getFormedOrder();
+        Order order = getFormedOrder();
         when(employeeRepository.findByUuid("abc")).thenReturn(Optional.of(employee));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(paymentRepository.findById(1L)).thenReturn(Optional.of(getManualPayment()));
@@ -364,20 +428,20 @@ class UBSManagementServiceImplTest {
 
     @Test
     void saveNewManualPaymentWithZeroAmount() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setRecipientName("Петро");
         user.setRecipientSurname("Петренко");
-        Order order = ModelUtils.getFormedOrder();
+        Order order = getFormedOrder();
         order.setPointsToUse(0);
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
         order.setOrderPaymentStatus(OrderPaymentStatus.UNPAID);
-        Payment payment = ModelUtils.getManualPayment();
+        Payment payment = getManualPayment();
         payment.setAmount(0L);
         order.setPayment(singletonList(payment));
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
             .settlementdate("02-08-2021").amount(0L).receiptLink("link").paymentId("1").build();
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -397,20 +461,20 @@ class UBSManagementServiceImplTest {
 
     @Test
     void saveNewManualPaymentWithHalfPaidAmount() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setRecipientName("Петро");
         user.setRecipientSurname("Петренко");
-        Order order = ModelUtils.getFormedOrder();
+        Order order = getFormedOrder();
         order.setPointsToUse(0);
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
         order.setOrderPaymentStatus(OrderPaymentStatus.HALF_PAID);
-        Payment payment = ModelUtils.getManualPayment();
+        Payment payment = getManualPayment();
         payment.setAmount(50_00L);
         order.setPayment(singletonList(payment));
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
             .settlementdate("02-08-2021").amount(50_00L).receiptLink("link").paymentId("1").build();
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -433,19 +497,19 @@ class UBSManagementServiceImplTest {
 
     @Test
     void saveNewManualPaymentWithPaidAmount() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setRecipientName("Петро");
         user.setRecipientSurname("Петренко");
-        Order order = ModelUtils.getFormedOrder();
+        Order order = getFormedOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
         order.setOrderPaymentStatus(OrderPaymentStatus.PAID);
-        Payment payment = ModelUtils.getManualPayment();
+        Payment payment = getManualPayment();
         payment.setAmount(500_00L);
         order.setPayment(singletonList(payment));
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
             .settlementdate("02-08-2021").amount(500_00L).receiptLink("link").paymentId("1").build();
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -468,17 +532,17 @@ class UBSManagementServiceImplTest {
 
     @Test
     void saveNewManualPaymentWithPaidOrder() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setRecipientName("Петро");
         user.setRecipientSurname("Петренко");
-        Order order = ModelUtils.getFormedOrder();
+        Order order = getFormedOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
         order.setOrderPaymentStatus(OrderPaymentStatus.PAID);
-        Payment payment = ModelUtils.getManualPayment();
+        Payment payment = getManualPayment();
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
             .settlementdate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -497,17 +561,17 @@ class UBSManagementServiceImplTest {
 
     @Test
     void saveNewManualPaymentWithPartiallyPaidOrder() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setRecipientName("Петро");
         user.setRecipientSurname("Петренко");
-        Order order = ModelUtils.getFormedOrder();
+        Order order = getFormedOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
         order.setOrderPaymentStatus(OrderPaymentStatus.HALF_PAID);
-        Payment payment = ModelUtils.getManualPayment();
+        Payment payment = getManualPayment();
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
             .settlementdate("02-08-2021").amount(200L).receiptLink("link").paymentId("1").build();
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -526,17 +590,17 @@ class UBSManagementServiceImplTest {
 
     @Test
     void saveNewManualPaymentWithUnpaidOrder() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setRecipientName("Петро");
         user.setRecipientSurname("Петренко");
-        Order order = ModelUtils.getFormedOrder();
+        Order order = getFormedOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
         order.setOrderPaymentStatus(OrderPaymentStatus.UNPAID);
-        Payment payment = ModelUtils.getManualPayment();
+        Payment payment = getManualPayment();
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
             .settlementdate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -555,17 +619,17 @@ class UBSManagementServiceImplTest {
 
     @Test
     void saveNewManualPaymentWithPaymentRefundedOrder() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setRecipientName("Петро");
         user.setRecipientSurname("Петренко");
-        Order order = ModelUtils.getFormedOrder();
+        Order order = getFormedOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
         order.setOrderPaymentStatus(OrderPaymentStatus.PAYMENT_REFUNDED);
-        Payment payment = ModelUtils.getManualPayment();
+        Payment payment = getManualPayment();
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
             .settlementdate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -616,7 +680,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void checkReturnOverpaymentInfo() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         when(orderRepository.findUserById(1L)).thenReturn(Optional.of(order));
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
 
@@ -642,7 +706,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void checkReturnOverpaymentThroweExceptioninGetPaymentInfo() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         when(orderRepository.findUserById(1L)).thenReturn(Optional.of(order));
 
         Assertions.assertThrows(NotFoundException.class, () -> ubsManagementService.returnOverpaymentInfo(1L, 1., 1L));
@@ -650,7 +714,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void checkGetPaymentInfo() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         order.setOrderStatus(OrderStatus.DONE);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         assertEquals(100L, ubsManagementService.getPaymentInfo(order.getId(), 800.).getOverpayment());
@@ -661,7 +725,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void checkGetPaymentInfoIfOrderStatusIsCanceled() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         order.setOrderStatus(OrderStatus.CANCELED);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         assertEquals(200L, ubsManagementService.getPaymentInfo(order.getId(), 800.).getOverpayment());
@@ -672,7 +736,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void checkGetPaymentInfoIfSumToPayIsNull() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         order.setOrderStatus(OrderStatus.DONE);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         assertEquals(900L, ubsManagementService.getPaymentInfo(order.getId(), null).getOverpayment());
@@ -689,7 +753,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateOrderDetailStatusFirst() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setRecipientName("Петро");
         user.setRecipientSurname("Петренко");
         Order order = user.getOrders().get(0);
@@ -705,7 +769,7 @@ class UBSManagementServiceImplTest {
         when(paymentRepository.saveAll(any())).thenReturn(payment);
         when(orderRepository.save(any())).thenReturn(order);
 
-        OrderDetailStatusRequestDto testOrderDetail = ModelUtils.getTestOrderDetailStatusRequestDto();
+        OrderDetailStatusRequestDto testOrderDetail = getTestOrderDetailStatusRequestDto();
         OrderDetailStatusDto expectedObject = ModelUtils.getTestOrderDetailStatusDto();
         OrderDetailStatusDto producedObject = ubsManagementService
             .updateOrderDetailStatus(order.getId(), testOrderDetail, "test@gmail.com");
@@ -809,7 +873,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateOrderDetailStatusSecond() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setRecipientName("Петро");
         user.setRecipientSurname("Петренко");
         Order order = user.getOrders().get(0);
@@ -823,7 +887,7 @@ class UBSManagementServiceImplTest {
         when(paymentRepository.saveAll(any())).thenReturn(payment);
         when(orderRepository.save(any())).thenReturn(order);
 
-        OrderDetailStatusRequestDto testOrderDetail = ModelUtils.getTestOrderDetailStatusRequestDto();
+        OrderDetailStatusRequestDto testOrderDetail = getTestOrderDetailStatusRequestDto();
         OrderDetailStatusDto expectedObject = ModelUtils.getTestOrderDetailStatusDto();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy");
         expectedObject.setDate(LocalDateTime.now().format(formatter));
@@ -839,17 +903,17 @@ class UBSManagementServiceImplTest {
 
     @Test
     void getAllEmployeesByPosition() {
-        Order order = ModelUtils.getOrder();
-        TariffsInfo tariffsInfo = ModelUtils.getTariffsInfo();
+        Order order = getOrder();
+        TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         EmployeePositionDtoRequest dto = ModelUtils.getEmployeePositionDtoRequest();
         List<EmployeeOrderPosition> newList = new ArrayList<>();
         newList.add(ModelUtils.getEmployeeOrderPosition());
         List<Position> positionList = new ArrayList<>();
         positionList.add(ModelUtils.getPosition());
         List<Employee> employeeList = new ArrayList<>();
-        employeeList.add(ModelUtils.getEmployee());
+        employeeList.add(getEmployee());
         when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -868,10 +932,10 @@ class UBSManagementServiceImplTest {
 
     @Test
     void getAllEmployeesByPositionThrowBadRequestException() {
-        Order order = ModelUtils.getOrder();
-        TariffsInfo tariffsInfo = ModelUtils.getTariffsInfo();
+        Order order = getOrder();
+        TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -993,7 +1057,7 @@ class UBSManagementServiceImplTest {
     @Test
     void testGetOrderExportDetailsReceivingStationNotFoundExceptionThrown() {
         when(orderRepository.findById(1L))
-            .thenReturn(Optional.of(ModelUtils.getOrder()));
+            .thenReturn(Optional.of(getOrder()));
         List<ReceivingStation> receivingStations = new ArrayList<>();
         when(receivingStationRepository.findAll())
             .thenReturn(receivingStations);
@@ -1026,7 +1090,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void testAddPointToUserThrowsException() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setUuid(null);
 
         AddingPointsToUserDto addingPointsToUserDto =
@@ -1036,7 +1100,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void testAddPointsToUser() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setUuid(userRemoteClient.findUuidByEmail(user.getRecipientEmail()));
         user.setCurrentPoints(1);
 
@@ -1080,9 +1144,9 @@ class UBSManagementServiceImplTest {
         doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
         doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
-        when(bagRepository.findBagsByOrderId(1L)).thenReturn(ModelUtils.getBag1list());
+        when(bagRepository.findBagsByOrderId(1L)).thenReturn(getBag1list());
         when(paymentRepository.selectSumPaid(1L)).thenReturn(5000L);
 
         ubsManagementService.setOrderDetail(1L,
@@ -1100,9 +1164,9 @@ class UBSManagementServiceImplTest {
         doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
         doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
-        when(bagRepository.findBagsByOrderId(1L)).thenReturn(ModelUtils.getBag1list());
+        when(bagRepository.findBagsByOrderId(1L)).thenReturn(getBag1list());
         when(paymentRepository.selectSumPaid(1L)).thenReturn(5000L);
         doNothing().when(orderRepository).updateOrderPaymentStatus(1L, OrderPaymentStatus.HALF_PAID.name());
 
@@ -1123,9 +1187,9 @@ class UBSManagementServiceImplTest {
         doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
         doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
-        when(bagRepository.findBagsByOrderId(1L)).thenReturn(ModelUtils.getBag1list());
+        when(bagRepository.findBagsByOrderId(1L)).thenReturn(getBag1list());
         when(paymentRepository.selectSumPaid(1L)).thenReturn(null);
         doNothing().when(orderRepository).updateOrderPaymentStatus(1L, OrderPaymentStatus.UNPAID.name());
 
@@ -1145,7 +1209,7 @@ class UBSManagementServiceImplTest {
         doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
         doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
         when(paymentRepository.selectSumPaid(1L)).thenReturn(null);
 
@@ -1181,7 +1245,7 @@ class UBSManagementServiceImplTest {
     @Test
     void testSetOrderDetailIfHalfPaid() {
         Order orderDto = ModelUtils.getOrdersStatusDoneDto();
-        Order orderDetailDto = ModelUtils.getOrdersStatusFormedDto();
+        Order orderDetailDto = getOrdersStatusFormedDto();
         Bag tariffBagDto = ModelUtils.getTariffBag();
         List<Bag> bagList = getBaglist();
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(orderDto));
@@ -1247,7 +1311,7 @@ class UBSManagementServiceImplTest {
         when(bagRepository.findCapacityById(1)).thenReturn(1);
         doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
         ubsManagementService.setOrderDetail(1L,
@@ -1264,7 +1328,7 @@ class UBSManagementServiceImplTest {
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusConfirmedDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
         when(orderDetailRepository.ifRecordExist(any(), any())).thenReturn(1L);
         when(orderDetailRepository.getAmount(any(), any())).thenReturn(1L);
@@ -1288,7 +1352,7 @@ class UBSManagementServiceImplTest {
         doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
         doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
         when(orderDetailRepository.ifRecordExist(any(), any())).thenReturn(1L);
         ubsManagementService.setOrderDetail(1L,
@@ -1305,11 +1369,11 @@ class UBSManagementServiceImplTest {
 
     @Test
     void testSetOrderDetailFormed() {
-        when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+        when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);
         doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
 
         ubsManagementService.setOrderDetail(1L,
@@ -1321,7 +1385,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void testSetOrderDetailFormedWithBagNoPresent() {
-        when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+        when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findCapacityById(1)).thenReturn(1);
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.empty());
@@ -1342,7 +1406,7 @@ class UBSManagementServiceImplTest {
         doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
         doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
 
@@ -1361,7 +1425,7 @@ class UBSManagementServiceImplTest {
         when(bagRepository.findCapacityById(1)).thenReturn(1);
         doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
 
         ubsManagementService.setOrderDetail(1L,
@@ -1380,7 +1444,7 @@ class UBSManagementServiceImplTest {
         doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
         doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
         ubsManagementService.setOrderDetail(1L,
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsConfirmed(),
@@ -1398,7 +1462,7 @@ class UBSManagementServiceImplTest {
         when(bagRepository.findCapacityById(1)).thenReturn(1);
         doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
         ubsManagementService.setOrderDetail(1L,
             UPDATE_ORDER_PAGE_ADMIN_DTO.getOrderDetailDto().getAmountOfBagsConfirmed(),
@@ -1416,7 +1480,7 @@ class UBSManagementServiceImplTest {
         doNothing().when(orderDetailRepository).updateExporter(anyInt(), anyLong(), anyLong());
         doNothing().when(orderDetailRepository).updateConfirm(anyInt(), anyLong(), anyLong());
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
 
         ubsManagementService.setOrderDetail(1L,
@@ -1447,15 +1511,15 @@ class UBSManagementServiceImplTest {
 
     @Test
     void testSaveAdminToOrder() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
             .thenReturn(Optional.of(tariffsInfo));
-        ubsManagementService.saveAdminCommentToOrder(ModelUtils.getAdminCommentDto(), "test@gmail.com");
+        ubsManagementService.saveAdminCommentToOrder(getAdminCommentDto(), "test@gmail.com");
         verify(orderRepository, times(1)).save(order);
         verify(eventService, times(1)).save(any(), any(), any());
         verify(tariffsInfoRepository, atLeastOnce()).findTariffsInfoByIdForEmployee(anyLong(), anyLong());
@@ -1463,14 +1527,14 @@ class UBSManagementServiceImplTest {
 
     @Test
     void testUpdateEcoNumberForOrder() {
-        when(orderRepository.findById(1L)).thenReturn(Optional.of(ModelUtils.getOrder()));
-        ubsManagementService.updateEcoNumberForOrder(ModelUtils.getEcoNumberDto(), 1L, "abc");
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(getOrder()));
+        ubsManagementService.updateEcoNumberForOrder(getEcoNumberDto(), 1L, "abc");
         verify(eventService, times(1)).saveEvent(any(), any(), any());
     }
 
     @Test
     void testUpdateEcoNumberThrowOrderNotFoundException() {
-        EcoNumberDto dto = ModelUtils.getEcoNumberDto();
+        EcoNumberDto dto = getEcoNumberDto();
         when(orderRepository.findById(1L)).thenReturn(Optional.empty());
         assertThrows(NotFoundException.class,
             () -> ubsManagementService.updateEcoNumberForOrder(dto, 1L, "test@gmail.com"));
@@ -1487,9 +1551,9 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateEcoNumberTrowsIncorrectEcoNumberFormatException() {
-        when(orderRepository.findById(1L)).thenReturn(Optional.of(ModelUtils.getOrder()));
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(getOrder()));
 
-        EcoNumberDto ecoNumberDto = ModelUtils.getEcoNumberDto();
+        EcoNumberDto ecoNumberDto = getEcoNumberDto();
         ecoNumberDto.setEcoNumber(new HashSet<>(List.of("1234a")));
         assertThrows(BadRequestException.class,
             () -> ubsManagementService.updateEcoNumberForOrder(ecoNumberDto, 1L, "abc"));
@@ -1505,7 +1569,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void getOrdersForUserTest() {
-        Order order1 = ModelUtils.getOrderUserFirst();
+        Order order1 = getOrderUserFirst();
         Order order2 = ModelUtils.getOrderUserSecond();
         List<Order> orders = List.of(order1, order2);
         OrderInfoDto info1 = OrderInfoDto.builder().id(1L).orderPrice(10).build();
@@ -1532,17 +1596,17 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateOrderAdminPageInfoTest() {
-        OrderDetailStatusRequestDto orderDetailStatusRequestDto = ModelUtils.getTestOrderDetailStatusRequestDto();
-        Order order = ModelUtils.getOrder();
+        OrderDetailStatusRequestDto orderDetailStatusRequestDto = getTestOrderDetailStatusRequestDto();
+        Order order = getOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setOrderDate(LocalDateTime.now()).setTariffsInfo(tariffsInfo);
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
             .thenReturn(Optional.of(tariffsInfo));
         when(paymentRepository.findAllByOrderId(1L))
-            .thenReturn(List.of(ModelUtils.getPayment()));
+            .thenReturn(List.of(getPayment()));
         lenient().when(ubsManagementServiceMock.updateOrderDetailStatus(1L, orderDetailStatusRequestDto, "abc"))
             .thenReturn(ModelUtils.getTestOrderDetailStatusDto());
         when(ubsClientService.updateUbsUserInfoInOrder(ModelUtils.getUbsCustomersDtoUpdate(),
@@ -1550,13 +1614,13 @@ class UBSManagementServiceImplTest {
         UpdateOrderPageAdminDto updateOrderPageAdminDto = updateOrderPageAdminDto();
         updateOrderPageAdminDto.setUserInfoDto(ModelUtils.getUbsCustomersDtoUpdate());
         when(orderAddressRepository.findById(1L))
-            .thenReturn(Optional.of(ModelUtils.getOrderAddress()));
+            .thenReturn(Optional.of(getOrderAddress()));
         when(receivingStationRepository.findAll())
-            .thenReturn(List.of(ModelUtils.getReceivingStation()));
-        var receivingStation = ModelUtils.getReceivingStation();
+            .thenReturn(List.of(getReceivingStation()));
+        var receivingStation = getReceivingStation();
         when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(receivingStation));
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
 
         ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, 1L, "en", "test@gmail.com");
@@ -1570,17 +1634,17 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateOrderAdminPageInfoWithUbsCourierSumAndWriteOffStationSum() {
-        OrderDetailStatusRequestDto orderDetailStatusRequestDto = ModelUtils.getTestOrderDetailStatusRequestDto();
-        Order order = ModelUtils.getOrder();
+        OrderDetailStatusRequestDto orderDetailStatusRequestDto = getTestOrderDetailStatusRequestDto();
+        Order order = getOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setOrderDate(LocalDateTime.now()).setTariffsInfo(tariffsInfo);
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
             .thenReturn(Optional.of(tariffsInfo));
         when(paymentRepository.findAllByOrderId(1L))
-            .thenReturn(List.of(ModelUtils.getPayment()));
+            .thenReturn(List.of(getPayment()));
         lenient().when(ubsManagementServiceMock.updateOrderDetailStatus(1L, orderDetailStatusRequestDto, "abc"))
             .thenReturn(ModelUtils.getTestOrderDetailStatusDto());
         when(ubsClientService.updateUbsUserInfoInOrder(ModelUtils.getUbsCustomersDtoUpdate(),
@@ -1590,13 +1654,13 @@ class UBSManagementServiceImplTest {
         updateOrderPageAdminDto.setUbsCourierSum(50.);
         updateOrderPageAdminDto.setWriteOffStationSum(100.);
         when(orderAddressRepository.findById(1L))
-            .thenReturn(Optional.of(ModelUtils.getOrderAddress()));
+            .thenReturn(Optional.of(getOrderAddress()));
         when(receivingStationRepository.findAll())
-            .thenReturn(List.of(ModelUtils.getReceivingStation()));
-        var receivingStation = ModelUtils.getReceivingStation();
+            .thenReturn(List.of(getReceivingStation()));
+        var receivingStation = getReceivingStation();
         when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(receivingStation));
         when(orderRepository.getOrderDetails(anyLong()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getOrdersStatusFormedDto()));
+            .thenReturn(Optional.ofNullable(getOrdersStatusFormedDto()));
         when(bagRepository.findById(1)).thenReturn(Optional.of(ModelUtils.getTariffBag()));
 
         ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, 1L, "en", "test@gmail.com");
@@ -1610,12 +1674,12 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateOrderAdminPageInfoWithStatusFormedTest() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setOrderDate(LocalDateTime.now()).setTariffsInfo(tariffsInfo);
         order.setOrderStatus(OrderStatus.FORMED);
         EmployeeOrderPosition employeeOrderPosition = ModelUtils.getEmployeeOrderPosition();
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         UpdateOrderPageAdminDto updateOrderPageAdminDto = ModelUtils.updateOrderPageAdminDtoWithStatusFormed();
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
@@ -1623,8 +1687,8 @@ class UBSManagementServiceImplTest {
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
             .thenReturn(Optional.of(tariffsInfo));
-        when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(ModelUtils.getPayment()));
-        when(receivingStationRepository.findAll()).thenReturn(List.of(ModelUtils.getReceivingStation()));
+        when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(getPayment()));
+        when(receivingStationRepository.findAll()).thenReturn(List.of(getReceivingStation()));
         when(employeeOrderPositionRepository.findAllByOrderId(1L)).thenReturn(List.of(employeeOrderPosition));
 
         ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, 1L, "en", "test@gmail.com");
@@ -1644,7 +1708,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateOrderAdminPageInfoWithStatusCanceledTest() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setOrderDate(LocalDateTime.now()).setTariffsInfo(tariffsInfo);
         order.setOrderStatus(OrderStatus.CANCELED);
@@ -1663,7 +1727,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateOrderAdminPageInfoWithStatusDoneTest() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setOrderDate(LocalDateTime.now()).setTariffsInfo(tariffsInfo);
         order.setOrderStatus(OrderStatus.DONE);
@@ -1682,7 +1746,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateOrderAdminPageInfoWithStatusBroughtItHimselfTest() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         LocalDateTime orderDate = LocalDateTime.of(2023, 6, 10, 12, 10);
         LocalDateTime deliverFrom = LocalDateTime.of(2023, 6, 16, 15, 30);
         LocalDateTime deliverTo = LocalDateTime.of(2023, 6, 16, 19, 30);
@@ -1693,7 +1757,7 @@ class UBSManagementServiceImplTest {
         order.setDeliverTo(deliverTo);
         order.setTariffsInfo(tariffsInfo);
         order.setOrderStatus(OrderStatus.BROUGHT_IT_HIMSELF);
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         UpdateOrderPageAdminDto updateOrderPageAdminDto =
             ModelUtils.updateOrderPageAdminDtoWithStatusBroughtItHimself();
 
@@ -1702,7 +1766,7 @@ class UBSManagementServiceImplTest {
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
             .thenReturn(Optional.of(tariffsInfo));
-        when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(ModelUtils.getPayment()));
+        when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(getPayment()));
 
         ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, 1L, "en", "test@gmail.com");
 
@@ -1720,11 +1784,11 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateOrderAdminPageInfoWithNullFieldsTest() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setOrderDate(LocalDateTime.now()).setTariffsInfo(tariffsInfo);
         order.setOrderStatus(OrderStatus.ON_THE_ROUTE);
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         UpdateOrderPageAdminDto updateOrderPageAdminDto =
             ModelUtils.updateOrderPageAdminDtoWithNullFields();
 
@@ -1733,8 +1797,8 @@ class UBSManagementServiceImplTest {
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
             .thenReturn(Optional.of(tariffsInfo));
-        when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(ModelUtils.getPayment()));
-        when(receivingStationRepository.findAll()).thenReturn(List.of(ModelUtils.getReceivingStation()));
+        when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(getPayment()));
+        when(receivingStationRepository.findAll()).thenReturn(List.of(getReceivingStation()));
 
         ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, 1L, "en", "test@gmail.com");
 
@@ -1753,9 +1817,9 @@ class UBSManagementServiceImplTest {
     void updateOrderAdminPageInfoTestThrowsException() {
         UpdateOrderPageAdminDto updateOrderPageAdminDto = updateOrderPageAdminDto();
         TariffsInfo tariffsInfo = getTariffsInfo();
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         order.setOrderDate(LocalDateTime.now()).setTariffsInfo(tariffsInfo);
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -1778,21 +1842,21 @@ class UBSManagementServiceImplTest {
 
         LocalDateTime orderDate = LocalDateTime.now();
         TariffsInfo tariffsInfo = getTariffsInfo();
-        Order expected = ModelUtils.getOrder();
+        Order expected = getOrder();
         expected.setOrderDate(orderDate).setTariffsInfo(tariffsInfo);
         expected.setOrderStatus(OrderStatus.DONE);
 
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         order.setOrderDate(orderDate).setTariffsInfo(tariffsInfo);
         order.setOrderStatus(OrderStatus.BROUGHT_IT_HIMSELF);
 
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
             .thenReturn(Optional.of(tariffsInfo));
-        when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(ModelUtils.getPayment()));
+        when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(getPayment()));
 
         ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, 1L, "en", "test@gmail.com");
 
@@ -1815,7 +1879,7 @@ class UBSManagementServiceImplTest {
     @Test
     void getOrderSumDetailsForFormedOrder() {
         CounterOrderDetailsDto dto = ModelUtils.getcounterOrderDetailsDto();
-        Order order = ModelUtils.getFormedOrder();
+        Order order = getFormedOrder();
         order.setOrderDate(LocalDateTime.now());
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
 
@@ -1829,7 +1893,7 @@ class UBSManagementServiceImplTest {
     @Test
     void getOrderSumDetailsForFormedOrderWithUbsCourierSumAndWriteOffStationSum() {
         CounterOrderDetailsDto dto = ModelUtils.getcounterOrderDetailsDto();
-        Order order = ModelUtils.getFormedOrder();
+        Order order = getFormedOrder();
         order.setOrderDate(LocalDateTime.now());
         order.setUbsCourierSum(50_00L);
         order.setWriteOffStationSum(100_00L);
@@ -1937,8 +2001,8 @@ class UBSManagementServiceImplTest {
 
     @Test
     void getOrderStatusDataTest() {
-        Order order = ModelUtils.getOrderForGetOrderStatusData2Test();
-        BagInfoDto bagInfoDto = ModelUtils.getBagInfoDto();
+        Order order = getOrderForGetOrderStatusData2Test();
+        BagInfoDto bagInfoDto = getBagInfoDto();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
         Employee employee = getEmployee();
@@ -1949,7 +2013,7 @@ class UBSManagementServiceImplTest {
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(bagRepository.findBagsByOrderId(1L)).thenReturn(getBaglist());
         when(bagRepository.findBagsByTariffsInfoId(1L)).thenReturn(getBaglist());
-        when(certificateRepository.findCertificate(1L)).thenReturn(ModelUtils.getCertificateList());
+        when(certificateRepository.findCertificate(1L)).thenReturn(getCertificateList());
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(getOrderForGetOrderStatusData2Test()));
         when(serviceRepository.findServiceByTariffsInfoId(1L)).thenReturn(Optional.of(getService()));
         when(modelMapper.map(getBaglist().get(0), BagInfoDto.class)).thenReturn(bagInfoDto);
@@ -1961,7 +2025,7 @@ class UBSManagementServiceImplTest {
                 .thenReturn(OrderPaymentStatusTranslation.builder().translationValue("name").build());
         when(orderPaymentStatusTranslationRepository.getAllBy()).thenReturn(getOrderStatusPaymentTranslations());
         when(orderRepository.findById(6L)).thenReturn(Optional.of(order));
-        when(receivingStationRepository.findAll()).thenReturn(ModelUtils.getReceivingList());
+        when(receivingStationRepository.findAll()).thenReturn(getReceivingList());
 
         ubsManagementService.getOrderStatusData(1L, "test@gmail.com");
 
@@ -1971,7 +2035,7 @@ class UBSManagementServiceImplTest {
         verify(certificateRepository).findCertificate(1L);
         verify(orderRepository, times(5)).findById(1L);
         verify(serviceRepository).findServiceByTariffsInfoId(1L);
-        verify(modelMapper).map(ModelUtils.getBaglist().get(0), BagInfoDto.class);
+        verify(modelMapper).map(getBaglist().get(0), BagInfoDto.class);
         verify(orderStatusTranslationRepository).getOrderStatusTranslationById(6L);
         verify(orderPaymentStatusTranslationRepository).getById(1L);
         verify(receivingStationRepository).findAll();
@@ -1982,17 +2046,17 @@ class UBSManagementServiceImplTest {
 
     @Test
     void saveNewManualPaymentWhenImageNotNull() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setRecipientName("Петро");
         user.setRecipientSurname("Петренко");
-        Order order = ModelUtils.getFormedOrder();
+        Order order = getFormedOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
         order.setOrderPaymentStatus(OrderPaymentStatus.PAID);
-        Payment payment = ModelUtils.getManualPayment();
+        Payment payment = getManualPayment();
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
             .settlementdate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -2046,7 +2110,7 @@ class UBSManagementServiceImplTest {
         verify(certificateRepository).findCertificate(1L);
         verify(orderRepository, times(5)).findById(1L);
         verify(serviceRepository).findServiceByTariffsInfoId(1L);
-        verify(modelMapper).map(ModelUtils.getBaglist().get(0), BagInfoDto.class);
+        verify(modelMapper).map(getBaglist().get(0), BagInfoDto.class);
         verify(orderStatusTranslationRepository).getOrderStatusTranslationById(6L);
         verify(orderPaymentStatusTranslationRepository).getById(1L);
         verify(receivingStationRepository).findAll();
@@ -2056,11 +2120,11 @@ class UBSManagementServiceImplTest {
 
     @Test
     void getOrderStatusDataWithEmptyCertificateTest() {
-        Order order = ModelUtils.getOrderForGetOrderStatusData2Test();
-        BagInfoDto bagInfoDto = ModelUtils.getBagInfoDto();
+        Order order = getOrderForGetOrderStatusData2Test();
+        BagInfoDto bagInfoDto = getBagInfoDto();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -2077,7 +2141,7 @@ class UBSManagementServiceImplTest {
             orderPaymentStatusTranslationRepository.getById(1L))
                 .thenReturn(OrderPaymentStatusTranslation.builder().translationValue("name").build());
         when(orderRepository.findById(6L)).thenReturn(Optional.of(order));
-        when(receivingStationRepository.findAll()).thenReturn(ModelUtils.getReceivingList());
+        when(receivingStationRepository.findAll()).thenReturn(getReceivingList());
 
         ubsManagementService.getOrderStatusData(1L, "test@gmail.com");
 
@@ -2086,7 +2150,7 @@ class UBSManagementServiceImplTest {
         verify(bagRepository).findBagsByTariffsInfoId(1L);
         verify(orderRepository, times(5)).findById(1L);
         verify(serviceRepository).findServiceByTariffsInfoId(1L);
-        verify(modelMapper).map(ModelUtils.getBaglist().get(0), BagInfoDto.class);
+        verify(modelMapper).map(getBaglist().get(0), BagInfoDto.class);
         verify(orderStatusTranslationRepository).getOrderStatusTranslationById(6L);
         verify(orderPaymentStatusTranslationRepository).getById(1L);
         verify(receivingStationRepository).findAll();
@@ -2095,11 +2159,11 @@ class UBSManagementServiceImplTest {
 
     @Test
     void getOrderStatusDataWhenOrderTranslationIsNull() {
-        Order order = ModelUtils.getOrderForGetOrderStatusData2Test();
-        BagInfoDto bagInfoDto = ModelUtils.getBagInfoDto();
+        Order order = getOrderForGetOrderStatusData2Test();
+        BagInfoDto bagInfoDto = getBagInfoDto();
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -2114,7 +2178,7 @@ class UBSManagementServiceImplTest {
             orderPaymentStatusTranslationRepository.getById(1L))
                 .thenReturn(OrderPaymentStatusTranslation.builder().translationValue("name").build());
         when(orderRepository.findById(6L)).thenReturn(Optional.of(order));
-        when(receivingStationRepository.findAll()).thenReturn(ModelUtils.getReceivingList());
+        when(receivingStationRepository.findAll()).thenReturn(getReceivingList());
 
         ubsManagementService.getOrderStatusData(1L, "test@gmail.com");
 
@@ -2123,7 +2187,7 @@ class UBSManagementServiceImplTest {
         verify(bagRepository).findBagsByTariffsInfoId(1L);
         verify(orderRepository, times(5)).findById(1L);
         verify(serviceRepository).findServiceByTariffsInfoId(1L);
-        verify(modelMapper).map(ModelUtils.getBaglist().get(0), BagInfoDto.class);
+        verify(modelMapper).map(getBaglist().get(0), BagInfoDto.class);
         verify(orderStatusTranslationRepository).getOrderStatusTranslationById(6L);
         verify(orderPaymentStatusTranslationRepository).getById(1L);
         verify(receivingStationRepository).findAll();
@@ -2132,21 +2196,21 @@ class UBSManagementServiceImplTest {
 
     @Test
     void getOrderStatusDataExceptionTest() {
-        Order order = ModelUtils.getOrderForGetOrderStatusData2Test();
+        Order order = getOrderForGetOrderStatusData2Test();
         TariffsInfo tariffsInfo = getTariffsInfo();
-        BagInfoDto bagInfoDto = ModelUtils.getBagInfoDto();
+        BagInfoDto bagInfoDto = getBagInfoDto();
         order.setTariffsInfo(tariffsInfo);
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
             .thenReturn(Optional.of(tariffsInfo));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
-        when(bagRepository.findBagsByOrderId(1L)).thenReturn(ModelUtils.getBaglist());
-        when(certificateRepository.findCertificate(1L)).thenReturn(ModelUtils.getCertificateList());
+        when(bagRepository.findBagsByOrderId(1L)).thenReturn(getBaglist());
+        when(certificateRepository.findCertificate(1L)).thenReturn(getCertificateList());
         when(serviceRepository.findServiceByTariffsInfoId(1L)).thenReturn(Optional.of(getService()));
         when(orderRepository.findById(1L)).thenReturn(Optional.ofNullable(getOrderForGetOrderStatusData2Test()));
-        when(modelMapper.map(ModelUtils.getBaglist().get(0), BagInfoDto.class)).thenReturn(bagInfoDto);
+        when(modelMapper.map(getBaglist().get(0), BagInfoDto.class)).thenReturn(bagInfoDto);
         when(orderStatusTranslationRepository.getOrderStatusTranslationById(6L))
             .thenReturn(Optional.ofNullable(getStatusTranslation()));
         when(
@@ -2162,7 +2226,7 @@ class UBSManagementServiceImplTest {
 
         List<ReceivingStation> receivingStations = List.of(getReceivingStation());
         ExportDetailsDtoUpdate testDetails = getExportDetailsRequestToday();
-        var receivingStation = ModelUtils.getReceivingStation();
+        var receivingStation = getReceivingStation();
         when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(receivingStation));
         when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
         when(receivingStationRepository.findAll()).thenReturn(receivingStations);
@@ -2181,7 +2245,7 @@ class UBSManagementServiceImplTest {
         order.setDeliverFrom(null);
         List<ReceivingStation> receivingStations = List.of(getReceivingStation());
         ExportDetailsDtoUpdate emptyDetails = ExportDetailsDtoUpdate.builder().receivingStationId(1L).build();
-        var receivingStation = ModelUtils.getReceivingStation();
+        var receivingStation = getReceivingStation();
         when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(receivingStation));
         when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
         when(receivingStationRepository.findAll()).thenReturn(receivingStations);
@@ -2209,7 +2273,7 @@ class UBSManagementServiceImplTest {
     void updateOrderExportDetailsReceivingStationNotFoundExceptionTest() {
         Order order = getOrder();
         ExportDetailsDtoUpdate testDetails = getExportDetailsRequest();
-        var receivingStation = ModelUtils.getReceivingStation();
+        var receivingStation = getReceivingStation();
         when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
         when(receivingStationRepository.findAll()).thenReturn(Collections.emptyList());
         assertThrows(NotFoundException.class,
@@ -2284,8 +2348,8 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateAllOrderAdminPageInfoUnexistingOrderExceptionTest() {
-        Order order = ModelUtils.getOrder();
-        UpdateAllOrderPageDto updateAllOrderPageDto = ModelUtils.updateAllOrderPageDto();
+        Order order = getOrder();
+        UpdateAllOrderPageDto updateAllOrderPageDto = updateAllOrderPageDto();
         when(orderRepository.findById(4L)).thenReturn(Optional.ofNullable(order));
         assertThrows(NotFoundException.class,
             () -> ubsManagementService.updateAllOrderAdminPageInfo(updateAllOrderPageDto, "uuid", "ua"));
@@ -2301,57 +2365,57 @@ class UBSManagementServiceImplTest {
 
     @Test
     void updateAllOrderAdminPageInfoStatusConfirmedTest() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         order.setOrderDate(LocalDateTime.now());
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(getReceivingStation()));
         when(receivingStationRepository.findAll()).thenReturn(List.of(getReceivingStation()));
 
-        UpdateAllOrderPageDto expectedObject = ModelUtils.updateAllOrderPageDto();
-        UpdateAllOrderPageDto actual = ModelUtils.updateAllOrderPageDto();
+        UpdateAllOrderPageDto expectedObject = updateAllOrderPageDto();
+        UpdateAllOrderPageDto actual = updateAllOrderPageDto();
         assertEquals(expectedObject.getExportDetailsDto().getDateExport(),
             actual.getExportDetailsDto().getDateExport());
 
         ubsManagementService.updateAllOrderAdminPageInfo(expectedObject, "uuid", "ua");
 
-        expectedObject = ModelUtils.updateAllOrderPageDto();
-        actual = ModelUtils.updateAllOrderPageDto();
+        expectedObject = updateAllOrderPageDto();
+        actual = updateAllOrderPageDto();
         assertEquals(expectedObject.getExportDetailsDto().getDateExport(),
             actual.getExportDetailsDto().getDateExport());
 
         ubsManagementService.updateAllOrderAdminPageInfo(expectedObject, "uuid", "ua");
 
-        expectedObject = ModelUtils.updateAllOrderPageDto();
-        actual = ModelUtils.updateAllOrderPageDto();
+        expectedObject = updateAllOrderPageDto();
+        actual = updateAllOrderPageDto();
         assertEquals(expectedObject.getExportDetailsDto().getDateExport(),
             actual.getExportDetailsDto().getDateExport());
 
         ubsManagementService.updateAllOrderAdminPageInfo(expectedObject, "uuid", "ua");
 
-        expectedObject = ModelUtils.updateAllOrderPageDto();
-        actual = ModelUtils.updateAllOrderPageDto();
+        expectedObject = updateAllOrderPageDto();
+        actual = updateAllOrderPageDto();
         assertEquals(expectedObject.getExportDetailsDto().getDateExport(),
             actual.getExportDetailsDto().getDateExport());
 
         ubsManagementService.updateAllOrderAdminPageInfo(expectedObject, "uuid", "ua");
 
-        expectedObject = ModelUtils.updateAllOrderPageDto();
-        actual = ModelUtils.updateAllOrderPageDto();
+        expectedObject = updateAllOrderPageDto();
+        actual = updateAllOrderPageDto();
         assertEquals(expectedObject.getExportDetailsDto().getDateExport(),
             actual.getExportDetailsDto().getDateExport());
 
         ubsManagementService.updateAllOrderAdminPageInfo(expectedObject, "uuid", "ua");
 
-        expectedObject = ModelUtils.updateAllOrderPageDto();
-        actual = ModelUtils.updateAllOrderPageDto();
+        expectedObject = updateAllOrderPageDto();
+        actual = updateAllOrderPageDto();
         assertEquals(expectedObject.getExportDetailsDto().getDateExport(),
             actual.getExportDetailsDto().getDateExport());
 
         ubsManagementService.updateAllOrderAdminPageInfo(expectedObject, "uuid", "ua");
 
-        expectedObject = ModelUtils.updateAllOrderPageDto();
-        actual = ModelUtils.updateAllOrderPageDto();
+        expectedObject = updateAllOrderPageDto();
+        actual = updateAllOrderPageDto();
         assertEquals(expectedObject.getExportDetailsDto().getDateExport(),
             actual.getExportDetailsDto().getDateExport());
 
@@ -2361,7 +2425,7 @@ class UBSManagementServiceImplTest {
     @Test
     void updateAllOrderAdminPageInfoAdditionalOrdersEmptyTest() {
         Order order = ModelUtils.getOrder2();
-        UpdateAllOrderPageDto updateAllOrderPageDto = ModelUtils.updateAllOrderPageDto();
+        UpdateAllOrderPageDto updateAllOrderPageDto = updateAllOrderPageDto();
         order.setOrderDate(LocalDateTime.now());
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(getReceivingStation()));
@@ -2374,7 +2438,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void checkGetPaymentInfoWhenPaymentsWithCertificatesAndPointsSmallerThanSumToPay() {
-        Order order = ModelUtils.getOrder();
+        Order order = getOrder();
         order.setOrderStatus(OrderStatus.DONE);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         assertEquals(0L, ubsManagementService.getPaymentInfo(order.getId(), 1100.).getOverpayment());
@@ -2382,7 +2446,7 @@ class UBSManagementServiceImplTest {
 
     @Test
     void testAddPointsToUserWhenCurrentPointIsNull() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         user.setUuid(userRemoteClient.findUuidByEmail(user.getRecipientEmail()));
         user.setCurrentPoints(null);
 
@@ -2412,7 +2476,7 @@ class UBSManagementServiceImplTest {
         OrderPaymentStatusTranslation orderPaymentStatusTranslation = mock(OrderPaymentStatusTranslation.class);
         TariffsInfo tariffsInfo = getTariffsInfo();
         order.setTariffsInfo(tariffsInfo);
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -2458,7 +2522,7 @@ class UBSManagementServiceImplTest {
         TariffsInfo tariffsInfo = getTariffsInfo();
         list.add(getOrderStatusTranslation());
         order.setTariffsInfo(tariffsInfo);
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(Optional.of(employee));
         when(tariffsInfoRepository.findTariffsInfoByIdForEmployee(anyLong(), anyLong()))
@@ -2561,15 +2625,15 @@ class UBSManagementServiceImplTest {
 
     @Test
     void addBonusesToUserTest() {
-        Order order = ModelUtils.getOrderForGetOrderStatusData2Test();
+        Order order = getOrderForGetOrderStatusData2Test();
         User user = order.getUser();
         Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
-        when(bagRepository.findBagsByOrderId(1L)).thenReturn(ModelUtils.getBaglist());
+        when(bagRepository.findBagsByOrderId(1L)).thenReturn(getBaglist());
         when(certificateRepository.findCertificate(order.getId())).thenReturn(getCertificateList());
 
-        ubsManagementService.addBonusesToUser(ModelUtils.getAddBonusesToUserDto(), 1L, employee.getEmail());
+        ubsManagementService.addBonusesToUser(getAddBonusesToUserDto(), 1L, employee.getEmail());
 
         verify(orderRepository).findById(1L);
         verify(orderRepository).save(order);
@@ -2580,16 +2644,16 @@ class UBSManagementServiceImplTest {
 
     @Test
     void addBonusesToUserIfOrderStatusIsCanceled() {
-        Order order = ModelUtils.getOrderForGetOrderStatusData2Test();
+        Order order = getOrderForGetOrderStatusData2Test();
         order.setOrderStatus(OrderStatus.CANCELED);
         User user = order.getUser();
         Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
-        when(bagRepository.findBagsByOrderId(1L)).thenReturn(ModelUtils.getBaglist());
+        when(bagRepository.findBagsByOrderId(1L)).thenReturn(getBaglist());
         when(certificateRepository.findCertificate(order.getId())).thenReturn(getCertificateList());
 
-        ubsManagementService.addBonusesToUser(ModelUtils.getAddBonusesToUserDto(), 1L, employee.getEmail());
+        ubsManagementService.addBonusesToUser(getAddBonusesToUserDto(), 1L, employee.getEmail());
 
         verify(orderRepository).findById(1L);
         verify(orderRepository).save(order);
@@ -2605,10 +2669,10 @@ class UBSManagementServiceImplTest {
         Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
-        when(bagRepository.findBagsByOrderId(1L)).thenReturn(ModelUtils.getBaglist());
+        when(bagRepository.findBagsByOrderId(1L)).thenReturn(getBaglist());
         when(certificateRepository.findCertificate(order.getId())).thenReturn(getCertificateList());
 
-        ubsManagementService.addBonusesToUser(ModelUtils.getAddBonusesToUserDto(), 1L, employee.getEmail());
+        ubsManagementService.addBonusesToUser(getAddBonusesToUserDto(), 1L, employee.getEmail());
 
         verify(orderRepository).findById(1L);
         verify(orderRepository).save(order);
@@ -2631,20 +2695,20 @@ class UBSManagementServiceImplTest {
         String email = getEmployee().getEmail();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
-        when(bagRepository.findBagsByOrderId(1L)).thenReturn(ModelUtils.getBag3list());
+        when(bagRepository.findBagsByOrderId(1L)).thenReturn(getBag3list());
         when(certificateRepository.findCertificate(order.getId())).thenReturn(getCertificateList());
 
-        AddBonusesToUserDto addBonusesToUserDto = ModelUtils.getAddBonusesToUserDto();
+        AddBonusesToUserDto addBonusesToUserDto = getAddBonusesToUserDto();
         assertThrows(BadRequestException.class,
             () -> ubsManagementService.addBonusesToUser(addBonusesToUserDto, 1L, email));
     }
 
     @Test
     void checkEmployeeForOrderTest() {
-        User user = ModelUtils.getTestUser();
+        User user = getTestUser();
         Order order = user.getOrders().get(0);
         order.setOrderStatus(OrderStatus.CANCELED).setTariffsInfo(getTariffsInfo());
-        Employee employee = ModelUtils.getEmployee();
+        Employee employee = getEmployee();
         List<Long> tariffsInfoIds = new ArrayList<>();
         tariffsInfoIds.add(1L);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
@@ -2667,7 +2731,7 @@ class UBSManagementServiceImplTest {
         Employee employee = getEmployee();
         List<ReceivingStation> receivingStations = List.of(getReceivingStation());
         ExportDetailsDtoUpdate testDetails = getExportDetailsRequest();
-        var receivingStation = ModelUtils.getReceivingStation();
+        var receivingStation = getReceivingStation();
         when(receivingStationRepository.findById(1L)).thenReturn(Optional.of(receivingStation));
         when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
         when(receivingStationRepository.findAll()).thenReturn(receivingStations);
@@ -2714,7 +2778,7 @@ class UBSManagementServiceImplTest {
         List<ReceivingStation> receivingStations = List.of(getReceivingStation());
         ExportDetailsDtoUpdate testDetails = getExportDetailsRequest();
         Order order = getOrderExportDetails();
-        var receivingStation = ModelUtils.getReceivingStation();
+        var receivingStation = getReceivingStation();
         order.setDeliverFrom(null);
         testDetails.setTimeDeliveryFrom(null);
         String expectedHistoryEvent = OrderHistory.UPDATE_EXPORT_DETAILS
@@ -2738,7 +2802,7 @@ class UBSManagementServiceImplTest {
         List<ReceivingStation> receivingStations = List.of(getReceivingStation());
         ExportDetailsDtoUpdate testDetails = getExportDetailsRequest();
         Order order = getOrderExportDetails();
-        var receivingStation = ModelUtils.getReceivingStation();
+        var receivingStation = getReceivingStation();
         order.setDeliverTo(null);
         testDetails.setTimeDeliveryTo(null);
         String expectedHistoryEvent = OrderHistory.UPDATE_EXPORT_DETAILS
@@ -2799,5 +2863,23 @@ class UBSManagementServiceImplTest {
             .settlementdate("02-08-2021").amount(500L).paymentId("1").build();
         assertThrows(BadRequestException.class,
             () -> ubsManagementService.saveNewManualPayment(1L, paymentDetails, null, "test@gmail.com"));
+    }
+
+    @Test
+    void saveOrderIdForRefundTest() {
+        Order order = getOrder();
+        Refund refund = getRefund(order.getId());
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(refundRepository.save(refund)).thenReturn(refund);
+        ubsManagementService.saveOrderIdForRefund(1L);
+        verify(orderRepository).findById(1L);
+        verify(refundRepository).save(refund);
+    }
+
+    @Test
+    void saveOrderIdForRefundThrowsNotFoundExceptionTest() {
+        when(orderRepository.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(NotFoundException.class, () -> ubsManagementService.getNotTakenOrderReason(1L));
+        verify(orderRepository).findById(1L);
     }
 }


### PR DESCRIPTION
# GreenCityUBS PR
https://github.com/ita-social-projects/GreenCity/issues/5803

## Summary Of Changes :fire:
Added endpoint for saving order ID of order for which we need to make a refund

## Added
* New endpoint [/ubs/management/save-order-for-refund/{orderId}]
* New table in DB to store refunds data
* Tests to cover new lines of code

## How to test :clipboard:
In can be test via swagger:
[/ubs/management/save-order-for-refund/{orderId}]

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
