### PR TITLE
[UBS] Change region name when we save order address on user profile page #6079

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -629,7 +629,7 @@ public class UBSClientServiceImpl implements UBSClientService {
             AddressComponentType.ROUTE, dtoRequest::setStreet,
             AddressComponentType.STREET_NUMBER, dtoRequest::setHouseNumber,
             AddressComponentType.SUBLOCALITY, dtoRequest::setDistrict,
-            AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_1, dtoRequest::setRegion);
+            AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_3, dtoRequest::setRegion);
     }
 
     private Map<AddressComponentType, Consumer<String>> initializeEnglishGeoCodingResult(
@@ -638,7 +638,7 @@ public class UBSClientServiceImpl implements UBSClientService {
             AddressComponentType.LOCALITY, dtoRequest::setCityEn,
             AddressComponentType.ROUTE, dtoRequest::setStreetEn,
             AddressComponentType.SUBLOCALITY, dtoRequest::setDistrictEn,
-            AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_1, dtoRequest::setRegionEn);
+            AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_3, dtoRequest::setRegionEn);
     }
 
     private void initializeGeoCodingResults(Map<AddressComponentType, Consumer<String>> initializedMap,


### PR DESCRIPTION
# GreenCityUBS PR
https://github.com/ita-social-projects/GreenCity/issues/6079

## Summary Of Changes :fire:
The correct region name saves to database when we add order addresses on user profile page.

## Changed
* Changed the logic in service layer, when we save order addresses which belong to Kyiv, the region of such addresses saved as Kyiv Oblast, instead of Kyiv.

## How to test :clipboard:
It can be tests via swagger, endpoint:
[/ubs/save-order-address]

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
