### PR TITLE
fix bug with receivingStation empty

### DIFF
--- a/service-api/src/main/java/greencity/dto/AddNewTariffDto.java
+++ b/service-api/src/main/java/greencity/dto/AddNewTariffDto.java
@@ -26,5 +26,6 @@ public class AddNewTariffDto {
     private Long courierId;
     @NotEmpty
     private List<@Min(1) Long> locationIdList;
+    @NotEmpty
     private List<@Min(1) Long> receivingStationsIdList;
 }

--- a/service-api/src/test/java/greencity/ModelUtils.java
+++ b/service-api/src/test/java/greencity/ModelUtils.java
@@ -121,7 +121,7 @@ public class ModelUtils {
             .regionId(null)
             .courierId(1L)
             .locationIdList(List.of(1L))
-            .receivingStationsIdList(null)
+            .receivingStationsIdList(List.of(1L))
             .build();
     }
 

--- a/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/courier/tariff/AddNewTariffDtoTest.java
@@ -50,12 +50,13 @@ class AddNewTariffDtoTest {
     @SneakyThrows
     @ParameterizedTest
     @MethodSource("provideFieldsAndInvalidValues")
-    void addNewTariffDtoWithInvalidValuesTest(Long courierId, List<Long> locationIdList) {
+    void addNewTariffDtoWithInvalidValuesTest(Long courierId, List<Long> locationIdList,
+        List<Long> receivingStationsIdList) {
         AddNewTariffDto dto = new AddNewTariffDto(
             0L,
             courierId,
             locationIdList,
-            List.of(0L));
+            receivingStationsIdList);
 
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         final Validator validator = factory.getValidator();
@@ -68,8 +69,8 @@ class AddNewTariffDtoTest {
 
     private static Stream<Arguments> provideFieldsAndInvalidValues() {
         return Stream.of(
-            Arguments.of(null, List.of()),
-            Arguments.of(-2L, List.of()),
-            Arguments.of(0L, List.of(0L)));
+            Arguments.of(null, List.of(), List.of()),
+            Arguments.of(-2L, List.of(), List.of()),
+            Arguments.of(0L, List.of(), List.of()));
     }
 }


### PR DESCRIPTION
Summary Of Issue :
[UBS Tariffs page_Create pricing card] The message about mandatory filling in the "receiving station" field is not displayed when only the location and the courier tags are selected when creating a new pricing card 

Issue Link:
https://github.com/ita-social-projects/GreenCity/issues/5973

Summary Of Changes :
-Create validation 