### PR TITLE
Change payment link in email notification for prod

### DIFF
--- a/core/src/main/resources/application-dev.properties
+++ b/core/src/main/resources/application-dev.properties
@@ -39,3 +39,5 @@ greencity.payment.fondy-payment-key=${FONDY_PAYMENT_KEY}
 #GreenCityClient
 greencity.redirect.green-city-client=http://localhost:4200/#/ubs/confirm
 
+#Unpaid order link
+greencity.internal.order-url=http://localhost:4200/#/ubs/order/

--- a/core/src/main/resources/application-docker.properties
+++ b/core/src/main/resources/application-docker.properties
@@ -38,3 +38,6 @@ greencity.payment.fondy-payment-key=${FONDY_PAYMENT_KEY}
 
 #GreenCityClient
 greencity.redirect.green-city-client=http://localhost:4200/#/ubs/confirm
+
+#Unpaid order link
+greencity.internal.order-url=http://localhost:4200/#/ubs/order/

--- a/core/src/main/resources/application-prod.properties
+++ b/core/src/main/resources/application-prod.properties
@@ -45,3 +45,5 @@ greencity.payment.fondy-payment-key=${FONDY_PAYMENT_KEY}
 #GreenCityClient
 greencity.redirect.green-city-client=https://www.pick-up.city/#/ubs/confirm
 
+#Unpaid order link
+greencity.internal.order-url=https://www.pick-up.city/#/ubs/order/

--- a/service/src/main/java/greencity/config/InternalUrlConfigProp.java
+++ b/service/src/main/java/greencity/config/InternalUrlConfigProp.java
@@ -10,5 +10,5 @@ import org.springframework.context.annotation.Configuration;
 @Setter
 @ConfigurationProperties(prefix = "greencity.internal", ignoreUnknownFields = false)
 public class InternalUrlConfigProp {
-    private String unpaidOrderUrl;
+    private String orderUrl;
 }

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -124,7 +124,7 @@ public class NotificationServiceImpl implements NotificationService {
 
         parameters.add(NotificationParameter.builder()
             .key(PAY_BUTTON)
-            .value(internalUrlConfigProp.getUnpaidOrderUrl() + order.getId())
+            .value(internalUrlConfigProp.getOrderUrl() + order.getId())
             .build());
 
         return parameters;


### PR DESCRIPTION
## Summary of issue

[#7052](https://github.com/ita-social-projects/GreenCity/issues/7052)

## Summary of change

Changed payment link from https://greencity-ubs.pick-up.city/ubs/details-for-existing-order/{orderId} to order url depending on a project profile. Also edited deprecated green city client link.

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions