### PR TITLE
Change regex for additionalOrders in OrderResponseDto

### DIFF
--- a/service-api/src/main/java/greencity/dto/order/OrderResponseDto.java
+++ b/service-api/src/main/java/greencity/dto/order/OrderResponseDto.java
@@ -35,7 +35,7 @@ public class OrderResponseDto implements Serializable {
     private Set<@Pattern(regexp = "(\\d{4}-\\d{4})|(^$)",
         message = "This certificate code is not valid") String> certificates;
 
-    private Set<@Pattern(regexp = "\\d{0,8}") String> additionalOrders;
+    private Set<@Pattern(regexp = "\\d{4,10}") String> additionalOrders;
 
     @Length(max = 255)
     private String orderComment;


### PR DESCRIPTION
# GreenCityUBS PR
[[UBS courier/Order details] An error message appears when user clicks the mouse outside the field "Order number" #6007](https://github.com/ita-social-projects/GreenCity/issues/6007)
## Summary Of Changes :fire:
Change of regex for field additionalOrders in OrderResponseDto. 
Before change it was from 0-8 digits, but it was decided to make it the same as in frontend, from 4-10 digits.
