### PR TITLE
Orders sort and order cancelation

### DIFF
--- a/dao/src/main/java/greencity/repository/OrdersForUserRepository.java
+++ b/dao/src/main/java/greencity/repository/OrdersForUserRepository.java
@@ -5,6 +5,7 @@ import greencity.entity.order.Order;
 import greencity.entity.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -27,6 +28,9 @@ public interface OrdersForUserRepository extends PagingAndSortingRepository<Orde
      * @param uuid     {@link User}'s uuid.
      * @return {@link Page} of {@link Order}.
      */
+    @Query(value = "SELECT o FROM Order AS o WHERE o.user = "
+        + "(SELECT u FROM User AS u WHERE u.uuid = :uuid) "
+        + "ORDER BY o.orderDate DESC")
     Page<Order> getAllByUserUuid(Pageable pageable, String uuid);
 
     /**
@@ -38,6 +42,11 @@ public interface OrdersForUserRepository extends PagingAndSortingRepository<Orde
      * @param statuses list of {@link OrderStatus} to match.
      * @return {@link Page} of {@link Order}.
      */
+
+    @Query(value = "SELECT o FROM Order AS o WHERE o.user = "
+        + "(SELECT u FROM User AS u WHERE u.uuid = :uuid) "
+        + "AND o.orderStatus IN (:statuses) "
+        + "ORDER BY o.orderDate DESC")
     Page<Order> getAllByUserUuidAndOrderStatusIn(Pageable pageable, String uuid, List<OrderStatus> statuses);
 
     /**

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -1477,7 +1477,8 @@ public class UBSClientServiceImpl implements UBSClientService {
             throw new NotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST);
         }
         order.updateWithNewOrderBags(Collections.emptyList());
-        orderRepository.delete(order);
+        order.setOrderStatus(OrderStatus.CANCELED);
+        orderRepository.save(order);
     }
 
     @Override

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -2846,7 +2846,8 @@ class UBSClientServiceImplTest {
 
         ubsService.deleteOrder(order.getUser().getUuid(), 1L);
 
-        verify(orderRepository).delete(order);
+        verify(orderRepository).save(order);
+        verify(ordersForUserRepository).getAllByUserUuidAndId(order.getUser().getUuid(), order.getId());
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUBS PR

## Summary Of Changes :fire:
Sorting orders
Order cancellation instead of delete.

## Issue Link :clipboard:
[[UBS User. Order payment] The user can't delete an unpaid order in the "Formed" status #6566](https://github.com/ita-social-projects/GreenCity/issues/6566)
[[UBS_Prod. UBS User. Orders] The 500 status code occurs when User clicks on 'Cancel' in case of order cancellation #5391](https://github.com/ita-social-projects/GreenCity/issues/5391)
[[UBS User. Current Orders Tab] The orders are displayed not sequentially #6569](https://github.com/ita-social-projects/GreenCity/issues/6569)

## Added
Added queries to etAllByUserUuidAndOrderStatusIn, getAllByUserUuid methods to order by OrderDate desc;

## Changed
Implementation of OrdersForUserRepository methods: getAllByUserUuidAndOrderStatusIn, getAllByUserUuid; 
Changed implementation of deleteOrder method, now order is not deleted from repository, instead OrderStatus is changed to CANCELED and saved to repository

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
