### PR TITLE
[GreenCityUBS] - Unable to access the Certificates page #6987

### DIFF
--- a/dao/src/main/java/greencity/repository/CertificateCriteriaRepo.java
+++ b/dao/src/main/java/greencity/repository/CertificateCriteriaRepo.java
@@ -61,15 +61,16 @@ public class CertificateCriteriaRepo {
         typedQuery.setMaxResults(certificatePage.getPageSize());
 
         Pageable pageable = getPageable(certificatePage);
-        long certificatesCount = getCertificatesCount(predicate);
+        long certificatesCount = getCertificatesCount(certificateFilterCriteria);
 
         return new PageImpl<>(typedQuery.getResultList(), pageable, certificatesCount);
     }
 
-    private long getCertificatesCount(Predicate predicate) {
-        CriteriaQuery<Long> countQuery = criteriaBuilder.createQuery(Long.class);
-        Root<Certificate> countRoot = countQuery.from(Certificate.class);
-        countQuery.select(criteriaBuilder.count(countRoot)).where(predicate);
+    private long getCertificatesCount(CertificateFilterCriteria certificateFilterCriteria) {
+        var countQuery = criteriaBuilder.createQuery(Long.class);
+        var countRoot = countQuery.from(Certificate.class);
+        var countPredicate = getPredicate(certificateFilterCriteria, countRoot);
+        countQuery.select(criteriaBuilder.count(countRoot)).where(countPredicate);
         return entityManager.createQuery(countQuery).getSingleResult();
     }
 


### PR DESCRIPTION
# GreenCityUBS PR
https://github.com/ita-social-projects/GreenCity/issues/6987

## Summary Of Changes :fire:
In Hibernate 6 it's no longer possible to reuse objects across different Criteria Queries, so we need to refactor code in CertificateCriteriaRepo class

## Changed
* Method in CertificateCriteriaRepo class

## How to test :clipboard:
It can be tests via swagger in Management-Order-Controller, endpoint /ubs/management/getAllCertificates

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
