### PR TITLE
#6125 Numeric data entered in the Name and Surname text fields is not saved

### DIFF
--- a/service-api/src/main/java/greencity/dto/user/UserProfileUpdateDto.java
+++ b/service-api/src/main/java/greencity/dto/user/UserProfileUpdateDto.java
@@ -27,10 +27,10 @@ import java.util.List;
 @EqualsAndHashCode
 public class UserProfileUpdateDto implements Serializable {
     @NotBlank
-    @Pattern(regexp = "[ЁёІіЇїҐґЄєА-Яа-яA-Za-z-ʼ'`ʹ\\s.]{1,30}")
+    @Pattern(regexp = "^(?!\\s*$)[ЁёІіЇїҐґЄєА-Яа-яA-Za-z0-9ʼ'`ʹ\\s-]{1,30}$")
     private String recipientName;
     @NotBlank
-    @Pattern(regexp = "[ЁёІіЇїҐґЄєА-Яа-яA-Za-z\\s-ʼ'`ʹ.]{1,30}")
+    @Pattern(regexp = "^(?!\\s*$)[ЁёІіЇїҐґЄєА-Яа-яA-Za-z0-9ʼ'`ʹ\\s-]{1,30}$")
     private String recipientSurname;
     @Email
     @Pattern(regexp = "[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}$")

--- a/service-api/src/test/java/greencity/dto/user/UserProfileUpdateDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/user/UserProfileUpdateDtoTest.java
@@ -7,7 +7,7 @@ import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class UserProfileUpdateDtoTest {
+class UserProfileUpdateDtoTest {
     void checkRegexPattern(String fieldName, String name, boolean validates) throws NoSuchFieldException {
         Field field = UserProfileUpdateDto.class.getDeclaredField(fieldName);
         javax.validation.constraints.Pattern[] annotations =

--- a/service-api/src/test/java/greencity/dto/user/UserProfileUpdateDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/user/UserProfileUpdateDtoTest.java
@@ -8,16 +8,16 @@ import java.lang.reflect.Field;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class UserProfileUpdateDtoTest {
-    void checkRegexPattern(String fieldName, String name, boolean validates) throws NoSuchFieldException {
+    void checkRegexPattern(String fieldName, String testValue, boolean validates) throws NoSuchFieldException {
         Field field = UserProfileUpdateDto.class.getDeclaredField(fieldName);
         javax.validation.constraints.Pattern[] annotations =
             field.getAnnotationsByType(javax.validation.constraints.Pattern.class);
-        assertEquals(name.matches(annotations[0].regexp()), validates);
+        assertEquals(testValue.matches(annotations[0].regexp()), validates);
     }
 
     @ParameterizedTest
     @ValueSource(
-        strings = {"John Doe", "абвгґіїьяюєАБВГҐІЇЬЯЮЄ-ʼ'`ʹ", "John-Doe", "John Doe12", "John Doe 12", "Johnʼ'`ʹDoe",
+        strings = {"John Doe", "абвгґіїьяюєёАБВГҐІЇЬЯЮЄЁ-ʼ'`ʹ", "John-Doe", "John Doe12", "John Doe 12", "Johnʼ'`ʹDoe",
             "ValidNameWithMaxLengthEquals30"})
     void testValidRecipientName(String name) throws NoSuchFieldException {
         checkRegexPattern("recipientName", name, true);
@@ -32,7 +32,7 @@ class UserProfileUpdateDtoTest {
 
     @ParameterizedTest
     @ValueSource(
-        strings = {"John Doe", "абвгґіїьяюєАБВГҐІЇЬЯЮЄ-ʼ'`ʹ", "John-Doe", "John Doe12", "John Doe 12", "Johnʼ'`ʹDoe",
+        strings = {"John Doe", "абвгґіїьяюєёАБВГҐІЇЬЯЮЄЁ-ʼ'`ʹ", "John-Doe", "John Doe12", "John Doe 12", "Johnʼ'`ʹDoe",
             "ValidNameWithMaxLengthEquals30"})
     void testValidRecipientSurname(String name) throws NoSuchFieldException {
         checkRegexPattern("recipientSurname", name, true);

--- a/service-api/src/test/java/greencity/dto/user/UserProfileUpdateDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/user/UserProfileUpdateDtoTest.java
@@ -1,0 +1,47 @@
+package greencity.dto.user;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UserProfileUpdateDtoTest {
+    void checkRegexPattern(String fieldName, String name, boolean validates) throws NoSuchFieldException {
+        Field field = UserProfileUpdateDto.class.getDeclaredField(fieldName);
+        javax.validation.constraints.Pattern[] annotations =
+            field.getAnnotationsByType(javax.validation.constraints.Pattern.class);
+        assertEquals(name.matches(annotations[0].regexp()), validates);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"John Doe", "абвгґіїьяюєАБВГҐІЇЬЯЮЄ-ʼ'`ʹ", "John-Doe", "John Doe12", "John Doe 12", "Johnʼ'`ʹDoe",
+            "ValidNameWithMaxLengthEquals30"})
+    void testValidRecipientName(String name) throws NoSuchFieldException {
+        checkRegexPattern("recipientName", name, true);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"InvalidLengthOfName31Characters", "", "   ", "!?+=@#$%^&*", "тест!", "тест@123", "Hello World!"})
+    void testInvalidRecipientName(String name) throws NoSuchFieldException {
+        checkRegexPattern("recipientName", name, false);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"John Doe", "абвгґіїьяюєАБВГҐІЇЬЯЮЄ-ʼ'`ʹ", "John-Doe", "John Doe12", "John Doe 12", "Johnʼ'`ʹDoe",
+            "ValidNameWithMaxLengthEquals30"})
+    void testValidRecipientSurname(String name) throws NoSuchFieldException {
+        checkRegexPattern("recipientSurname", name, true);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"InvalidLengthOfName31Characters", "", "   ", "!?+=@#$%^&*", "тест!", "тест@123", "Hello World!"})
+    void testInvalidRecipientSurname(String name) throws NoSuchFieldException {
+        checkRegexPattern("recipientSurname", name, false);
+    }
+}


### PR DESCRIPTION
## Summary Of Issue :
When the User enters numeric data in the Name and Surname text fields, the data is not saved.

**Issue Link**
https://github.com/ita-social-projects/GreenCity/issues/6125

## Summary Of Changes :
1) Updated regexp for recipientName and recipientSurname fields of UserProfileUpdateDto.class with supporting numeric characters and rejection of empty strings;
2) Added tests.

## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] All files reviewed before sending to reviewers
