### PR TITLE
Fix the access issue for order editing by another administrator if the order is already locked

### DIFF
--- a/core/src/main/resources/application-dev.properties
+++ b/core/src/main/resources/application-dev.properties
@@ -3,7 +3,7 @@ spring.datasource.url=${DATASOURCE_URL}
 spring.datasource.username=${DATASOURCE_USER}
 spring.datasource.password=${DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
-server.port=8055
+server.port=8050
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto=validate

--- a/core/src/main/resources/application-dev.properties
+++ b/core/src/main/resources/application-dev.properties
@@ -3,7 +3,7 @@ spring.datasource.url=${DATASOURCE_URL}
 spring.datasource.username=${DATASOURCE_USER}
 spring.datasource.password=${DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
-server.port=8050
+server.port=8055
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto=validate
@@ -44,3 +44,6 @@ greencity.redirect.green-city-client=http://localhost:4200/#/ubs/confirm/
 
 #Unpaid order link
 greencity.internal.order-url=https://localhost:4200/#/ubs/order/
+
+#OrderLockDuration
+order.lock.duration.minutes=5

--- a/core/src/main/resources/application-docker.properties
+++ b/core/src/main/resources/application-docker.properties
@@ -40,3 +40,6 @@ greencity.redirect.green-city-client=http://localhost:4200/#/ubs/confirm/
 
 #Unpaid order link
 greencity.internal.order-url=https://localhost:4200/#/ubs/order/
+
+#OrderLockDuration
+order.lock.duration.minutes=5

--- a/core/src/main/resources/application-prod.properties
+++ b/core/src/main/resources/application-prod.properties
@@ -42,3 +42,6 @@ greencity.redirect.green-city-client=https://www.greencity.social/#/ubs/confirm/
 
 #Unpaid order link
 greencity.internal.order-url=https://www.greencity.social/#/ubs/order/
+
+#OrderLockDuration
+order.lock.duration.minutes=5

--- a/core/src/main/resources/application-test.properties
+++ b/core/src/main/resources/application-test.properties
@@ -26,3 +26,6 @@ greencity.payment.fondy-payment-key=mock
 #LiqPay
 liqpay.private.key=111111
 liqpay.public.key=111111
+
+#OrderLockDuration
+order.lock.duration.minutes=5

--- a/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
+++ b/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
@@ -27,10 +27,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Sql(scripts = "/sqlFiles/bigOrderTableRepository/insert.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-@Sql(scripts = "/sqlFiles/bigOrderTableRepository/delete.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = UbsApplication.class)
+//@Sql(scripts = "/sqlFiles/bigOrderTableRepository/insert.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+//@Sql(scripts = "/sqlFiles/bigOrderTableRepository/delete.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+//@ExtendWith(SpringExtension.class)
+//@SpringBootTest(classes = UbsApplication.class)
 class BigOrderTableRepositoryTest extends IntegrationTestBase {
     @Autowired
     private BigOrderTableRepository bigOrderTableRepository;
@@ -53,7 +53,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
     private static final OrderPage ORDER_PAGE_PAGE_NUMBER_3_PAGE_SIZE_2_ASC =
         new OrderPage().setPageNumber(3).setPageSize(2).setSortBy("id").setSortDirection(Sort.Direction.ASC);
 
-    @Test
+    // @Test
     void is_ModelUtil_Data_Equal_SQL() {
         List<BigOrderTableViews> expectedValue = ModelUtils.getAllBOTViewsASC();
         var actualValue = bigOrderTableRepository.findAll(ORDER_PAGE_PAGE_NUMBER_0_PAGE_SIZE_12_ASC,
@@ -61,7 +61,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Default_Page_ASC() {
         var expectedValue = ModelUtils.getListBOTViewsStandardPageASC();
         var actualValue = bigOrderTableRepository.findAll(DEFAULT_ORDER_PAGE_ASC,
@@ -69,7 +69,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Default_Page_DESC() {
         var expectedValue = ModelUtils.getListBOTViewsStandardPageDESC();
         var actualValue = bigOrderTableRepository.findAll(DEFAULT_ORDER_PAGE_DESC,
@@ -77,7 +77,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Page_Sorting_By_Order_Payment_Status_DESC() {
         var page = new OrderPage().setPageNumber(0).setPageSize(12).setSortBy("orderPaymentStatus")
             .setSortDirection(Sort.Direction.DESC);
@@ -94,7 +94,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Order_Status_Is_Formed_DESC() {
         var filter = new OrderSearchCriteria().setOrderStatus(new OrderStatus[] {OrderStatus.FORMED});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -106,7 +106,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Size_Two_Page_One_DESC() {
         var expectedValue = ModelUtils.getListBOTViewsSizeTwoPageOneDESC();
         var actualValue = bigOrderTableRepository.findAll(ORDER_PAGE_PAGE_NUMBER_1_PAGE_SIZE_2_DESC,
@@ -114,7 +114,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Order_Status_Is_Formed_And_CONFIRMED_DESC() {
         var filter =
             new OrderSearchCriteria().setOrderStatus(new OrderStatus[] {OrderStatus.FORMED, OrderStatus.CONFIRMED});
@@ -128,7 +128,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Payment_Status_Is_PAID_DESC() {
         var filter =
             new OrderSearchCriteria().setOrderPaymentStatus(new OrderPaymentStatus[] {OrderPaymentStatus.PAID});
@@ -142,7 +142,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_City_DESC() {
         var filter = new OrderSearchCriteria().setCities(new String[] {"Київ"});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -154,7 +154,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Region_DESC() {
         var filter = new OrderSearchCriteria().setRegion(new String[] {"Київська область"});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -166,7 +166,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Districts_DESC() {
         var filter = new OrderSearchCriteria().setDistricts(new String[] {"Подільський"});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -179,7 +179,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
             expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Order_Date_Between_DESC() {
         var filter = new OrderSearchCriteria().setOrderDate(new DateFilter().setFrom("2022-02-01").setTo("2022-02-02"));
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -193,7 +193,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Order_Date_Less_Then_Or_Equal_DESC() {
         var filter = new OrderSearchCriteria().setOrderDate(new DateFilter().setTo("2022-02-01"));
         LocalDateTime endDate = LocalDateTime.of(2022, 2, 2, 0, 0, 1);
@@ -207,7 +207,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Order_Date_Greater_Then_Or_Equal_DESC() {
         var filter = new OrderSearchCriteria().setOrderDate(new DateFilter().setFrom("2022-02-01"));
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -220,7 +220,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Date_Of_Export_Between_DESC() {
         var filter =
             new OrderSearchCriteria().setDeliveryDate(new DateFilter().setFrom("2022-02-03").setTo("2022-02-04"));
@@ -236,7 +236,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Payment_Date_Between() {
         var filter =
             new OrderSearchCriteria().setPaymentDate(new DateFilter().setFrom("2022-02-02").setTo("2022-02-02"));
@@ -252,7 +252,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Receiving_Station_DESC() {
         var filter = new OrderSearchCriteria().setReceivingStation(new Long[] {1L});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -265,7 +265,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Responsible_Logic_Man_ASC() {
         var filter = new OrderSearchCriteria().setResponsibleLogicManId(new Long[] {10L});
         var expectedValue = ModelUtils.getAllBOTViewsASC().stream()
@@ -278,7 +278,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Responsible_Caller_ASC() {
         var filter = new OrderSearchCriteria().setResponsibleCallerId(new Long[] {15L});
         var expectedValue = ModelUtils.getAllBOTViewsASC().stream()
@@ -291,7 +291,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Responsible_Driver_ASC() {
         var filter = new OrderSearchCriteria().setResponsibleDriverId(new Long[] {10L});
         var expectedValue = ModelUtils.getAllBOTViewsASC().stream()
@@ -304,7 +304,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Filter_By_Responsible_Navigator_DESC() {
         var filter = new OrderSearchCriteria().setResponsibleNavigatorId(new Long[] {10L});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -317,7 +317,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Search_by_phone_DESC() {
         var filter = new OrderSearchCriteria().setSearch(new String[] {"+380631144678"});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -330,7 +330,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Sort_By_OrderStatus_UA_Localization_ASC() {
         OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderStatus")
             .setSortDirection(Sort.Direction.ASC);
@@ -341,7 +341,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertTrue(isListCorrectlySorted);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Sort_By_OrderStatus_UA_Localization_DESC() {
         OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderStatus")
             .setSortDirection(Sort.Direction.DESC);
@@ -352,7 +352,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertTrue(isListCorrectlySorted);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Search_by_Client_Name_DESC() {
         var filter = new OrderSearchCriteria().setSearch(new String[] {"Anna Maria"});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -365,7 +365,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Combination_Filter_DESC() {
         var filter = new OrderSearchCriteria()
             .setOrderPaymentStatus(new OrderPaymentStatus[] {OrderPaymentStatus.PAID})
@@ -381,7 +381,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_Combination_Filter_ASC() {
         var filter = new OrderSearchCriteria()
             .setOrderPaymentStatus(new OrderPaymentStatus[] {OrderPaymentStatus.PAID})
@@ -397,7 +397,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_PageImpl_ASC() {
         var expectedValue = ModelUtils.getPageableAllBOTViews_ASC();
         var actualValue =
@@ -406,7 +406,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_PageImpl_Total_Elements_ASC() {
         var expectedValue = ModelUtils.getPageableAllBOTViews_Two_Element_On_Page_ASC().getTotalElements();
         var actualValue =
@@ -415,7 +415,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_PageImpl_Size_ASC() {
         var expectedValue = ModelUtils.getPageableAllBOTViews_Two_Element_On_Page_ASC().getSize();
         List<Long> tariffsInfoIds = new ArrayList<>();
@@ -427,7 +427,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_PageImpl_Number_ASC() {
         var expectedValue = ModelUtils.getPageableAllBOTViews_Two_Element_On_Page_ASC().getNumber();
         var actualValue =
@@ -436,7 +436,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    // @Test
     void get_All_Orders_PageImpl_Number_Of_Elements_ASC() {
         var expectedValue = ModelUtils.getPageableAllBOTViews_Two_Element_On_Page_ASC().getNumberOfElements();
         var actualValue =

--- a/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
+++ b/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
@@ -28,10 +28,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-//@Sql(scripts = "/sqlFiles/bigOrderTableRepository/insert.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-//@Sql(scripts = "/sqlFiles/bigOrderTableRepository/delete.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
-//@ExtendWith(SpringExtension.class)
-//@SpringBootTest(classes = UbsApplication.class)
+@Sql(scripts = "/sqlFiles/bigOrderTableRepository/insert.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "/sqlFiles/bigOrderTableRepository/delete.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = UbsApplication.class)
 class BigOrderTableRepositoryTest extends IntegrationTestBase {
     @Autowired
     private BigOrderTableRepository bigOrderTableRepository;
@@ -54,7 +54,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
     private static final OrderPage ORDER_PAGE_PAGE_NUMBER_3_PAGE_SIZE_2_ASC =
         new OrderPage().setPageNumber(3).setPageSize(2).setSortBy("id").setSortDirection(Sort.Direction.ASC);
 
-    // @Test
+    @Test
     void is_ModelUtil_Data_Equal_SQL() {
         List<BigOrderTableViews> expectedValue = ModelUtils.getAllBOTViewsASC();
         var actualValue = bigOrderTableRepository.findAll(ORDER_PAGE_PAGE_NUMBER_0_PAGE_SIZE_12_ASC,
@@ -62,7 +62,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Default_Page_ASC() {
         var expectedValue = ModelUtils.getListBOTViewsStandardPageASC();
         var actualValue = bigOrderTableRepository.findAll(DEFAULT_ORDER_PAGE_ASC,
@@ -70,7 +70,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Default_Page_DESC() {
         var expectedValue = ModelUtils.getListBOTViewsStandardPageDESC();
         var actualValue = bigOrderTableRepository.findAll(DEFAULT_ORDER_PAGE_DESC,
@@ -78,7 +78,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Page_Sorting_By_Order_Payment_Status_DESC() {
         var page = new OrderPage().setPageNumber(0).setPageSize(12).setSortBy("orderPaymentStatus")
             .setSortDirection(Sort.Direction.DESC);
@@ -95,7 +95,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Order_Status_Is_Formed_DESC() {
         var filter = new OrderSearchCriteria().setOrderStatus(new OrderStatus[] {OrderStatus.FORMED});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -107,7 +107,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Size_Two_Page_One_DESC() {
         var expectedValue = ModelUtils.getListBOTViewsSizeTwoPageOneDESC();
         var actualValue = bigOrderTableRepository.findAll(ORDER_PAGE_PAGE_NUMBER_1_PAGE_SIZE_2_DESC,
@@ -115,7 +115,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Order_Status_Is_Formed_And_CONFIRMED_DESC() {
         var filter =
             new OrderSearchCriteria().setOrderStatus(new OrderStatus[] {OrderStatus.FORMED, OrderStatus.CONFIRMED});
@@ -129,7 +129,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Payment_Status_Is_PAID_DESC() {
         var filter =
             new OrderSearchCriteria().setOrderPaymentStatus(new OrderPaymentStatus[] {OrderPaymentStatus.PAID});
@@ -143,7 +143,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_City_DESC() {
         var filter = new OrderSearchCriteria().setCities(new String[] {"Київ"});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -155,7 +155,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Region_DESC() {
         var filter = new OrderSearchCriteria().setRegion(new String[] {"Київська область"});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -167,7 +167,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Districts_DESC() {
         var filter = new OrderSearchCriteria().setDistricts(new String[] {"Подільський"});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -180,7 +180,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
             expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Order_Date_Between_DESC() {
         var filter = new OrderSearchCriteria().setOrderDate(new DateFilter().setFrom("2022-02-01").setTo("2022-02-02"));
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -194,7 +194,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Order_Date_Less_Then_Or_Equal_DESC() {
         var filter = new OrderSearchCriteria().setOrderDate(new DateFilter().setTo("2022-02-01"));
         LocalDateTime endDate = LocalDateTime.of(2022, 2, 2, 0, 0, 1);
@@ -208,7 +208,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Order_Date_Greater_Then_Or_Equal_DESC() {
         var filter = new OrderSearchCriteria().setOrderDate(new DateFilter().setFrom("2022-02-01"));
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -221,7 +221,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Date_Of_Export_Between_DESC() {
         var filter =
             new OrderSearchCriteria().setDeliveryDate(new DateFilter().setFrom("2022-02-03").setTo("2022-02-04"));
@@ -237,7 +237,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Payment_Date_Between() {
         var filter =
             new OrderSearchCriteria().setPaymentDate(new DateFilter().setFrom("2022-02-02").setTo("2022-02-02"));
@@ -253,7 +253,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Receiving_Station_DESC() {
         var filter = new OrderSearchCriteria().setReceivingStation(new Long[] {1L});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -266,7 +266,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Responsible_Logic_Man_ASC() {
         var filter = new OrderSearchCriteria().setResponsibleLogicManId(new Long[] {10L});
         var expectedValue = ModelUtils.getAllBOTViewsASC().stream()
@@ -279,7 +279,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Responsible_Caller_ASC() {
         var filter = new OrderSearchCriteria().setResponsibleCallerId(new Long[] {15L});
         var expectedValue = ModelUtils.getAllBOTViewsASC().stream()
@@ -292,7 +292,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Responsible_Driver_ASC() {
         var filter = new OrderSearchCriteria().setResponsibleDriverId(new Long[] {10L});
         var expectedValue = ModelUtils.getAllBOTViewsASC().stream()
@@ -305,7 +305,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Filter_By_Responsible_Navigator_DESC() {
         var filter = new OrderSearchCriteria().setResponsibleNavigatorId(new Long[] {10L});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -318,7 +318,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Search_by_phone_DESC() {
         var filter = new OrderSearchCriteria().setSearch(new String[] {"+380631144678"});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -331,7 +331,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Sort_By_OrderStatus_UA_Localization_ASC() {
         OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderStatus")
             .setSortDirection(Sort.Direction.ASC);
@@ -342,7 +342,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertTrue(isListCorrectlySorted);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Sort_By_OrderStatus_UA_Localization_DESC() {
         OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderStatus")
             .setSortDirection(Sort.Direction.DESC);
@@ -353,7 +353,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertTrue(isListCorrectlySorted);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Search_by_Client_Name_DESC() {
         var filter = new OrderSearchCriteria().setSearch(new String[] {"Anna Maria"});
         var expectedValue = ModelUtils.getAllBOTViewsDESC().stream()
@@ -366,7 +366,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Combination_Filter_DESC() {
         var filter = new OrderSearchCriteria()
             .setOrderPaymentStatus(new OrderPaymentStatus[] {OrderPaymentStatus.PAID})
@@ -382,7 +382,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Combination_Filter_ASC() {
         var filter = new OrderSearchCriteria()
             .setOrderPaymentStatus(new OrderPaymentStatus[] {OrderPaymentStatus.PAID})
@@ -398,7 +398,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_PageImpl_ASC() {
         var expectedValue = ModelUtils.getPageableAllBOTViews_ASC();
         var actualValue =
@@ -407,7 +407,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_PageImpl_Total_Elements_ASC() {
         var expectedValue = ModelUtils.getPageableAllBOTViews_Two_Element_On_Page_ASC().getTotalElements();
         var actualValue =
@@ -416,7 +416,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_PageImpl_Size_ASC() {
         var expectedValue = ModelUtils.getPageableAllBOTViews_Two_Element_On_Page_ASC().getSize();
         List<Long> tariffsInfoIds = new ArrayList<>();
@@ -428,7 +428,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_PageImpl_Number_ASC() {
         var expectedValue = ModelUtils.getPageableAllBOTViews_Two_Element_On_Page_ASC().getNumber();
         var actualValue =
@@ -437,7 +437,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_PageImpl_Number_Of_Elements_ASC() {
         var expectedValue = ModelUtils.getPageableAllBOTViews_Two_Element_On_Page_ASC().getNumberOfElements();
         var actualValue =
@@ -446,7 +446,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Sort_By_OrderPaymentStatus_UA_Localization_ASC() {
         OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderPaymentStatus")
             .setSortDirection(Sort.Direction.ASC);
@@ -457,7 +457,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertTrue(isListCorrectlySorted);
     }
 
-    // @Test
+    @Test
     void get_All_Orders_Sort_By_OrderPaymentStatus_UA_Localization_DESC() {
         OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderPaymentStatus")
             .setSortDirection(Sort.Direction.DESC);

--- a/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
+++ b/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
@@ -446,7 +446,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    @Test
+    //@Test
     void get_All_Orders_Sort_By_OrderPaymentStatus_UA_Localization_ASC() {
         OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderPaymentStatus")
             .setSortDirection(Sort.Direction.ASC);
@@ -457,7 +457,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertTrue(isListCorrectlySorted);
     }
 
-    @Test
+    //@Test
     void get_All_Orders_Sort_By_OrderPaymentStatus_UA_Localization_DESC() {
         OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderPaymentStatus")
             .setSortDirection(Sort.Direction.DESC);

--- a/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
+++ b/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
@@ -446,7 +446,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertEquals(expectedValue, actualValue);
     }
 
-    //@Test
+    // @Test
     void get_All_Orders_Sort_By_OrderPaymentStatus_UA_Localization_ASC() {
         OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderPaymentStatus")
             .setSortDirection(Sort.Direction.ASC);
@@ -457,7 +457,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Assertions.assertTrue(isListCorrectlySorted);
     }
 
-    //@Test
+    // @Test
     void get_All_Orders_Sort_By_OrderPaymentStatus_UA_Localization_DESC() {
         OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderPaymentStatus")
             .setSortDirection(Sort.Direction.DESC);

--- a/dao/src/main/java/greencity/entity/order/Order.java
+++ b/dao/src/main/java/greencity/entity/order/Order.java
@@ -86,6 +86,9 @@ public class Order {
     @JoinColumn(name = "employee_id")
     private Employee blockedByEmployee;
 
+    @Column(name = "blocked_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime blockedAt;
+
     @ElementCollection
     @CollectionTable(name = "order_bag_mapping",
         joinColumns = {@JoinColumn(name = "order_id", referencedColumnName = "id")})

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -228,4 +228,5 @@
     <include file="/db/changelog/logs/2024-05-16-ch-add-column-template_id-to-UserNotification-Ryhal.xml"/>
     <include file="/db/changelog/logs/2024-05-20-ch-add-column-userCategory-to-NotificationTemplate-Ryhal.xml"/>
     <include file="/db/changelog/logs/2024-05-20-ch-set-values-isScheduleUpdateForbidden-true-to-NotificationTemplate-Ryhal.xml"/>
+    <include file="db/changelog/logs/ch-add-column-blocked-at-to-orders-table-Kizerov.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-add-column-blocked-at-to-orders-table-Kizerov.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-column-blocked-at-to-orders-table-Kizerov.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="ch-add-column-blocked-at-to-orders-table-Kizerov" author="Kizerov">
+        <addColumn tableName="orders">
+            <column name="blocked_at" type="timestamp">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/service-api/src/main/java/greencity/dto/order/GeneralOrderInfo.java
+++ b/service-api/src/main/java/greencity/dto/order/GeneralOrderInfo.java
@@ -31,4 +31,5 @@ public class GeneralOrderInfo {
     private String orderPaymentStatusName;
     private String orderPaymentStatusNameEng;
     private String adminComment;
+    private Boolean blocked;
 }

--- a/service-api/src/main/java/greencity/service/ubs/OrderLockService.java
+++ b/service-api/src/main/java/greencity/service/ubs/OrderLockService.java
@@ -1,0 +1,28 @@
+package greencity.service.ubs;
+
+import greencity.entity.order.Order;
+import greencity.entity.user.employee.Employee;
+
+public interface OrderLockService {
+    /**
+     * Locks the order for editing by a specific employee. If the lock is not
+     * released within the specified duration, it will be automatically unlocked.
+     *
+     * @param order    the order to lock.
+     * @param employee the employee who locks the order.
+     */
+    void lockOrder(Order order, Employee employee);
+
+    /**
+     * Unlocks the order, allowing it to be edited again.
+     *
+     * @param order order to unlock.
+     */
+    void unlockOrder(Order order);
+
+    /**
+     * Periodically checks and unlocks orders that have been locked for longer than
+     * the specified duration.
+     */
+    void checkLockOrders();
+}

--- a/service/src/main/java/greencity/service/ubs/OrderLockServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/OrderLockServiceImpl.java
@@ -1,0 +1,63 @@
+package greencity.service.ubs;
+
+import greencity.entity.order.Order;
+import greencity.entity.user.employee.Employee;
+import greencity.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class OrderLockServiceImpl implements OrderLockService {
+    private final OrderRepository orderRepository;
+    @Value("${order.lock.duration.minutes}")
+    private int lockDurationMinutes;
+    private static final String REMOVE_LOCK_MESSAGE = "Remove lock from order with id: {}";
+    private static final String SET_LOCK_MESSAGE = "Set lock to order with id: {}";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public synchronized void lockOrder(Order order, Employee employee) {
+        if (!order.isBlocked()) {
+            order.setBlocked(true);
+            order.setBlockedByEmployee(employee);
+            order.setBlockedAt(LocalDateTime.now());
+            orderRepository.save(order);
+            log.info(SET_LOCK_MESSAGE, order.getId());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional
+    public synchronized void unlockOrder(Order order) {
+        order.setBlocked(false);
+        order.setBlockedByEmployee(null);
+        order.setBlockedAt(null);
+        orderRepository.save(order);
+        log.info(REMOVE_LOCK_MESSAGE, order.getId());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Scheduled(fixedRate = 60000)
+    @Transactional
+    public void checkLockOrders() {
+        LocalDateTime expirationTime = LocalDateTime.now().minusMinutes(lockDurationMinutes);
+        orderRepository.unlockExpiredOrders(expirationTime);
+        log.info("Unlock orders");
+    }
+}

--- a/service/src/test/java/greencity/service/ubs/OrderLockServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/OrderLockServiceImplTest.java
@@ -1,0 +1,63 @@
+package greencity.service.ubs;
+
+import greencity.entity.order.Order;
+import greencity.entity.user.employee.Employee;
+import greencity.repository.OrderRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class OrderLockServiceImplTest {
+    @Mock
+    private OrderRepository orderRepository;
+
+    @InjectMocks
+    private OrderLockServiceImpl orderLockService;
+
+    @Test
+    void lockOrderTest() {
+        Order order = new Order();
+        order.setId(1L);
+        Employee employee = new Employee();
+        employee.setId(1L);
+
+        LocalDateTime currentTime = LocalDateTime.now();
+
+        orderLockService.lockOrder(order, employee);
+
+        verify(orderRepository, times(1)).save(order);
+
+        assertTrue(order.isBlocked());
+        assertEquals(employee, order.getBlockedByEmployee());
+        assertTrue(order.getBlockedAt().isAfter(currentTime.minusSeconds(1)));
+    }
+
+    @Test
+    void unlockOrderTest() {
+        Order order = Order.builder()
+            .id(1L)
+            .blocked(true)
+            .blockedByEmployee(Employee.builder()
+                .id(1L)
+                .build())
+            .blockedAt(LocalDateTime.now())
+            .build();
+
+        orderLockService.unlockOrder(order);
+
+        verify(orderRepository, times(1)).save(order);
+
+        assertFalse(order.isBlocked());
+        assertNull(order.getBlockedByEmployee());
+        assertNull(order.getBlockedAt());
+    }
+}

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -274,6 +274,8 @@ class UBSManagementServiceImplTest {
     private OrderBagService orderBagService;
     @Mock
     private OrderBagRepository orderBagRepository;
+    @Mock
+    private OrderLockService orderLockService;
 
     @Test
     void getAllCertificates() {


### PR DESCRIPTION
# GreenCityUBS PR

## Summary Of Changes :fire:
- add a service to block and unblock orders. Also, add a scheduled method to automatically unblock orders at regular intervals.
- fix the logic to block and unblock orders.
- add tests.

# Issue Link

[#5557
](https://github.com/ita-social-projects/GreenCity/issues/5557)

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers