### PR TITLE
Changes columns length to 255 and validation max length i…

### DIFF
--- a/dao/src/main/java/greencity/entity/order/Service.java
+++ b/dao/src/main/java/greencity/entity/order/Service.java
@@ -40,10 +40,10 @@ public class Service {
     @Column(nullable = false)
     private Long price;
 
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false)
     private String nameEng;
 
     @Column(nullable = false)

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -215,4 +215,5 @@
     <include file="/db/changelog/logs/ch-upd-notification-templates-titles-Lenets.xml"/>
     <include file="db/changelog/logs/ch-add-table-refunds-Bondar.xml"/>
     <include file="db/changelog/logs/2023-08-07-change-service-name-column-length.xml"/>
+    <include file="db/changelog/logs/2023-08-08-change-bag-name-column-length.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/2023-08-08-change-bag-name-column-length.xml
+++ b/dao/src/main/resources/db/changelog/logs/2023-08-08-change-bag-name-column-length.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet id="change-bag-name-column-length.xml" author="Olena Sotnik">
+        <sqlFile path="db/changelog/sql/bag-name-length-change.sql"/>
+        <comment>Changed bag name and name_eng columns length from 30 to 255 chars</comment>
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/sql/bag-name-length-change.sql
+++ b/dao/src/main/resources/db/changelog/sql/bag-name-length-change.sql
@@ -1,0 +1,4 @@
+ALTER TABLE bag
+    ALTER COLUMN name TYPE varchar(255);
+ALTER TABLE bag
+    ALTER COLUMN name_eng TYPE varchar(255);

--- a/service-api/src/main/java/greencity/dto/service/ServiceDto.java
+++ b/service-api/src/main/java/greencity/dto/service/ServiceDto.java
@@ -22,11 +22,11 @@ import javax.validation.constraints.NotNull;
 @ToString
 public class ServiceDto {
     @NotBlank
-    @Length(max = 30)
+    @Length(max = 255)
     private String name;
 
     @NotBlank
-    @Length(max = 30)
+    @Length(max = 255)
     private String nameEng;
 
     @NotBlank


### PR DESCRIPTION
# GreenCityUBS PR
[[UBS Admin Cabinet] User can`t save "Найменування послуги"(name of the service in UA) in "Сервіси" with 255 characters #5579](https://github.com/ita-social-projects/GreenCity/issues/5579)

## Summary Of Changes :fire:
Service entity, ServiceDto fields changed length from 30 to 255 chars
Changed table bag column name and name_eng length from 30 to 255.
Added sql file and made changeset to database.
Included xml file with changes to db.changelog-master.xml