### PR TITLE
Adds checks to block orders

### DIFF
--- a/core/src/main/java/greencity/controller/AdminUbsController.java
+++ b/core/src/main/java/greencity/controller/AdminUbsController.java
@@ -141,6 +141,7 @@ public class AdminUbsController {
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })
+    @PreAuthorize("@preAuthorizer.hasAuthority('EDIT_ORDER', authentication)")
     @PutMapping("/changingOrder")
     public ResponseEntity<List<Long>> saveNewValueFromOrdersTable(
         @Parameter(hidden = true) HttpServletRequest request,

--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -612,7 +612,8 @@ public class ManagementOrderController {
      */
     @Operation(summary = "Controller to check current employee for order")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
+            content = @Content(schema = @Schema(implementation = OrderStatusPageDto.class))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })

--- a/dao/src/main/java/greencity/repository/PositionRepository.java
+++ b/dao/src/main/java/greencity/repository/PositionRepository.java
@@ -2,7 +2,10 @@ package greencity.repository;
 
 import greencity.entity.user.employee.Position;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import java.util.List;
 
 @Repository
 public interface PositionRepository extends JpaRepository<Position, Long> {
@@ -22,4 +25,13 @@ public interface PositionRepository extends JpaRepository<Position, Long> {
      * @return {@link Boolean}
      */
     boolean existsPositionByIdAndName(Long id, String name);
+
+    /**
+     * Finds all position IDs that match the given list of English names.
+     *
+     * @param names the list of English names to search for
+     * @return a list of position IDs that have names matching the given names
+     */
+    @Query("SELECT p.id FROM Position p WHERE p.nameEn IN :names")
+    List<Long> findAllIdsFromNames(@Param("names") List<String> names);
 }

--- a/service-api/src/main/java/greencity/dto/order/GeneralOrderInfo.java
+++ b/service-api/src/main/java/greencity/dto/order/GeneralOrderInfo.java
@@ -31,5 +31,5 @@ public class GeneralOrderInfo {
     private String orderPaymentStatusName;
     private String orderPaymentStatusNameEng;
     private String adminComment;
-    private Boolean blocked;
+    private boolean blocked;
 }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -332,7 +332,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
         Employee employee = employeeRepository.findByEmail(email)
             .orElseThrow(() -> new NotFoundException(EMPLOYEE_NOT_FOUND));
 
-        if (!order.isBlocked()) {
+        if (!order.isBlocked() && checkEmployeePositionsIsAdmin(employee.getEmployeePosition())) {
             orderLockService.lockOrder(order, employee);
         }
 
@@ -379,6 +379,12 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             .courierInfo(modelMapper.map(order.getTariffsInfo(), CourierInfoDto.class))
             .writeOffStationSum(convertCoinsIntoBills(order.getWriteOffStationSum()))
             .build();
+    }
+
+    private boolean checkEmployeePositionsIsAdmin(Set<Position> positions) {
+        List<Long> adminsIds = List.of(6L, 7L);
+        return positions.stream()
+            .anyMatch(p -> adminsIds.contains(p.getId()));
     }
 
     private Double setTotalPrice(CounterOrderDetailsDto dto) {

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -172,7 +172,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     private final RefundRepository refundRepository;
     private final OrderLockService orderLockService;
     private static final String DEFAULT_IMAGE_PATH = AppConstant.DEFAULT_IMAGE;
-
+    private static final List<String> ADMIN_POSITION_NAMES = List.of("Admin", "Super Admin");
     private final Set<OrderStatus> orderStatusesBeforeShipment =
         EnumSet.of(OrderStatus.FORMED, OrderStatus.CONFIRMED, OrderStatus.ADJUSTMENT);
     private final Set<OrderStatus> orderStatusesAfterConfirmation =
@@ -381,12 +381,19 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             .build();
     }
 
+    /**
+     * Checks if any position in the given set has administrative permissions.
+     * Specifically, it checks if any position's ID matches the IDs associated with
+     * the "Admin" or "Super Admin" roles.
+     *
+     * @param positions the set of positions to check
+     * @return true if any position in the set is an admin position, false otherwise
+     */
     private boolean checkEmployeePositionsIsAdmin(Set<Position> positions) {
-        Long adminId = 7L;
-        Long superAdminId = 6L;
-        List<Long> adminsIds = List.of(adminId, superAdminId);
+        List<Long> idsWithValidPermissionsToEditOrder = positionRepository
+            .findAllIdsFromNames(ADMIN_POSITION_NAMES);
         return positions.stream()
-            .anyMatch(p -> adminsIds.contains(p.getId()));
+            .anyMatch(p -> idsWithValidPermissionsToEditOrder.contains(p.getId()));
     }
 
     private Double setTotalPrice(CounterOrderDetailsDto dto) {

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -382,7 +382,9 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     }
 
     private boolean checkEmployeePositionsIsAdmin(Set<Position> positions) {
-        List<Long> adminsIds = List.of(6L, 7L);
+        Long adminId = 7L;
+        Long superAdminId = 6L;
+        List<Long> adminsIds = List.of(adminId, superAdminId);
         return positions.stream()
             .anyMatch(p -> adminsIds.contains(p.getId()));
     }


### PR DESCRIPTION
# GreenCityUBS PR

Adds a check to save edited orders: if an employee lacks the necessary authorities, they cannot edit the order.
Adds a check when an employee opens an order: the method verifies the authorities and sets the order to a blocked status if the employee has valid authorities.

## Summary Of Changes :fire:

- adds 2 checks to block orders.

# Issue Link

[#5557
](https://github.com/ita-social-projects/GreenCity/issues/5557)

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers