### PR TITLE
Quantity field added to BagTranslationDto

### DIFF
--- a/dao/src/main/java/greencity/repository/OrderBagRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderBagRepository.java
@@ -7,8 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface OrderBagRepository extends JpaRepository<OrderBag, Long> {
@@ -70,4 +70,26 @@ public interface OrderBagRepository extends JpaRepository<OrderBag, Long> {
      * @author Oksana Spodaryk
      */
     List<OrderBag> findAllByBagId(Integer bagId);
+
+    /**
+     * Method returns OrderBags quantity by bag id and order id. It prioritizes the
+     * following quantities in descending order: 1. Exported Quantity: If all
+     * OrderBags have the 'exportedQuantity' attribute set, the method will return
+     * it. 2. Confirmed Quantity: If 'exportedQuantity' is not available for all
+     * OrderBags but 'confirmedQuantity' is, the method will return it. 3. Regular
+     * Amount: If neither 'exportedQuantity' nor 'confirmedQuantity' are available
+     * for all OrderBags, the method will return the 'amount' attribute.
+     *
+     * @param bagId   {@link Integer} bag id
+     * @param orderId {@link Long} order id
+     *
+     * @return {@link Optional} of {@link Integer} returns actual bags' amount
+     * @author Olena Sotnik
+     */
+    @Query(value = "SELECT COALESCE(obm.exported_quantity, obm.confirmed_quantity, obm.amount) "
+        + "FROM order_bag_mapping AS obm "
+        + "WHERE obm.order_id = :orderId "
+        + "AND obm.bag_id = :bagId", nativeQuery = true)
+    Optional<Integer> getAmountOfOrderBagsByOrderIdAndBagId(@Param("orderId") Long orderId,
+        @Param("bagId") Integer bagId);
 }

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -165,6 +165,8 @@ public final class ErrorMessage {
     public static final String INVALID_URL = "Invalid URL: ";
     public static final String LOCATION_CAN_NOT_BE_DELETED =
         "Such location cannot be deleted as it is linked to the tariff";
+    public static final String BAGS_QUANTITY_NOT_FOUND_MESSAGE = "Bags quantity not found by current orderId "
+        + "and bagId.";
 
     /**
      * Constructor.

--- a/service-api/src/main/java/greencity/dto/bag/BagTranslationDto.java
+++ b/service-api/src/main/java/greencity/dto/bag/BagTranslationDto.java
@@ -6,7 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
-
+import lombok.ToString;
 import javax.validation.constraints.Min;
 import java.io.Serializable;
 
@@ -14,6 +14,7 @@ import java.io.Serializable;
 @Getter
 @Setter
 @EqualsAndHashCode
+@ToString
 @Builder
 public class BagTranslationDto implements Serializable {
     @Min(1)
@@ -28,4 +29,5 @@ public class BagTranslationDto implements Serializable {
     private String nameEng;
     @NonNull
     private Boolean limitedIncluded;
+    private Integer quantity;
 }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -5322,4 +5322,19 @@ public class ModelUtils {
     public static Refund getRefund(Long id) {
         return Refund.builder().orderId(id).build();
     }
+
+    public static UserPointsAndAllBagsDto getUserPointsAndAllBagsDtoWithQuantity() {
+        return new UserPointsAndAllBagsDto(
+            List.of(
+                BagTranslationDto.builder()
+                    .id(1)
+                    .name("name")
+                    .capacity(20)
+                    .price(170.)
+                    .nameEng("nameEng")
+                    .limitedIncluded(false)
+                    .quantity(2)
+                    .build()),
+            100);
+    }
 }

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -675,22 +675,25 @@ class UBSClientServiceImplTest {
         var tariffLocation = getTariffLocation();
 
         var bags = getBag1list();
-        var bagTranslationDto = getBagTranslationDto();
-        var userPointsAndAllBagsDtoExpected = getUserPointsAndAllBagsDto();
+        var userPointsAndAllBagsDtoExpected = ModelUtils.getUserPointsAndAllBagsDtoWithQuantity();
 
         when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.of(user));
         when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
         when(tariffLocationRepository.findTariffLocationByTariffsInfoAndLocation(tariffsInfo, location))
             .thenReturn(Optional.of(tariffLocation));
         when(bagRepository.findAllActiveBagsByTariffsInfoId(tariffsInfoId)).thenReturn(bags);
-        when(modelMapper.map(bags.get(0), BagTranslationDto.class)).thenReturn(bagTranslationDto);
+        when(orderBagRepository.getAmountOfOrderBagsByOrderIdAndBagId(anyLong(), anyInt()))
+            .thenReturn(Optional.of(2));
 
         var userPointsAndAllBagsDtoActual =
             ubsService.getFirstPageDataByOrderId(uuid, orderId);
 
         assertEquals(
-            userPointsAndAllBagsDtoExpected.getBags(),
-            userPointsAndAllBagsDtoActual.getBags());
+            userPointsAndAllBagsDtoExpected.getBags().get(0).toString(),
+            userPointsAndAllBagsDtoActual.getBags().get(0).toString());
+        assertEquals(
+            userPointsAndAllBagsDtoExpected.getBags().get(0).getQuantity(),
+            userPointsAndAllBagsDtoActual.getBags().get(0).getQuantity());
         assertEquals(
             userPointsAndAllBagsDtoExpected.getBags().get(0).getId(),
             userPointsAndAllBagsDtoActual.getBags().get(0).getId());
@@ -702,7 +705,7 @@ class UBSClientServiceImplTest {
         verify(orderRepository).findById(orderId);
         verify(tariffLocationRepository).findTariffLocationByTariffsInfoAndLocation(tariffsInfo, location);
         verify(bagRepository).findAllActiveBagsByTariffsInfoId(tariffsInfoId);
-        verify(modelMapper).map(bags.get(0), BagTranslationDto.class);
+        verify(orderBagRepository).getAmountOfOrderBagsByOrderIdAndBagId(anyLong(), anyInt());
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUBS PR
Addition of field "quantity" to BagTranslationDto that returns actual bags' amount

## Summary Of Changes :fire:
-Added field Integer "quantity" to BagTranslationDto
-Updated method getFirstPageDataByOrderId in UBSClientServiceImpl
-Added extra method "buildBagTranslationDto(Long orderId, Bag source)" that returns BagTranslationDto
-Added additional method "getQuantityOfBagsByBagIdAndOrderId(Long orderId, Integer bagId)" that returns Integer that uses OrderBagRepository method with Query
-Added method "getAmountOfOrderBagsByOrderIdAndBagId" with Query that returns first non-null result from COALESCE(exported_quantity, confirmed_quantity, amount) which is prioritiesed by from exported_quantity to amount.
-Provided necessary tests
-As there is one more endpoint that uses UserPointsAndAllBagsDto which has List of BagTranslationDto, it was decided to use new method similar, but with Quantity calculated using orderId which is not present in other endpoint as argument: getUserPointsAndAllBagsDtoByTariffIdAndOrderIdAndUserPoints(Long tariffId,Integer userPoints, Long orderId) ;


# PR Checklist Forms
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers