### PR TITLE
Commit with save address houseNumber fix

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -597,6 +597,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         }
 
         OrderAddressDtoRequest dtoRequest = getLocationDto(addressRequestDto.getPlaceId());
+        dtoRequest.setHouseNumber(addressRequestDto.getHouseNumber());
 
         OrderAddressDtoRequest addressRequestDtoForNullCheck =
             modelMapper.map(addressRequestDto, OrderAddressDtoRequest.class);


### PR DESCRIPTION
# GreenCityUBS PR
User passes houseNumber like 7-0 and address saved contains houseNumber 7.
Problem occurs when houseNumber is not found by GoogleApi during frontend  placeId processing ,so it contains the one that user passes or changed by closest number if not found.
On backend the houseNumber is changed while processing GeoCodingResults by placeId(that contains info about houseNumber).

## Summary Of Changes :fire:
- setHouseNumber value added after geoCodingResult updated houseNumber by placeId

## Issue Link
[[Order form] The house number is not fully saved in section “Адреса вивозу відходів” #6016](https://github.com/ita-social-projects/GreenCity/issues/6016)

# PR Checklist Forms
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers