### PR TITLE
Commit with change value validation regex

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1608,7 +1608,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             && !added.contains("")) {
             historyChanges.append(collectInfoAboutChangesOfEcoNumber(added, OrderHistory.ADD_NEW_ECO_NUMBER));
             added.forEach(newNumber -> {
-                if (!newNumber.matches("[0-9]+") || newNumber.length() != 10) {
+                if (!newNumber.matches("\\d{4,10}")) {
                     throw new BadRequestException(INCORRECT_ECO_NUMBER);
                 }
                 order.getAdditionalOrders().add(newNumber);


### PR DESCRIPTION
# GreenCityUBS PR
[[UBS courier/Order details] An error message appears when user clicks the mouse outside the field "Order number" #6007](https://github.com/ita-social-projects/GreenCity/issues/6007)
## Summary Of Changes :fire:
Change of regex in updateEcoNumberForOrder method.
Before change was expected 10 digits, but  was decided to make it the same as in frontend, from 4-10 digits. Practically checked. 
