### PR TITLE
Activation of inactive employee during saveEmployee()

### DIFF
--- a/dao/src/main/java/greencity/repository/EmployeeRepository.java
+++ b/dao/src/main/java/greencity/repository/EmployeeRepository.java
@@ -1,6 +1,7 @@
 package greencity.repository;
 
 import greencity.entity.user.employee.Employee;
+import greencity.enums.EmployeeStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -132,4 +133,34 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
             + "WHERE EMPLOYEE_ID = :employeeId",
         nativeQuery = true)
     List<Long> findTariffsInfoForEmployee(Long employeeId);
+
+    /**
+     * Method returns true or false if Employee exists by email with
+     * EmployeeStatus.INACTIVE.
+     *
+     * @param email {@link String}.
+     * @return boolean.
+     * @author Olena Sotnik.
+     */
+    @Query("SELECT CASE WHEN COUNT(e) > 0 THEN true "
+        + "ELSE false END "
+        + "FROM Employee e "
+        + "WHERE e.email = ?1 "
+        + "AND e.employeeStatus = 'INACTIVE'")
+    boolean existsByEmailAndInactiveStatus(String email);
+
+    /**
+     * Method returns true or false if Employee exists by email with
+     * EmployeeStatus.ACTIVE.
+     *
+     * @param email {@link String}.
+     * @return boolean.
+     * @author Olena Sotnik.
+     */
+    @Query(value = "SELECT CASE WHEN COUNT(e) > 0 THEN true "
+        + "ELSE false END "
+        + "FROM Employee e "
+        + "WHERE e.email = ?1 "
+        + "AND e.employeeStatus = 'ACTIVE'")
+    boolean existsByEmailAndActiveStatus(String email);
 }

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -39,7 +39,8 @@ public final class ErrorMessage {
     public static final String EMPLOYEE_NOT_FOUND = "Employee with current id doesn't exist: ";
     public static final String EMPLOYEE_NOT_FOUND_BY_EMAIL = "Employee with current id doesn't exist: ";
     public static final String EMPLOYEE_WITH_UUID_NOT_FOUND = "Employee with current uuid doesn't exist: ";
-    public static final String CURRENT_EMAIL_ALREADY_EXISTS = "Employee with this email already exists: ";
+    public static final String ACTIVE_EMPLOYEE_WITH_CURRENT_EMAIL_ALREADY_EXISTS =
+        "Active employee with this email already exists: ";
     public static final String PHONE_NUMBER_PARSING_FAIL = "Phone number parsing fail: ";
     public static final String CURRENT_POSITION_ALREADY_EXISTS = "Position with this name already exists: ";
     public static final String POSITION_NOT_FOUND_BY_ID = "Position with current id doesn't exist: ";

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -35,7 +35,9 @@ public final class ErrorMessage {
     public static final String ORDER_STATUS_NOT_FOUND = "Order status not found";
     public static final String ORDER_PAYMENT_STATUS_NOT_FOUND = "Order payment status not found";
     public static final String FILE_NOT_SAVED = "File hasn't been saved";
+
     public static final String EMPLOYEE_NOT_FOUND = "Employee with current id doesn't exist: ";
+    public static final String EMPLOYEE_NOT_FOUND_BY_EMAIL = "Employee with current id doesn't exist: ";
     public static final String EMPLOYEE_WITH_UUID_NOT_FOUND = "Employee with current uuid doesn't exist: ";
     public static final String CURRENT_EMAIL_ALREADY_EXISTS = "Employee with this email already exists: ";
     public static final String PHONE_NUMBER_PARSING_FAIL = "Phone number parsing fail: ";

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -69,7 +69,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
         if (employeeEmail != null
             && employeeRepository.existsByEmailAndActiveStatus(employeeEmail)) {
             throw new UnprocessableEntityException(
-                ErrorMessage.CURRENT_EMAIL_ALREADY_EXISTS + employeeEmail);
+                ErrorMessage.ACTIVE_EMPLOYEE_WITH_CURRENT_EMAIL_ALREADY_EXISTS + employeeEmail);
         }
 
         if (employeeRepository.existsByEmailAndInactiveStatus(employeeEmail)) {
@@ -210,7 +210,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
         updateEmployeeAuthoritiesToRelatedPositions(dto);
 
         Employee updatedEmployee = modelMapper.map(dto, Employee.class);
-        updatedEmployee.setTariffInfos(tariffsInfoRepository.findTariffsInfosByIdIsIn(List.of(31L)));
+        updatedEmployee.setTariffInfos(tariffsInfoRepository.findTariffsInfosByIdIsIn(dto.getTariffId()));
         updatedEmployee.setUuid(upEmployee.getUuid());
         updatedEmployee.setEmployeeStatus(upEmployee.getEmployeeStatus());
 

--- a/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
@@ -142,7 +142,7 @@ class UBSManagementEmployeeServiceImplTest {
         Exception thrown = assertThrows(UnprocessableEntityException.class,
             () -> employeeService.save(dto, null));
         assertEquals(thrown.getMessage(),
-            ErrorMessage.CURRENT_EMAIL_ALREADY_EXISTS + dto.getEmployeeDto().getEmail());
+            ErrorMessage.ACTIVE_EMPLOYEE_WITH_CURRENT_EMAIL_ALREADY_EXISTS + dto.getEmployeeDto().getEmail());
 
         verify(repository).existsByEmailAndActiveStatus(getAddEmployeeDto().getEmail());
     }
@@ -176,7 +176,8 @@ class UBSManagementEmployeeServiceImplTest {
         Exception thrown = assertThrows(UnprocessableEntityException.class,
             () -> employeeService.save(employeeWithTariffsIdDto, null));
         assertEquals(thrown.getMessage(),
-            ErrorMessage.CURRENT_EMAIL_ALREADY_EXISTS + employeeWithTariffsIdDto.getEmployeeDto().getEmail());
+            ErrorMessage.ACTIVE_EMPLOYEE_WITH_CURRENT_EMAIL_ALREADY_EXISTS
+                + employeeWithTariffsIdDto.getEmployeeDto().getEmail());
 
         verify(repository).existsByEmailAndActiveStatus(getAddEmployeeDto().getEmail());
     }


### PR DESCRIPTION
# GreenCityUBS PR
Addition of activation of existing employee with INACTIVE status in save method.

## Summary Of Changes :fire:
-Added methods to EmployeeRepository: boolean existsByEmailAndActiveStatus()
 and boolean existsByEmailAndInactiveStatus();
-Updated method **save()** in UBSManagementEmployeeServiceImpl;
-Added test saveEmployeeTestWithInactiveStatus() and updated other tests for save method;
-Added new const EMPLOYEE_NOT_FOUND_BY_EMAIL to ErrorMessage;


# PR Checklist Forms
- [ ] Code is up-to-date with the `prod` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers