### PR TITLE
Bug #5264 fixed [UBS Order Form][Step 0.1.] Incorrect names of drop-down list items 

### DIFF
--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -222,6 +222,7 @@
     <include file="/db/changelog/logs/ch-insert-into-users-Spodaryk.xml"/>
     <include file="/db/changelog/logs/ch-add-columns-nameEventEng-and-authorEng-to-Events-Bokalo.xml"/>
     <include file="/db/changelog/logs/ch-update-employees-set-new-main-email-Midianyi.xml"/>
+    <include file="/db/changelog/logs/ch-delete-from-locations-Liubchenko.xml"/>
 
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/logs/ch-delete-from-locations-Liubchenko.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-delete-from-locations-Liubchenko.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="ch-delete-from-locations-Liubchenko" author="Denys Liubchenko">
+        <delete tableName="tariffs_locations">
+            <where>location_id=2</where>
+        </delete>
+
+        <delete tableName="locations">
+            <where>id=2</where>
+        </delete>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Summary of issue

[Bug#5264](https://github.com/ita-social-projects/GreenCity/issues/5264)

## Summary of change

Added changelog for deleting incorrect location.
The following list items are displayed:
Київ, Київська область

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions