### PR TITLE
Pull Request with change of max characters for Tariff Service Name from 30 to 255

### DIFF
--- a/dao/src/main/java/greencity/entity/order/Bag.java
+++ b/dao/src/main/java/greencity/entity/order/Bag.java
@@ -47,10 +47,10 @@ public class Bag {
     @Column(nullable = false)
     private Long fullPrice;
 
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false)
     private String nameEng;
 
     @Column(nullable = false)

--- a/service-api/src/main/java/greencity/dto/service/TariffServiceDto.java
+++ b/service-api/src/main/java/greencity/dto/service/TariffServiceDto.java
@@ -43,11 +43,11 @@ public class TariffServiceDto {
     private Double commission;
 
     @NotBlank
-    @Length(min = 1, max = 30)
+    @Length(min = 1, max = 255)
     private String name;
 
     @NotBlank
-    @Length(min = 1, max = 30)
+    @Length(min = 1, max = 255)
     private String nameEng;
 
     @NotBlank


### PR DESCRIPTION
# GreenCityUBS PR
[[UBS Admin Cabinet] User can`t save "Найменування послуги"(name of the service in UA) in "Сервіси" with 255 characters #5579](https://github.com/ita-social-projects/GreenCity/issues/5579)

## Summary Of Changes :fire:
1) In entity class **"Bag"**, deleted max value 30, default 255 left instead, as it is used in method editTariffService in SuperAdminServiceImpl class.
2) In dto class **"TariffServiceDto"**  changed max to 255 characters for name of service, as it is used in editTariffService method in editTariffService in SuperAdminServiceImpl and 
in  SuperAdminController for the same end-point.

## How to test :clipboard:
**Steps to reproduce:** 
1) The website is opened https://www.testgreencity.ga/#/ubs
2) Login as super admin user
3) Page "Tariffs" is opened
4) Click on the string with a tariff
5) Click on the 'pencil' in "Сервіси"
6) Write "впоравпрлаврпвролпрворполвраполвролпрволвпоравпрлаврпвролпрворполвраполвролпрволвпоравпрлаврпвролпрвon" the field “Найменування послуги”
7) Click button 'Зберегти'

**Expected result**
Service saved
