### PR TITLE
Bug-employee-pagination-after-filtering

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementEmployeeController.java
+++ b/core/src/main/java/greencity/controller/ManagementEmployeeController.java
@@ -74,8 +74,9 @@ public class ManagementEmployeeController {
     /**
      * Controller gets all employees.
      *
-     * @return {@link PageableAdvancedDto} pageable employees.
-     * @author Mykola Danylko and Olena Sotnik.
+     * @return PageableDto of {@link GetEmployeeDto} employees.
+     * @author Mykola Danylko.
+     * @author Olena Sotnik.
      */
     @ApiOperation(value = "Get all employees")
     @ApiResponses(value = {

--- a/core/src/main/java/greencity/controller/ManagementEmployeeController.java
+++ b/core/src/main/java/greencity/controller/ManagementEmployeeController.java
@@ -1,6 +1,5 @@
 package greencity.controller;
 
-import greencity.annotations.ApiPageable;
 import greencity.constants.HttpStatuses;
 import greencity.constants.SwaggerExampleModel;
 import greencity.dto.employee.EmployeeWithTariffsIdDto;
@@ -8,6 +7,7 @@ import greencity.dto.employee.EmployeeWithTariffsDto;
 import greencity.dto.employee.GetEmployeeDto;
 import greencity.dto.employee.UserEmployeeAuthorityDto;
 import greencity.dto.pageble.PageableAdvancedDto;
+import greencity.dto.pageble.PageableDto;
 import greencity.dto.position.PositionAuthoritiesDto;
 import greencity.dto.position.PositionDto;
 import greencity.dto.tariff.GetTariffInfoForEmployeeDto;
@@ -20,7 +20,6 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -76,7 +75,7 @@ public class ManagementEmployeeController {
      * Controller gets all employees.
      *
      * @return {@link PageableAdvancedDto} pageable employees.
-     * @author Mykola Danylko.
+     * @author Mykola Danylko and Olena Sotnik.
      */
     @ApiOperation(value = "Get all employees")
     @ApiResponses(value = {
@@ -84,10 +83,9 @@ public class ManagementEmployeeController {
         @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
         @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN)
     })
-    @ApiPageable
     @PreAuthorize("@preAuthorizer.hasAuthority('SEE_EMPLOYEES_PAGE', authentication)")
     @GetMapping("/getAll-employees")
-    public ResponseEntity<Page<GetEmployeeDto>> getAllEmployees(
+    public ResponseEntity<PageableDto<GetEmployeeDto>> getAllEmployees(
         EmployeePage employeePage,
         EmployeeFilterCriteria employeeFilterCriteria) {
         return ResponseEntity.status(HttpStatus.OK)

--- a/dao/src/main/java/greencity/repository/EmployeeCriteriaRepository.java
+++ b/dao/src/main/java/greencity/repository/EmployeeCriteriaRepository.java
@@ -28,6 +28,7 @@ public class EmployeeCriteriaRepository {
     private final EntityManager entityManager;
     private final CriteriaBuilder criteriaBuilder;
     private static final String POSITION_ID = "positionId";
+    private static final String EMPLOYEE_ID = "employeeId";
 
     /**
      * Constructor to initialize EntityManager and CriteriaBuilder.
@@ -96,7 +97,7 @@ public class EmployeeCriteriaRepository {
         Subquery<Long> subQuery = criteriaQuery.subquery(Long.class);
         Root<EmployeeFilterView> subQueryRoot = subQuery.from(EmployeeFilterView.class);
         subQuery.select(criteriaBuilder.min(subQueryRoot.get(POSITION_ID)))
-            .where(criteriaBuilder.equal(subQueryRoot.get("employeeId"), employeeFilterViewRoot.get("employeeId")));
+            .where(criteriaBuilder.equal(subQueryRoot.get(EMPLOYEE_ID), employeeFilterViewRoot.get(EMPLOYEE_ID)));
         predicates.add(criteriaBuilder.equal(employeeFilterViewRoot.get(POSITION_ID), subQuery));
     }
 

--- a/dao/src/main/java/greencity/repository/EmployeeCriteriaRepository.java
+++ b/dao/src/main/java/greencity/repository/EmployeeCriteriaRepository.java
@@ -3,23 +3,31 @@ package greencity.repository;
 import greencity.entity.user.employee.EmployeeFilterView;
 import greencity.filters.EmployeeFilterCriteria;
 import greencity.filters.EmployeePage;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.*;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Order;
+import javax.persistence.criteria.Subquery;
+import javax.persistence.criteria.Expression;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static greencity.enums.EmployeeStatus.*;
-import static java.util.Arrays.*;
+import static greencity.enums.EmployeeStatus.employeeStatusExist;
+import static java.util.Arrays.stream;
 
 @Repository
 public class EmployeeCriteriaRepository {
     private final EntityManager entityManager;
     private final CriteriaBuilder criteriaBuilder;
+    private static final String POSITION_ID = "positionId";
 
     /**
      * Constructor to initialize EntityManager and CriteriaBuilder.
@@ -87,9 +95,9 @@ public class EmployeeCriteriaRepository {
         List<Predicate> predicates) {
         Subquery<Long> subQuery = criteriaQuery.subquery(Long.class);
         Root<EmployeeFilterView> subQueryRoot = subQuery.from(EmployeeFilterView.class);
-        subQuery.select(criteriaBuilder.min(subQueryRoot.get("positionId")))
+        subQuery.select(criteriaBuilder.min(subQueryRoot.get(POSITION_ID)))
             .where(criteriaBuilder.equal(subQueryRoot.get("employeeId"), employeeFilterViewRoot.get("employeeId")));
-        predicates.add(criteriaBuilder.equal(employeeFilterViewRoot.get("positionId"), subQuery));
+        predicates.add(criteriaBuilder.equal(employeeFilterViewRoot.get(POSITION_ID), subQuery));
     }
 
     private void addCourierPredicate(EmployeeFilterCriteria employeeFilterCriteria,
@@ -123,7 +131,7 @@ public class EmployeeCriteriaRepository {
         Root<EmployeeFilterView> employeeFilterViewRoot,
         List<Predicate> predicates) {
         if (isListNotNullAndNotEmpty(employeeFilterCriteria.getPositions())) {
-            predicates.add(employeeFilterViewRoot.get("positionId")
+            predicates.add(employeeFilterViewRoot.get(POSITION_ID)
                 .in(employeeFilterCriteria.getPositions()));
         }
     }

--- a/dao/src/test/java/greencity/repository/EmployeeCriteriaRepositoryTest.java
+++ b/dao/src/test/java/greencity/repository/EmployeeCriteriaRepositoryTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class EmployeeCriteriaRepositoryTest {
+  
+}

--- a/dao/src/test/java/greencity/repository/EmployeeCriteriaRepositoryTest.java
+++ b/dao/src/test/java/greencity/repository/EmployeeCriteriaRepositoryTest.java
@@ -1,4 +1,0 @@
-import static org.junit.jupiter.api.Assertions.*;
-class EmployeeCriteriaRepositoryTest {
-  
-}

--- a/service-api/src/main/java/greencity/service/ubs/UBSManagementEmployeeService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSManagementEmployeeService.java
@@ -9,7 +9,6 @@ import greencity.dto.position.PositionDto;
 import greencity.dto.tariff.GetTariffInfoForEmployeeDto;
 import greencity.filters.EmployeeFilterCriteria;
 import greencity.filters.EmployeePage;
-import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;

--- a/service-api/src/main/java/greencity/service/ubs/UBSManagementEmployeeService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSManagementEmployeeService.java
@@ -3,6 +3,7 @@ package greencity.service.ubs;
 import greencity.dto.employee.EmployeeWithTariffsDto;
 import greencity.dto.employee.GetEmployeeDto;
 import greencity.dto.employee.EmployeeWithTariffsIdDto;
+import greencity.dto.pageble.PageableDto;
 import greencity.dto.position.AddingPositionDto;
 import greencity.dto.position.PositionDto;
 import greencity.dto.tariff.GetTariffInfoForEmployeeDto;
@@ -28,7 +29,7 @@ public interface UBSManagementEmployeeService {
     /**
      * {@inheritDoc}
      */
-    Page<GetEmployeeDto> findAll(EmployeePage employeePage, EmployeeFilterCriteria employeeFilterCriteria);
+    PageableDto<GetEmployeeDto> findAll(EmployeePage employeePage, EmployeeFilterCriteria employeeFilterCriteria);
 
     /**
      * Method updates information about employee.

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -120,12 +120,13 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
     }
 
     private List<GetEmployeeDto> mapEmployeeFilterViewsToGetEmployeeDtos(List<EmployeeFilterView> employeeFilterViews) {
+        List<Employee> employees = employeeRepository.findAll();
         Map<Long, GetEmployeeDto> getEmployeeDtoMap = new LinkedHashMap<>();
         for (var employeeFilterView : employeeFilterViews) {
             var getEmployeeDto = getEmployeeDtoMap.computeIfAbsent(employeeFilterView.getEmployeeId(),
                 id -> modelMapper.map(employeeFilterView, GetEmployeeDto.class));
             initializeGetEmployeeDtoCollectionsIfNeeded(getEmployeeDto);
-            fillGetEmployeeDto(employeeFilterView, getEmployeeDto);
+            fillGetEmployeeDto(employeeFilterView, getEmployeeDto, employees);
         }
         return new ArrayList<>(getEmployeeDtoMap.values());
     }
@@ -135,8 +136,8 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
         return PageRequest.of(employeePage.getPageNumber(), employeePage.getPageSize(), sort);
     }
 
-    private void fillGetEmployeeDto(EmployeeFilterView emplView, GetEmployeeDto getEmployeeDto) {
-        List<Employee> employees = employeeRepository.findAll();
+    private void fillGetEmployeeDto(EmployeeFilterView emplView, GetEmployeeDto getEmployeeDto,
+        List<Employee> employees) {
         fillGetTariffInfoForEmployeeDto(emplView, getEmployeeDto, employees);
         fillPositionDto(emplView, getEmployeeDto, employees);
     }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -13,6 +13,7 @@ import greencity.dto.pageble.PageableDto;
 import greencity.dto.position.AddingPositionDto;
 import greencity.dto.position.PositionDto;
 import greencity.dto.tariff.GetTariffInfoForEmployeeDto;
+import greencity.dto.tariff.GetTariffsInfoDto;
 import greencity.entity.order.TariffsInfo;
 import greencity.entity.user.employee.Employee;
 import greencity.entity.user.employee.EmployeeFilterView;
@@ -142,18 +143,24 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
     }
 
     private void fillPositionDto(EmployeeFilterView emplView, GetEmployeeDto getEmployeeDto, List<Employee> employees) {
-        employees.stream().filter(employee -> employee.getId().equals(emplView.getEmployeeId()))
-            .forEach(employee -> employee.getEmployeePosition().stream()
-                .map(position -> modelMapper.map(position, PositionDto.class))
-                .forEach(positionDto -> getEmployeeDto.getEmployeePositions().add(positionDto)));
+        List<PositionDto> positionsDtos = employees.stream()
+            .filter(employee -> employee.getId().equals(emplView.getEmployeeId()))
+            .flatMap(employee -> employee.getEmployeePosition().stream()
+                .map(position -> modelMapper.map(position, PositionDto.class)))
+            .collect(Collectors.toList());
+
+        getEmployeeDto.getEmployeePositions().addAll(positionsDtos);
     }
 
-    private void fillGetTariffInfoForEmployeeDto(EmployeeFilterView emplView, GetEmployeeDto getEmployeeDto,
-        List<Employee> employees) {
-        employees.stream().filter(employee -> employee.getId().equals(emplView.getEmployeeId()))
-            .forEach(employee -> employee.getTariffInfos().stream()
-                .map(tariffsInfo -> modelMapper.map(tariffsInfo, GetTariffInfoForEmployeeDto.class))
-                .forEach(tariffInfoDto -> getEmployeeDto.getTariffs().add(tariffInfoDto)));
+    private void fillGetTariffInfoForEmployeeDto(
+        EmployeeFilterView emplView, GetEmployeeDto getEmployeeDto, List<Employee> employees) {
+        List<GetTariffInfoForEmployeeDto> tariffsInfoDtos = employees.stream()
+            .filter(employee -> employee.getId().equals(emplView.getEmployeeId()))
+            .flatMap(employee -> employee.getTariffInfos().stream()
+                .map(tariffsInfo -> modelMapper.map(tariffsInfo, GetTariffInfoForEmployeeDto.class)))
+            .collect(Collectors.toList());
+
+        getEmployeeDto.getTariffs().addAll(tariffsInfoDtos);
     }
 
     private void initializeGetEmployeeDtoCollectionsIfNeeded(GetEmployeeDto getEmployeeDto) {

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -13,7 +13,6 @@ import greencity.dto.pageble.PageableDto;
 import greencity.dto.position.AddingPositionDto;
 import greencity.dto.position.PositionDto;
 import greencity.dto.tariff.GetTariffInfoForEmployeeDto;
-import greencity.dto.tariff.GetTariffsInfoDto;
 import greencity.entity.order.TariffsInfo;
 import greencity.entity.user.employee.Employee;
 import greencity.entity.user.employee.EmployeeFilterView;

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -143,7 +143,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
     }
 
     private void fillPositionDto(EmployeeFilterView emplView, GetEmployeeDto getEmployeeDto, List<Employee> employees) {
-        employees.stream().filter(employee -> employee.getId() == emplView.getEmployeeId())
+        employees.stream().filter(employee -> employee.getId().equals(emplView.getEmployeeId()))
             .forEach(employee -> employee.getEmployeePosition().stream()
                 .map(position -> modelMapper.map(position, PositionDto.class))
                 .forEach(positionDto -> getEmployeeDto.getEmployeePositions().add(positionDto)));
@@ -151,7 +151,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
 
     private void fillGetTariffInfoForEmployeeDto(EmployeeFilterView emplView, GetEmployeeDto getEmployeeDto,
         List<Employee> employees) {
-        employees.stream().filter(employee -> employee.getId() == emplView.getEmployeeId())
+        employees.stream().filter(employee -> employee.getId().equals(emplView.getEmployeeId()))
             .forEach(employee -> employee.getTariffInfos().stream()
                 .map(tariffsInfo -> modelMapper.map(tariffsInfo, GetTariffInfoForEmployeeDto.class))
                 .forEach(tariffInfoDto -> getEmployeeDto.getTariffs().add(tariffInfoDto)));

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.LinkedHashMap;
-import java.util.HashMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
 

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -173,6 +173,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -188,6 +189,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
 import static greencity.enums.NotificationReceiverType.EMAIL;
 import static greencity.enums.NotificationReceiverType.MOBILE;
 import static greencity.enums.NotificationReceiverType.SITE;
@@ -303,6 +305,29 @@ public class ModelUtils {
             getEmployeeFilterViewWithPassedIds(employeeId, 3L, tariffsInfoId),
             getEmployeeFilterViewWithPassedIds(employeeId, 5L, tariffsInfoId),
             getEmployeeFilterViewWithPassedIds(employeeId, 7L, tariffsInfoId));
+    }
+
+    public static List<Employee> getEmployeeListForGetAllMethod() {
+        return List.of(
+            Employee.builder()
+                .id(1L)
+                .firstName("First Name")
+                .lastName("Last Name")
+                .phoneNumber("Phone Number")
+                .email("employee@gmail.com")
+                .employeeStatus(EmployeeStatus.ACTIVE)
+                .employeePosition(new HashSet<>())
+                .tariffInfos(new HashSet<>())
+                .imagePath("path")
+                .tariffs(List.of(getTariffInfo()))
+                .build());
+    }
+
+    public static GetEmployeeDto getEmployeeDtoWithoutPositionsAndTariffsForGetAllMethod() {
+        var getEmployeeDto = getEmployeeDto();
+        getEmployeeDto.setEmployeePositions(new ArrayList<>());
+        getEmployeeDto.setTariffs(new ArrayList<>());
+        return getEmployeeDto;
     }
 
     public static GetEmployeeDto getEmployeeDtoWithPositionsAndTariffs() {
@@ -1872,6 +1897,14 @@ public class ModelUtils {
     public static Position getPosition() {
         return Position.builder()
             .id(1L)
+            .name("Водій")
+            .nameEn("Driver")
+            .build();
+    }
+
+    public static Position getPosition(Long id) {
+        return Position.builder()
+            .id(id)
             .name("Водій")
             .nameEn("Driver")
             .build();

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -330,6 +330,16 @@ public class ModelUtils {
         return getEmployeeDto;
     }
 
+    public static GetEmployeeDto getEmployeeDtoWithPositionsForGetAllMethod() {
+        var getEmployeeDto = getEmployeeDto();
+        getEmployeeDto.setEmployeePositions(List.of(
+            getPositionDto(3L),
+            getPositionDto(5L),
+            getPositionDto(7L)));
+        getEmployeeDto.setTariffs(new ArrayList<>());
+        return getEmployeeDto;
+    }
+
     public static GetEmployeeDto getEmployeeDtoWithPositionsAndTariffs() {
         var getEmployeeDto = getEmployeeDto();
 

--- a/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
@@ -163,6 +163,36 @@ class UBSManagementEmployeeServiceImplTest {
     }
 
     @Test
+    void findAllTestWithEmployeePositions() {
+        var employeePage = new EmployeePage();
+        var employeeFilterCriteria = new EmployeeFilterCriteria();
+        var employeeId = 1L;
+        var tariffsInfoId = 10L;
+        var employeeFilterViews =
+            getEmployeeFilterViewListForOneEmployeeWithDifferentPositions(employeeId, tariffsInfoId);
+        var expectedGetEmployeeDto = getEmployeeDtoWithPositionsForGetAllMethod();
+        var expectedEmployeesList = getEmployeeListForGetAllMethod();
+        var firstElement = employeeFilterViews.get(0);
+
+        when(employeeCriteriaRepository.findAll(employeePage, employeeFilterCriteria))
+            .thenReturn(employeeFilterViews);
+        when(repository.findAll()).thenReturn(expectedEmployeesList);
+        when(modelMapper.map(firstElement, GetEmployeeDto.class))
+            .thenReturn(getEmployeeDtoWithPositionsForGetAllMethod());
+
+        var getPageableDtoGetEmployeeDto =
+            employeeService.findAll(employeePage, employeeFilterCriteria);
+        var actualGetEmployeeDto = getPageableDtoGetEmployeeDto.getPage().get(0);
+
+        assertEquals(expectedGetEmployeeDto, actualGetEmployeeDto);
+        assertEquals(expectedGetEmployeeDto.getId(), actualGetEmployeeDto.getId());
+        assertEquals(expectedGetEmployeeDto.getEmail(), actualGetEmployeeDto.getEmail());
+        verify(employeeCriteriaRepository).findAll(employeePage, employeeFilterCriteria);
+        verify(modelMapper, times(1)).map(employeeFilterViews.get(0), GetEmployeeDto.class);
+        verify(repository).findAll();
+    }
+
+    @Test
     void updateEmployeeTest() {
         Employee employee = getEmployeeForUpdateEmailCheck();
         EmployeeWithTariffsIdDto dto = getEmployeeWithTariffsIdDto();

--- a/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
@@ -4,18 +4,13 @@ import com.netflix.hystrix.exception.HystrixRuntimeException;
 import greencity.client.UserRemoteClient;
 import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
-import greencity.dto.LocationsDtos;
-import greencity.dto.courier.GetReceivingStationDto;
 import greencity.dto.employee.EmployeeWithTariffsIdDto;
 import greencity.dto.employee.GetEmployeeDto;
-import greencity.dto.location.api.DistrictDto;
-import greencity.dto.location.api.LocationDto;
 import greencity.dto.position.AddingPositionDto;
 import greencity.dto.position.PositionDto;
 import greencity.dto.tariff.GetTariffInfoForEmployeeDto;
 import greencity.entity.order.TariffsInfo;
 import greencity.entity.user.employee.Employee;
-import greencity.entity.user.employee.EmployeeFilterView;
 import greencity.entity.user.employee.Position;
 import greencity.enums.EmployeeStatus;
 import greencity.exceptions.BadRequestException;
@@ -23,27 +18,24 @@ import greencity.exceptions.NotFoundException;
 import greencity.exceptions.UnprocessableEntityException;
 import greencity.filters.EmployeeFilterCriteria;
 import greencity.filters.EmployeePage;
-import greencity.repository.*;
-import greencity.service.locations.LocationApiService;
+import greencity.repository.EmployeeRepository;
+import greencity.repository.PositionRepository;
+import greencity.repository.TariffsInfoRepository;
+import greencity.repository.EmployeeCriteriaRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import org.springframework.mock.web.MockMultipartFile;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.ArrayList;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import static greencity.ModelUtils.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -52,7 +44,6 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
@@ -65,8 +56,6 @@ class UBSManagementEmployeeServiceImplTest {
     @Mock
     private PositionRepository positionRepository;
     @Mock
-    private ReceivingStationRepository stationRepository;
-    @Mock
     private TariffsInfoRepository tariffsInfoRepository;
     @Mock
     private FileService fileService;
@@ -78,10 +67,6 @@ class UBSManagementEmployeeServiceImplTest {
     private UBSManagementEmployeeServiceImpl employeeService;
     @Mock
     private EmployeeCriteriaRepository employeeCriteriaRepository;
-    @Mock
-    private LocationApiService locationApiService;
-    @Mock
-    private UBSClientServiceImpl ubsClientService;
 
     @Test
     void saveEmployeeTest() {
@@ -153,58 +138,28 @@ class UBSManagementEmployeeServiceImplTest {
         var employeeFilterCriteria = new EmployeeFilterCriteria();
         var employeeId = 1L;
         var tariffsInfoId = 10L;
-        var employeeFilterViews = getEmployeeFilterViewListForOneEmployeeWithDifferentPositions(
-            employeeId, tariffsInfoId);
-        var expectedGetEmployeeDto = getEmployeeDtoWithPositionsAndTariffs();
+        var employeeFilterViews =
+            getEmployeeFilterViewListForOneEmployeeWithDifferentPositions(employeeId, tariffsInfoId);
+        var expectedGetEmployeeDto = getEmployeeDtoWithoutPositionsAndTariffsForGetAllMethod();
+        var expectedEmployeesList = getEmployeeListForGetAllMethod();
+        var firstElement = employeeFilterViews.get(0);
 
         when(employeeCriteriaRepository.findAll(employeePage, employeeFilterCriteria))
             .thenReturn(employeeFilterViews);
-        mockModelMapperBehaviourForEmployeeFilterViewCollection(employeeFilterViews);
-
-        var getEmployeeDtoPage = employeeService.findAll(employeePage, employeeFilterCriteria);
-        var actualGetEmployeeDto = getEmployeeDtoPage.get()
-            .findAny()
-            .orElseThrow();
-
-        assertEquals(expectedGetEmployeeDto, actualGetEmployeeDto);
-        verify(employeeCriteriaRepository).findAll(employeePage, employeeFilterCriteria);
-        verifyAllModelMappersWasInvokedForFirstRecordOfEmployeeFilterViewCollection(employeeFilterViews);
-        verifyOnlyModelMapperToPositionDtoWasInvoked(employeeFilterViews);
-    }
-
-    private void verifyOnlyModelMapperToPositionDtoWasInvoked(List<EmployeeFilterView> employeeFilterViews) {
-        for (int i = 1; i < employeeFilterViews.size(); i++) {
-            verify(modelMapper, never()).map(employeeFilterViews.get(i), GetEmployeeDto.class);
-            verify(modelMapper, never()).map(employeeFilterViews.get(i), GetTariffInfoForEmployeeDto.class);
-            verify(modelMapper, never()).map(employeeFilterViews.get(i), LocationsDtos.class);
-            verify(modelMapper, never()).map(employeeFilterViews.get(i), GetReceivingStationDto.class);
-            verify(modelMapper, times(1)).map(employeeFilterViews.get(i), PositionDto.class);
-        }
-    }
-
-    private void verifyAllModelMappersWasInvokedForFirstRecordOfEmployeeFilterViewCollection(
-        List<EmployeeFilterView> employeeFilterViews) {
-        verify(modelMapper, times(1)).map(employeeFilterViews.get(0), GetEmployeeDto.class);
-        verify(modelMapper, times(1)).map(employeeFilterViews.get(0), GetTariffInfoForEmployeeDto.class);
-        verify(modelMapper, times(1)).map(employeeFilterViews.get(0), LocationsDtos.class);
-        verify(modelMapper, times(1)).map(employeeFilterViews.get(0), GetReceivingStationDto.class);
-        verify(modelMapper, times(1)).map(employeeFilterViews.get(0), PositionDto.class);
-    }
-
-    private void mockModelMapperBehaviourForEmployeeFilterViewCollection(List<EmployeeFilterView> employeeFilterViews) {
-        var firstElement = employeeFilterViews.get(0);
+        when(repository.findAll()).thenReturn(expectedEmployeesList);
         when(modelMapper.map(firstElement, GetEmployeeDto.class))
             .thenReturn(getEmployeeDto());
-        when(modelMapper.map(firstElement, GetTariffInfoForEmployeeDto.class))
-            .thenReturn(getTariffInfoForEmployeeDto2());
-        when(modelMapper.map(firstElement, LocationsDtos.class))
-            .thenReturn(getLocationsDtos(firstElement.getLocationId()));
-        when(modelMapper.map(firstElement, GetReceivingStationDto.class))
-            .thenReturn(getReceivingStationDto2());
-        for (var employeeFilterView : employeeFilterViews) {
-            when(modelMapper.map(employeeFilterView, PositionDto.class))
-                .thenReturn(getPositionDto(employeeFilterView.getPositionId()));
-        }
+
+        var getPageableDtoGetEmployeeDto =
+            employeeService.findAll(employeePage, employeeFilterCriteria);
+        var actualGetEmployeeDto = getPageableDtoGetEmployeeDto.getPage().get(0);
+
+        assertEquals(expectedGetEmployeeDto, actualGetEmployeeDto);
+        assertEquals(expectedGetEmployeeDto.getId(), actualGetEmployeeDto.getId());
+        assertEquals(expectedGetEmployeeDto.getEmail(), actualGetEmployeeDto.getEmail());
+        verify(employeeCriteriaRepository).findAll(employeePage, employeeFilterCriteria);
+        verify(modelMapper, times(1)).map(employeeFilterViews.get(0), GetEmployeeDto.class);
+        verify(repository).findAll();
     }
 
     @Test
@@ -498,5 +453,4 @@ class UBSManagementEmployeeServiceImplTest {
         verify(modelMapper, times(1)).map(any(), any());
         verify(tariffsInfoRepository).findAll();
     }
-
 }

--- a/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
@@ -163,36 +163,6 @@ class UBSManagementEmployeeServiceImplTest {
     }
 
     @Test
-    void findAllTestWithEmployeePositions() {
-        var employeePage = new EmployeePage();
-        var employeeFilterCriteria = new EmployeeFilterCriteria();
-        var employeeId = 1L;
-        var tariffsInfoId = 10L;
-        var employeeFilterViews =
-            getEmployeeFilterViewListForOneEmployeeWithDifferentPositions(employeeId, tariffsInfoId);
-        var expectedGetEmployeeDto = getEmployeeDtoWithPositionsForGetAllMethod();
-        var expectedEmployeesList = getEmployeeListForGetAllMethod();
-        var firstElement = employeeFilterViews.get(0);
-
-        when(employeeCriteriaRepository.findAll(employeePage, employeeFilterCriteria))
-            .thenReturn(employeeFilterViews);
-        when(repository.findAll()).thenReturn(expectedEmployeesList);
-        when(modelMapper.map(firstElement, GetEmployeeDto.class))
-            .thenReturn(getEmployeeDtoWithPositionsForGetAllMethod());
-
-        var getPageableDtoGetEmployeeDto =
-            employeeService.findAll(employeePage, employeeFilterCriteria);
-        var actualGetEmployeeDto = getPageableDtoGetEmployeeDto.getPage().get(0);
-
-        assertEquals(expectedGetEmployeeDto, actualGetEmployeeDto);
-        assertEquals(expectedGetEmployeeDto.getId(), actualGetEmployeeDto.getId());
-        assertEquals(expectedGetEmployeeDto.getEmail(), actualGetEmployeeDto.getEmail());
-        verify(employeeCriteriaRepository).findAll(employeePage, employeeFilterCriteria);
-        verify(modelMapper, times(1)).map(employeeFilterViews.get(0), GetEmployeeDto.class);
-        verify(repository).findAll();
-    }
-
-    @Test
     void updateEmployeeTest() {
         Employee employee = getEmployeeForUpdateEmailCheck();
         EmployeeWithTariffsIdDto dto = getEmployeeWithTariffsIdDto();


### PR DESCRIPTION
# GreenCityUBS PR
[#6144[Employee (Admin cabinet)]Not implemented infinite scroll on the 'Employees page' ](https://github.com/ita-social-projects/GreenCity/issues/6144)

##  Issue description:
The problem was with mapping and pagitating object List EmployeeFilterView from 'employees_filters' table( where all employees are saved multiple times with different positions and different tariffInfos. So that 1 Employee could be saved up to 7 times depends on tariffsInfos set and position set).
So when we make pagination, only two employees were mapped instead of 10 for example. 

## Summary Of Changes :fire:
- Method findAll in UBSManagementEmployeeServiceImpl has been optimized. Changed few methods to map from EmployeeFilterView to GetEmployeeDto, so that now collections of positions and tariffs of Employee are mapped from real employees objects in database. (It was changed because during distinction of multiple same objects in criteriaQuery in EmployeeCriteriaRepository, mapping would be wrong as 1 EmployeeFilterView has information about 1 position of employee and 1 tariffInfo).
- Changed method findAll in EmployeeCriteriaRepository. Subquery added in orter to distinct  EmployeeFilterView objects with unique employeeId. 
- Changed test method in UBSManagementEmployeeServiceImplTest.
- Changed return parameter in controller class,service class and service interface, from Page<GetEmployeeDto> to PageableDto<GetEmployeeDto>, to make result value more useable for infinity scroll provision by FrontEnd developer.
## Deleted
Deleted unnecessary method for tariff and position mapping as the mapping way has been changed.
Deleted not used imports in classes.