### PR TITLE
Fix order address save house number

### DIFF
--- a/core/src/main/java/greencity/controller/ClientController.java
+++ b/core/src/main/java/greencity/controller/ClientController.java
@@ -34,7 +34,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
-
 import javax.validation.Valid;
 import java.util.List;
 import java.util.Locale;
@@ -201,28 +200,6 @@ public class ClientController {
     @GetMapping("/order-payment-detail/{orderId}")
     public ResponseEntity<OrderPaymentDetailDto> getOrderPaymentDetail(@PathVariable Long orderId) {
         return ResponseEntity.status(HttpStatus.OK).body(ubsClientService.getOrderPaymentDetail(orderId));
-    }
-
-    /**
-     * Controller for getting order info data about surcharge.
-     *
-     * @return {@link OrderStatusPageDto}.
-     * @author Igor Boykov
-     */
-    @ApiOperation(value = "Controller for getting order info data about surcharge")
-    @ApiResponses({
-        @ApiResponse(code = 200, message = HttpStatuses.OK, response = OrderStatusPageDto.class),
-        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(code = 401, message = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(code = 403, message = HttpStatuses.FORBIDDEN),
-        @ApiResponse(code = 404, message = HttpStatuses.NOT_FOUND)
-    })
-    @GetMapping("/get-data-for-order-surcharge/{id}")
-    public ResponseEntity<OrderStatusPageDto> getDataForOrderSurcharge(
-        @PathVariable(name = "id") Long orderId,
-        @ApiIgnore @CurrentUserUuid String uuid) {
-        return ResponseEntity.status(HttpStatus.OK)
-            .body(ubsClientService.getOrderInfoForSurcharge(orderId, uuid));
     }
 
     /**

--- a/core/src/test/java/greencity/controller/ClientControllerTest.java
+++ b/core/src/test/java/greencity/controller/ClientControllerTest.java
@@ -20,11 +20,9 @@ import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
 import java.security.Principal;
 import java.util.List;
 import java.util.Locale;
-
 import static greencity.ModelUtils.getOrderClientDto;
 import static greencity.ModelUtils.getUuid;
 import static org.mockito.Mockito.*;
@@ -101,12 +99,6 @@ class ClientControllerTest {
             .andExpect(status().isOk());
 
         verify(ubsClientService, times(1)).getOrderPaymentDetail(1L);
-    }
-
-    @Test
-    void getDataForOrderStatusPageTest() throws Exception {
-        this.mockMvc.perform(get(ubsLink + "/get-data-for-order-surcharge/{id}", 1L));
-        verify(ubsClientService).getOrderInfoForSurcharge(1L, null);
     }
 
     @Test

--- a/service-api/src/main/java/greencity/service/ubs/UBSClientService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSClientService.java
@@ -20,7 +20,6 @@ import greencity.dto.order.OrderClientDto;
 import greencity.dto.order.OrderFondyClientDto;
 import greencity.dto.order.OrderPaymentDetailDto;
 import greencity.dto.order.OrderResponseDto;
-import greencity.dto.order.OrderStatusPageDto;
 import greencity.dto.order.OrderWithAddressesResponseDto;
 import greencity.dto.order.OrdersDataForUserDto;
 import greencity.dto.pageble.PageableDto;
@@ -40,7 +39,6 @@ import greencity.entity.user.User;
 import greencity.enums.OrderStatus;
 import greencity.exceptions.payment.PaymentLinkException;
 import org.springframework.data.domain.Pageable;
-
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -289,14 +287,6 @@ public interface UBSClientService {
      * @author Yuriy Bahlay.
      */
     List<EventDto> getAllEventsForOrder(Long orderId, String email, String language);
-
-    /**
-     * Method that returns order info for surcharge.
-     *
-     * @return {@link OrderStatusPageDto}.
-     * @author Igor Boykov
-     */
-    OrderStatusPageDto getOrderInfoForSurcharge(Long orderId, String uuid);
 
     /**
      * Method for delete user order.

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -37,7 +37,6 @@ import greencity.dto.order.OrderClientDto;
 import greencity.dto.order.OrderFondyClientDto;
 import greencity.dto.order.OrderPaymentDetailDto;
 import greencity.dto.order.OrderResponseDto;
-import greencity.dto.order.OrderStatusPageDto;
 import greencity.dto.order.OrderWithAddressesResponseDto;
 import greencity.dto.order.OrdersDataForUserDto;
 import greencity.dto.pageble.PageableDto;
@@ -1494,20 +1493,6 @@ public class UBSClientServiceImpl implements UBSClientService {
         orderAddressRepository.save(orderAddress);
 
         return orderAddress;
-    }
-
-    @Override
-    public OrderStatusPageDto getOrderInfoForSurcharge(Long orderId, String uuid) {
-        OrderStatusPageDto orderStatusPageDto = ubsManagementService.getOrderStatusData(orderId, uuid);
-        Map<Integer, Integer> amountBagsOrder = orderStatusPageDto.getAmountOfBagsOrdered();
-        Map<Integer, Integer> amountBagsOrderExported = orderStatusPageDto.getAmountOfBagsExported();
-        amountBagsOrderExported.replaceAll((id, quantity) -> quantity = quantity - amountBagsOrder.get(id));
-        orderStatusPageDto.setAmountOfBagsExported(amountBagsOrderExported);
-        Double exportedPrice = orderStatusPageDto.getOrderExportedDiscountedPrice();
-        Double initialPrice = orderStatusPageDto.getOrderDiscountedPrice();
-        orderStatusPageDto.setOrderExportedDiscountedPrice(BigDecimal.valueOf(exportedPrice - initialPrice)
-            .setScale(AppConstant.TWO_DECIMALS_AFTER_POINT_IN_CURRENCY, RoundingMode.HALF_UP).doubleValue());
-        return orderStatusPageDto;
     }
 
     @Override

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -597,6 +597,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         }
 
         OrderAddressDtoRequest dtoRequest = getLocationDto(addressRequestDto.getPlaceId());
+        dtoRequest.setHouseNumber(addressRequestDto.getHouseNumber());
 
         OrderAddressDtoRequest addressRequestDtoForNullCheck =
             modelMapper.map(addressRequestDto, OrderAddressDtoRequest.class);


### PR DESCRIPTION
# GreenCityUBS PR
User passes houseNumber like 7-0 and address saved contains houseNumber 7.
Problem occurs when houseNumber is not found by GoogleApi during frontend  placeId processing ,so it contains the one that user passes or changed by closest number if not found.
On backend the houseNumber is changed while processing GeoCodingResults by placeId(that contains info about houseNumber).

## Summary Of Changes :fire:
- setHouseNumber value added after geoCodingResult updated houseNumber by placeId

## Issue Link
[[Order form] The house number is not fully saved in section “Адреса вивозу відходів” #6016](https://github.com/ita-social-projects/GreenCity/issues/6016)

# PR Checklist Forms
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers