### PR TITLE
[Pick up city UBS.Admin Cabinet] Admin doesn't see used bonuses in the "Planned amount" and "Confirmed amount" columns of the "Order details" section when he/she cancels the order in the order form #5823

### DIFF
--- a/service/src/main/java/greencity/service/ubs/OrdersAdminsPageServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/OrdersAdminsPageServiceImpl.java
@@ -490,7 +490,6 @@ public class OrdersAdminsPageServiceImpl implements OrdersAdminsPageService {
         if (isNull(pointsToReturn) || pointsToReturn == 0) {
             return;
         }
-        order.setPointsToUse(0);
         User user = order.getUser();
         if (isNull(user.getCurrentPoints())) {
             user.setCurrentPoints(0);

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1094,7 +1094,6 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         if (isNull(pointsToReturn) || pointsToReturn == 0) {
             return;
         }
-        order.setPointsToUse(0);
         User user = order.getUser();
         if (isNull(user.getCurrentPoints())) {
             user.setCurrentPoints(0);

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -816,7 +816,7 @@ class UBSManagementServiceImplTest {
         assertEquals(expectedObject.getOrderStatus(), producedObjectCancelled.getOrderStatus());
         assertEquals(expectedObject.getPaymentStatus(), producedObjectCancelled.getPaymentStatus());
         assertEquals(expectedObject.getDate(), producedObjectCancelled.getDate());
-        assertEquals(0, order.getPointsToUse());
+        assertEquals(700, order.getPointsToUse());
 
         order.setOrderStatus(OrderStatus.ON_THE_ROUTE);
         testOrderDetail.setOrderStatus(OrderStatus.DONE.toString());


### PR DESCRIPTION
# GreenCityUBS PR
https://github.com/ita-social-projects/GreenCity/issues/5823

## Summary Of Changes :fire:
The amount of used bonuses is now not deleted from the database.

## Changed
* Changed the logic in service layer to avoid deleting bonuses from database.

## How to test :clipboard:
It can be tests via swagger, endpoint:
[/ubs/management/changingOrder]

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
