### PR TITLE
Change in method initializeGetEmployeeDtoCollections

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -124,7 +124,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
         for (var employeeFilterView : employeeFilterViews) {
             var getEmployeeDto = getEmployeeDtoMap.computeIfAbsent(employeeFilterView.getEmployeeId(),
                 id -> modelMapper.map(employeeFilterView, GetEmployeeDto.class));
-            initializeGetEmployeeDtoCollectionsIfNeeded(getEmployeeDto);
+            initializeGetEmployeeDtoCollections(getEmployeeDto);
             fillGetEmployeeDto(employeeFilterView, getEmployeeDto, employees);
         }
         return new ArrayList<>(getEmployeeDtoMap.values());
@@ -162,11 +162,9 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
         getEmployeeDto.getTariffs().addAll(tariffsInfoDtos);
     }
 
-    private void initializeGetEmployeeDtoCollectionsIfNeeded(GetEmployeeDto getEmployeeDto) {
-        if (getEmployeeDto.getEmployeePositions() == null || getEmployeeDto.getTariffs() == null) {
-            getEmployeeDto.setEmployeePositions(new ArrayList<>());
-            getEmployeeDto.setTariffs(new ArrayList<>());
-        }
+    private void initializeGetEmployeeDtoCollections(GetEmployeeDto getEmployeeDto) {
+        getEmployeeDto.setEmployeePositions(new ArrayList<>());
+        getEmployeeDto.setTariffs(new ArrayList<>());
     }
 
     private PageableDto<GetEmployeeDto> getAllTranslationDto(Page<GetEmployeeDto> pages) {

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.Collections;
 
 @Service
 @Data

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -163,8 +163,8 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
     }
 
     private void initializeGetEmployeeDtoCollections(GetEmployeeDto getEmployeeDto) {
-        getEmployeeDto.setEmployeePositions(new ArrayList<>());
-        getEmployeeDto.setTariffs(new ArrayList<>());
+        getEmployeeDto.setEmployeePositions(Collections.emptyList());
+        getEmployeeDto.setTariffs(Collections.emptyList());
     }
 
     private PageableDto<GetEmployeeDto> getAllTranslationDto(Page<GetEmployeeDto> pages) {


### PR DESCRIPTION
# GreenCityUBS PR
Change of method is neccessary to provide correct mapping of Collections in GetEmployeeDto. 

## Issue Link :clipboard:
[[Employee (Admin cabinet)]Not implemented infinite scroll on the 'Employees page' #6144](https://github.com/ita-social-projects/GreenCity/issues/6144)
## Summary Of Changes :fire:
Deleted check if tariffInfo and positions in GetEmployeeDto are not null.
Changed name of method that corresponds more to its function.
