### PR TITLE
Fix access issue to order cancellation reason endpoint

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -200,7 +200,6 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET,
                     UBS_MANAG_LINK + "/**",
                     SUPER_ADMIN_LINK + "/**",
-                    UBS_LINK + "/order/{id}/cancellation",
                     ADMIN_LINK + "/notification/get-all",
                     ADMIN_LINK + "/notification/{id}",
                     ADMIN_LINK + "/**",
@@ -254,6 +253,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET,
                     UBS_LINK + "/**",
                     UBS_LINK + "/client/**",
+                    UBS_LINK + "/order/{id}/cancellation",
                     "/notifications",
                     "/notifications/**",
                     "/notifications/quantityUnreadenNotifications")

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -1449,7 +1449,9 @@ public class UBSClientServiceImpl implements UBSClientService {
     public OrderCancellationReasonDto getOrderCancellationReason(final Long orderId, String uuid) {
         Order order = orderRepository.findById(orderId)
             .orElseThrow(() -> new NotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST));
-        if (!order.getUser().equals(userRepository.findByUuid(uuid))) {
+        User user = userRepository.findByUuid(uuid);
+        boolean isAdminOrUbsEmployee = employeeRepository.findByUuid(uuid).isPresent();
+        if (!isAdminOrUbsEmployee && !(order.getUser().equals(user))) {
             throw new AccessDeniedException(CANNOT_ACCESS_ORDER_CANCELLATION_REASON);
         }
         return OrderCancellationReasonDto.builder()

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -2785,6 +2785,7 @@ class UBSClientServiceImplTest {
         Order orderDto = getOrderTest();
         when(orderRepository.findById(anyLong())).thenReturn(Optional.ofNullable(orderDto));
         assert orderDto != null;
+        when(employeeRepository.findByUuid(anyString())).thenReturn(Optional.of(new Employee()));
         when(userRepository.findByUuid(anyString())).thenReturn(orderDto.getUser());
         OrderCancellationReasonDto result = ubsService.getOrderCancellationReason(1L, anyString());
 
@@ -2802,6 +2803,7 @@ class UBSClientServiceImplTest {
     @Test
     void getOrderCancellationReasonAccessDeniedException() {
         when(orderRepository.findById(anyLong())).thenReturn(Optional.ofNullable(getOrderTest()));
+        when(employeeRepository.findByUuid(anyString())).thenReturn(Optional.empty());
         when(userRepository.findByUuid(anyString())).thenReturn(getTestUser());
         assertThrows(AccessDeniedException.class,
             () -> ubsService.getOrderCancellationReason(1L, "abc"));

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -2794,6 +2794,34 @@ class UBSClientServiceImplTest {
     }
 
     @Test
+    void testGetOrderCancellationReasonForAdmin() {
+        OrderCancellationReasonDto dto = getCancellationDto();
+        Order orderDto = getOrderTest();
+        when(orderRepository.findById(anyLong())).thenReturn(Optional.ofNullable(orderDto));
+        assert orderDto != null;
+        when(employeeRepository.findByUuid(anyString())).thenReturn(Optional.of(new Employee()));
+        when(userRepository.findByUuid(anyString())).thenReturn(null);
+        OrderCancellationReasonDto result = ubsService.getOrderCancellationReason(1L, anyString());
+
+        assertEquals(dto.getCancellationReason(), result.getCancellationReason());
+        assertEquals(dto.getCancellationComment(), result.getCancellationComment());
+    }
+
+    @Test
+    void testGetOrderCancellationReasonForUser() {
+        OrderCancellationReasonDto dto = getCancellationDto();
+        Order orderDto = getOrderTest();
+        when(orderRepository.findById(anyLong())).thenReturn(Optional.ofNullable(orderDto));
+        assert orderDto != null;
+        when(employeeRepository.findByUuid(anyString())).thenReturn(Optional.empty());
+        when(userRepository.findByUuid(anyString())).thenReturn(orderDto.getUser());
+        OrderCancellationReasonDto result = ubsService.getOrderCancellationReason(1L, anyString());
+
+        assertEquals(dto.getCancellationReason(), result.getCancellationReason());
+        assertEquals(dto.getCancellationComment(), result.getCancellationComment());
+    }
+
+    @Test
     void getOrderCancellationReasonOrderNotFoundException() {
         when(orderRepository.findById(anyLong())).thenReturn(Optional.empty());
         assertThrows(NotFoundException.class,


### PR DESCRIPTION
# GreenCityUBS PR
[[API][Swagger/Order Controller] User and UBS Admin can't get info about order cancellation reason #6699](https://github.com/ita-social-projects/GreenCity/issues/6699)

## Summary Of Changes :fire:
- Updated access to endpoint [GET] /ubs/order/{id}/cancellation in SecurityConfig
- Added check for user to be Admin or UbsEmployee to be able to access endpoint 

## How to test: 
Via Swagger log in as user who created order and use endpoint - expected result - 200 Status Code
Log in as Admin or UbsEmployee - expected result - 200 Status Code
Log in as other user - expected result - exception with message informing that there is no access for current user to see reason of cancellation order; 
# PR Checklist Forms
_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers
