### PR TITLE
#5920 notofication for brought by himself orders

### DIFF
--- a/dao/src/main/java/greencity/entity/notifications/NotificationParameter.java
+++ b/dao/src/main/java/greencity/entity/notifications/NotificationParameter.java
@@ -18,6 +18,7 @@ public class NotificationParameter {
 
     @ManyToOne
     @JoinColumn(name = "notification_id", nullable = false)
+    @ToString.Exclude
     private UserNotification userNotification;
 
     @Column(nullable = false, name = "key", length = 50)

--- a/service-api/src/main/java/greencity/service/ubs/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/ubs/NotificationService.java
@@ -87,6 +87,15 @@ public interface NotificationService {
     void notifyUnpaidOrder(Order order);
 
     /**
+     * Notifies the customer that the order status has been changed to "Brought by
+     * himself".
+     *
+     * @param order The order {@link Order} which status was changed.
+     * @author Maksym Lenets
+     */
+    public void notifySelfPickupOrder(Order order);
+
+    /**
      * Method that returns page with notifications for user by UUID.
      *
      * @author Ann Sakhno

--- a/service-api/src/main/java/greencity/service/ubs/OrdersAdminsPageService.java
+++ b/service-api/src/main/java/greencity/service/ubs/OrdersAdminsPageService.java
@@ -5,6 +5,7 @@ import greencity.dto.order.ChangeOrderResponseDTO;
 import greencity.dto.order.RequestToChangeOrdersDataDto;
 import greencity.dto.table.ColumnWidthDto;
 import greencity.dto.table.TableParamsDto;
+import greencity.entity.user.employee.Employee;
 
 import java.util.List;
 
@@ -48,12 +49,12 @@ public interface OrdersAdminsPageService {
     /**
      * Method changing order's status.
      *
-     * @param value      of {@link String}
-     * @param ordersId   of {@link List}
-     * @param employeeId of {@link Long}
+     * @param value    of {@link String}
+     * @param ordersId of {@link List}
+     * @param employee of {@link Employee}
      * @author Liubomyr Pater
      */
-    List<Long> orderStatusForDevelopStage(List<Long> ordersId, String value, Long employeeId);
+    List<Long> orderStatusForDevelopStage(List<Long> ordersId, String value, Employee employee);
 
     /**
      * Method changing order's date of export.

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -226,6 +226,18 @@ public class NotificationServiceImpl implements NotificationService {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void notifySelfPickupOrder(Order order) {
+        Set<NotificationParameter> parameters = Set.of(NotificationParameter.builder()
+            .key(ORDER_NUMBER_KEY)
+            .value(order.getId().toString())
+            .build());
+        fillAndSendNotification(parameters, order, NotificationType.ORDER_STATUS_CHANGED);
+    }
+
     private Double getAmountToPay(Order order) {
         long bonusesInCoins = order.getPointsToUse() == null ? 0L : order.getPointsToUse() * 100L;
         long certificatesInCoins = order.getCertificates() == null ? 0L

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1031,6 +1031,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                 eventService.saveEvent(OrderHistory.ORDER_DONE, email, order);
             } else if (order.getOrderStatus() == OrderStatus.BROUGHT_IT_HIMSELF) {
                 eventService.saveEvent(OrderHistory.ORDER_BROUGHT_IT_HIMSELF, email, order);
+                notificationService.notifySelfPickupOrder(order);
             } else if (order.getOrderStatus() == OrderStatus.ON_THE_ROUTE) {
                 eventService.saveEvent(OrderHistory.ORDER_ON_THE_ROUTE, email, order);
             }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -569,6 +569,7 @@ public class ModelUtils {
     public static Order getOrder() {
         return Order.builder()
             .id(1L)
+            .orderDate(LocalDateTime.of(2023, 10, 20, 14, 58))
             .payment(Lists.newArrayList(Payment.builder()
                 .id(1L)
                 .paymentId("1")

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -667,4 +667,30 @@ class NotificationServiceImplTest {
         assertEquals(TEST_NOTIFICATION_TEMPLATE.getTitleEng(), result.getTitle());
     }
 
+    @Test
+    void notifySelfPickupOrderTest() {
+        User user = getUser();
+        Long orderId = 2L;
+        Order order = Order.builder()
+            .id(orderId)
+            .user(user)
+            .build();
+        UserNotification notification = new UserNotification();
+        notification.setNotificationType(NotificationType.ORDER_STATUS_CHANGED);
+        notification.setUser(user);
+        notification.setOrder(order);
+        Set<NotificationParameter> parameters = Set.of(NotificationParameter.builder()
+            .key("orderNumber")
+            .value(orderId.toString())
+            .userNotification(notification)
+            .build());
+
+        when(userNotificationRepository.save(any())).thenReturn(notification);
+        when(notificationParameterRepository.saveAll(any())).thenReturn(new ArrayList<>(parameters));
+
+        notificationService.notifySelfPickupOrder(order);
+
+        verify(userNotificationRepository).save(notification);
+        verify(notificationParameterRepository).saveAll(parameters);
+    }
 }

--- a/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
@@ -524,7 +524,7 @@ class OrdersAdminsPageServiceImplTest {
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
 
-        ordersAdminsPageService.orderStatusForDevelopStage(List.of(1L), newStatus, 1L);
+        ordersAdminsPageService.orderStatusForDevelopStage(List.of(1L), newStatus, ModelUtils.getEmployee());
 
         assertNotNull(order.getDateOfExport());
         assertNotNull(order.getDeliverFrom());
@@ -533,6 +533,28 @@ class OrdersAdminsPageServiceImplTest {
         assertNotNull(order.getEmployeeOrderPositions());
 
         verify(orderRepository).save(order);
+    }
+
+    @Test
+    void orderStatusForDevelopStageChangeStatusToBroughtItHimselfTest() {
+        String newStatus = "BROUGHT_IT_HIMSELF";
+        Order saved = ModelUtils.getOrder();
+        saved.setOrderStatus(OrderStatus.FORMED);
+
+        Order expected = ModelUtils.getOrder();
+        expected.setOrderStatus(OrderStatus.BROUGHT_IT_HIMSELF);
+        expected.setDateOfExport(null);
+        expected.setDeliverFrom(null);
+        expected.setDeliverTo(null);
+        expected.setReceivingStation(null);
+
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(saved));
+
+        ordersAdminsPageService.orderStatusForDevelopStage(List.of(1L), newStatus, ModelUtils.getEmployee());
+
+        verify(eventService).save(eq(OrderHistory.ORDER_BROUGHT_IT_HIMSELF), anyString(), any(Order.class));
+        verify(notificationService).notifySelfPickupOrder(expected);
+        verify(orderRepository).save(expected);
     }
 
     @ParameterizedTest
@@ -556,7 +578,7 @@ class OrdersAdminsPageServiceImplTest {
 
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
 
-        ordersAdminsPageService.orderStatusForDevelopStage(List.of(1L), newStatus, 1L);
+        ordersAdminsPageService.orderStatusForDevelopStage(List.of(1L), newStatus, ModelUtils.getEmployee());
 
         verify(orderRepository).save(order);
     }
@@ -565,7 +587,7 @@ class OrdersAdminsPageServiceImplTest {
     void orderStatusForDevelopStageEntityNotFoundException() {
         when(orderRepository.findById(1L)).thenReturn(Optional.empty());
         assertEquals(List.of(1L),
-            ordersAdminsPageService.orderStatusForDevelopStage(List.of(1L), "", 1L));
+            ordersAdminsPageService.orderStatusForDevelopStage(List.of(1L), "", ModelUtils.getEmployee()));
     }
 
     @Test
@@ -573,7 +595,7 @@ class OrdersAdminsPageServiceImplTest {
         when(orderRepository.findById(1L))
             .thenReturn(Optional.of(ModelUtils.getOrder().setOrderStatus(OrderStatus.FORMED)));
         assertEquals(List.of(1L),
-            ordersAdminsPageService.orderStatusForDevelopStage(List.of(1L), "DONE", 1L));
+            ordersAdminsPageService.orderStatusForDevelopStage(List.of(1L), "DONE", ModelUtils.getEmployee()));
     }
 
     @Test
@@ -581,7 +603,6 @@ class OrdersAdminsPageServiceImplTest {
         var orderId = 1L;
         var ordersId = List.of(orderId);
         var newValue = "CONFIRMED";
-        var employeeId = 3L;
         var anotherEmployeeId = 4L;
 
         var order = Order.builder()
@@ -593,7 +614,7 @@ class OrdersAdminsPageServiceImplTest {
 
         when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
 
-        var result = ordersAdminsPageService.orderStatusForDevelopStage(ordersId, newValue, employeeId);
+        var result = ordersAdminsPageService.orderStatusForDevelopStage(ordersId, newValue, ModelUtils.getEmployee());
 
         verify(orderRepository).findById(orderId);
         verify(orderRepository, never()).save(any(Order.class));

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -927,6 +927,29 @@ class UBSManagementServiceImplTest {
     }
 
     @Test
+    void updateOrderDetailStatusToBroughtItHimselfTest() {
+        String email = "some@email.com";
+        Order saved = getOrder();
+        saved.setOrderStatus(OrderStatus.FORMED);
+        Order updated = getOrder();
+        updated.setOrderStatus(OrderStatus.BROUGHT_IT_HIMSELF);
+
+        when(paymentRepository.findAllByOrderId(saved.getId())).thenReturn(saved.getPayment());
+
+        OrderDetailStatusRequestDto detailStatusDto = OrderDetailStatusRequestDto.builder()
+            .orderStatus("BROUGHT_IT_HIMSELF")
+            .build();
+
+        OrderDetailStatusDto result = ubsManagementService.updateOrderDetailStatus(saved, detailStatusDto, email);
+
+        verify(eventService).saveEvent(OrderHistory.ORDER_BROUGHT_IT_HIMSELF, email, updated);
+        verify(notificationService).notifySelfPickupOrder(updated);
+        verify(orderRepository).save(updated);
+
+        assertEquals(OrderStatus.BROUGHT_IT_HIMSELF.name(), result.getOrderStatus());
+    }
+
+    @Test
     void getAllEmployeesByPosition() {
         Order order = getOrder();
         TariffsInfo tariffsInfo = getTariffsInfo();


### PR DESCRIPTION
## Summary Of Issue :
Notification is not sent to the user after the order status is changed to 'Brought by himself'

**Issue Link**
https://github.com/ita-social-projects/GreenCity/issues/5920

## Summary Of Changes :
1) Added a new method, NotificationServiceImpl.notifySelfPickupOrder, that sends of notifications.
2) Implemented the functionality to send notifications when updating orders from both the order card and the order table.
3) Included new test cases and made updates to existing ones.

## CHECK LIST
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] All files reviewed before sending to reviewers