### PR TITLE
Commit with fix cityName trim function

### DIFF
--- a/service/src/main/java/greencity/service/locations/LocationApiServiceImpl.java
+++ b/service/src/main/java/greencity/service/locations/LocationApiServiceImpl.java
@@ -340,8 +340,7 @@ public class LocationApiServiceImpl implements LocationApiService {
     }
 
     private static String removeWordCity(String sentence) {
-        String withoutSpaces = sentence.replace(" ", "");
-        String withoutRegion = withoutSpaces.replaceAll("(?iu)city", "");
-        return replaceAllQuotes(withoutRegion.replaceAll("(?iu)місто", ""));
+        String withoutRegion = sentence.replaceAll("(?iu)city", "").trim();
+        return replaceAllQuotes(withoutRegion.replaceAll("(?iu)місто", "").trim());
     }
 }


### PR DESCRIPTION
# GreenCityUBS PR

##Issue Description
There is a 400 code error during [GET]/ubs/findAll-order-address, when address is saved with city having 2 words like Bila Tzerkva, Sofiivska Borschahivca, etc.
Converting from Address to AddressDto produce error.

## Summary Of Changes :fire:
-updated pattern to trim the cityName, before it reduced all spaces, now only from sides. 
Which works for 2 words cities.

# PR Checklist Forms
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers