### PR TITLE
Fix save employee not to save new employee on existing id

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -84,7 +84,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
         }
         checkValidPosition(dto.getEmployeeDto().getEmployeePositions());
 
-        Employee employee = modelMapper.map(dto, Employee.class);
+        Employee employee = buildEmployeeFromEmployeeWithTariffsIdDto(dto);
         employee.setUuid(UUID.randomUUID().toString());
         employee.setTariffInfos(tariffsInfoRepository.findTariffsInfosByIdIsIn(dto.getTariffId()));
         employee.setEmployeeStatus(EmployeeStatus.ACTIVE);
@@ -95,6 +95,22 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
         }
         signUpEmployee(employee);
         return modelMapper.map(employeeRepository.save(employee), EmployeeWithTariffsDto.class);
+    }
+
+    private Employee buildEmployeeFromEmployeeWithTariffsIdDto(EmployeeWithTariffsIdDto employeeWithTariffsIdDto) {
+        return Employee.builder()
+            .firstName(employeeWithTariffsIdDto.getEmployeeDto().getFirstName())
+            .lastName(employeeWithTariffsIdDto.getEmployeeDto().getLastName())
+            .phoneNumber(employeeWithTariffsIdDto.getEmployeeDto().getPhoneNumber())
+            .email(employeeWithTariffsIdDto.getEmployeeDto().getEmail())
+            .employeePosition(employeeWithTariffsIdDto.getEmployeeDto().getEmployeePositions().stream()
+                .map(positionDto -> Position.builder()
+                    .id(positionDto.getId())
+                    .name(positionDto.getName())
+                    .nameEn(positionDto.getNameEn())
+                    .build())
+                .collect(Collectors.toSet()))
+            .build();
     }
 
     private void signUpEmployee(Employee employee) {

--- a/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
@@ -84,13 +84,11 @@ class UBSManagementEmployeeServiceImplTest {
             "", "application/json", "random Bytes".getBytes());
 
         when(repository.existsByEmailAndActiveStatus(getAddEmployeeDto().getEmail())).thenReturn(false);
-        when(modelMapper.map(dto, Employee.class)).thenReturn(employee);
         when(repository.save(any())).thenReturn(employee);
         when(positionRepository.existsPositionByIdAndName(any(), any())).thenReturn(true);
         employeeService.save(dto, file);
 
         verify(repository, times(1)).existsByEmailAndActiveStatus(getAddEmployeeDto().getEmail());
-        verify(modelMapper, times(2)).map(any(), any());
         verify(repository, times(1)).save(any());
         verify(positionRepository, atLeastOnce()).existsPositionByIdAndName(any(), any());
     }

--- a/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
@@ -158,14 +158,12 @@ class UBSManagementEmployeeServiceImplTest {
         EmployeeWithTariffsIdDto dto = getEmployeeWithTariffsIdDto();
 
         when(repository.existsByEmailAndActiveStatus(getAddEmployeeDto().getEmail())).thenReturn(false);
-        when(modelMapper.map(dto, Employee.class)).thenReturn(employee);
         when(repository.save(any())).thenReturn(employee);
         when(positionRepository.existsPositionByIdAndName(any(), any())).thenReturn(true);
         employeeService.save(dto, null);
 
         verify(repository, times(1))
             .existsByEmailAndActiveStatus(getAddEmployeeDto().getEmail());
-        verify(modelMapper, times(2)).map(any(), any());
         verify(repository, times(1)).save(any());
         verify(positionRepository, atLeastOnce()).existsPositionByIdAndName(any(), any());
     }


### PR DESCRIPTION
# GreenCityUBS PR
In case we add id field to dto during swagger endpoint usage ([POST]admin/ubs-employee/save-employee) for new employee with not registered email in employee table, we basically update previous table record, with new email.
To avoid problem - new method to build Employee from EmployeeWithTariffsIdDto was created. 
We use id in some cases therefore we don't delete it from EmployeeDto. 
Mapper that was used previously uses field id for update endpoint, so it could not be changed. As it is it saves id from dto to database.

## Added
-new method buildEmployeeFromEmployeeWithTariffsIdDto()
-updated tests for save Employee method
-updated save method 


# PR Checklist Forms
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers