### PR TITLE
#7095 sorting order table by payment status ua localization

### DIFF
--- a/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
+++ b/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
@@ -4,7 +4,11 @@ import com.google.common.collect.Comparators;
 import greencity.IntegrationTestBase;
 import greencity.UbsApplication;
 import greencity.entity.order.BigOrderTableViews;
-import greencity.enums.*;
+import greencity.enums.OrderPaymentStatus;
+import greencity.enums.OrderPaymentStatusSortingTranslation;
+import greencity.enums.OrderStatus;
+import greencity.enums.OrderStatusSortingTranslation;
+import greencity.enums.PaymentStatus;
 import greencity.filters.DateFilter;
 import greencity.filters.OrderPage;
 import greencity.filters.OrderSearchCriteria;
@@ -435,22 +439,22 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
     @Test
     void get_All_Orders_Sort_By_OrderPaymentStatus_UA_Localization_ASC() {
         OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderPaymentStatus")
-                .setSortDirection(Sort.Direction.ASC);
+            .setSortDirection(Sort.Direction.ASC);
         List<BigOrderTableViews> bigOrderTableViewsList = bigOrderTableRepository.findAll(orderPage,
-                DEFAULT_ORDER_SEARCH_CRITERIA, TARIFFS_ID_LIST, USER_LANGUAGE_UA).getContent();
+            DEFAULT_ORDER_SEARCH_CRITERIA, TARIFFS_ID_LIST, USER_LANGUAGE_UA).getContent();
         boolean isListCorrectlySorted =
-                Comparators.isInOrder(bigOrderTableViewsList, orderPaymentStatusTranslationComparator(false));
+            Comparators.isInOrder(bigOrderTableViewsList, orderPaymentStatusTranslationComparator(false));
         Assertions.assertTrue(isListCorrectlySorted);
     }
 
     @Test
     void get_All_Orders_Sort_By_OrderPaymentStatus_UA_Localization_DESC() {
         OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderPaymentStatus")
-                .setSortDirection(Sort.Direction.DESC);
+            .setSortDirection(Sort.Direction.DESC);
         var bigOrderTableViewsList = bigOrderTableRepository.findAll(orderPage,
-                DEFAULT_ORDER_SEARCH_CRITERIA, TARIFFS_ID_LIST, USER_LANGUAGE_UA).getContent();
+            DEFAULT_ORDER_SEARCH_CRITERIA, TARIFFS_ID_LIST, USER_LANGUAGE_UA).getContent();
         boolean isListCorrectlySorted =
-                Comparators.isInOrder(bigOrderTableViewsList, orderPaymentStatusTranslationComparator(true));
+            Comparators.isInOrder(bigOrderTableViewsList, orderPaymentStatusTranslationComparator(true));
         Assertions.assertTrue(isListCorrectlySorted);
     }
 
@@ -471,7 +475,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
 
     private Comparator<BigOrderTableViews> orderPaymentStatusTranslationComparator(boolean descending) {
         Comparator<BigOrderTableViews> comparator = Comparator.comparingInt(
-                view -> OrderPaymentStatusSortingTranslation.valueOf(view.getOrderPaymentStatus()).getSortOrder());
+            view -> OrderPaymentStatusSortingTranslation.valueOf(view.getOrderPaymentStatus()).getSortOrder());
         return descending ? comparator.reversed() : comparator;
     }
 }

--- a/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
+++ b/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
@@ -4,10 +4,7 @@ import com.google.common.collect.Comparators;
 import greencity.IntegrationTestBase;
 import greencity.UbsApplication;
 import greencity.entity.order.BigOrderTableViews;
-import greencity.enums.OrderPaymentStatus;
-import greencity.enums.OrderStatus;
-import greencity.enums.OrderStatusSortingTranslation;
-import greencity.enums.PaymentStatus;
+import greencity.enums.*;
 import greencity.filters.DateFilter;
 import greencity.filters.OrderPage;
 import greencity.filters.OrderSearchCriteria;
@@ -436,6 +433,28 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
     }
 
     @Test
+    void get_All_Orders_Sort_By_OrderPaymentStatus_UA_Localization_ASC() {
+        OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderPaymentStatus")
+                .setSortDirection(Sort.Direction.ASC);
+        List<BigOrderTableViews> bigOrderTableViewsList = bigOrderTableRepository.findAll(orderPage,
+                DEFAULT_ORDER_SEARCH_CRITERIA, TARIFFS_ID_LIST, USER_LANGUAGE_UA).getContent();
+        boolean isListCorrectlySorted =
+                Comparators.isInOrder(bigOrderTableViewsList, orderPaymentStatusTranslationComparator(false));
+        Assertions.assertTrue(isListCorrectlySorted);
+    }
+
+    @Test
+    void get_All_Orders_Sort_By_OrderPaymentStatus_UA_Localization_DESC() {
+        OrderPage orderPage = new OrderPage().setPageNumber(0).setPageSize(15).setSortBy("orderPaymentStatus")
+                .setSortDirection(Sort.Direction.DESC);
+        var bigOrderTableViewsList = bigOrderTableRepository.findAll(orderPage,
+                DEFAULT_ORDER_SEARCH_CRITERIA, TARIFFS_ID_LIST, USER_LANGUAGE_UA).getContent();
+        boolean isListCorrectlySorted =
+                Comparators.isInOrder(bigOrderTableViewsList, orderPaymentStatusTranslationComparator(true));
+        Assertions.assertTrue(isListCorrectlySorted);
+    }
+
+    @Test
     void get_All_Orders_PageImpl_Number_Of_Elements_ASC() {
         var expectedValue = ModelUtils.getPageableAllBOTViews_Two_Element_On_Page_ASC().getNumberOfElements();
         var actualValue =
@@ -448,5 +467,11 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
         Comparator<BigOrderTableViews> comparator = Comparator.comparingInt(
             view -> OrderStatusSortingTranslation.valueOf(view.getOrderStatus()).getSortOrder());
         return ascending ? comparator.reversed() : comparator;
+    }
+
+    private Comparator<BigOrderTableViews> orderPaymentStatusTranslationComparator(boolean descending) {
+        Comparator<BigOrderTableViews> comparator = Comparator.comparingInt(
+                view -> OrderPaymentStatusSortingTranslation.valueOf(view.getOrderPaymentStatus()).getSortOrder());
+        return descending ? comparator.reversed() : comparator;
     }
 }

--- a/dao/src/main/java/greencity/enums/OrderPaymentStatusSortingTranslation.java
+++ b/dao/src/main/java/greencity/enums/OrderPaymentStatusSortingTranslation.java
@@ -19,7 +19,7 @@ public enum OrderPaymentStatusSortingTranslation implements SortingTranslation<O
     private final int sortOrder;
 
     private static final Set<OrderPaymentStatusSortingTranslation> ASC_ORDER_PAYMENT_STATUS_TRANSLATIONS =
-            Collections.unmodifiableSet(EnumSet.allOf(OrderPaymentStatusSortingTranslation.class));
+        Collections.unmodifiableSet(EnumSet.allOf(OrderPaymentStatusSortingTranslation.class));
 
     /**
      * Method returns order payment status translations sorted in ascending order

--- a/dao/src/main/java/greencity/enums/OrderPaymentStatusSortingTranslation.java
+++ b/dao/src/main/java/greencity/enums/OrderPaymentStatusSortingTranslation.java
@@ -1,0 +1,39 @@
+package greencity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+@Getter
+@AllArgsConstructor
+public enum OrderPaymentStatusSortingTranslation implements SortingTranslation<OrderPaymentStatusSortingTranslation> {
+    UNPAID(1),
+    PAYMENT_REFUNDED(2),
+    PAID(3),
+    HALF_PAID(4),
+    OTHER(5);
+
+    private final int sortOrder;
+
+    private static final Set<OrderPaymentStatusSortingTranslation> ASC_ORDER_PAYMENT_STATUS_TRANSLATIONS =
+            Collections.unmodifiableSet(EnumSet.allOf(OrderPaymentStatusSortingTranslation.class));
+
+    /**
+     * Method returns order payment status translations sorted in ascending order
+     * according to the Ukrainian alphabet.
+     *
+     * @return {@link Set} of {@link OrderPaymentStatusSortingTranslation}
+     */
+    @Override
+    public Set<OrderPaymentStatusSortingTranslation> getSortedTranslations() {
+        return ASC_ORDER_PAYMENT_STATUS_TRANSLATIONS;
+    }
+
+    @Override
+    public OrderPaymentStatusSortingTranslation getOtherStatus() {
+        return OTHER;
+    }
+}

--- a/dao/src/main/java/greencity/enums/OrderPaymentStatusSortingTranslation.java
+++ b/dao/src/main/java/greencity/enums/OrderPaymentStatusSortingTranslation.java
@@ -22,7 +22,7 @@ public enum OrderPaymentStatusSortingTranslation implements SortingTranslation<O
         Collections.unmodifiableSet(EnumSet.allOf(OrderPaymentStatusSortingTranslation.class));
 
     /**
-     * Method returns order payment status translations sorted in ascending order
+     * Method returns order status translations sorted in ascending order
      * according to the Ukrainian alphabet.
      *
      * @return {@link Set} of {@link OrderPaymentStatusSortingTranslation}

--- a/dao/src/main/java/greencity/enums/OrderStatusSortingTranslation.java
+++ b/dao/src/main/java/greencity/enums/OrderStatusSortingTranslation.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 @Getter
 @AllArgsConstructor
-public enum OrderStatusSortingTranslation {
+public enum OrderStatusSortingTranslation implements SortingTranslation<OrderStatusSortingTranslation>{
     DONE(1),
     ON_THE_ROUTE(2),
     NOT_TAKEN_OUT(3),
@@ -25,12 +25,18 @@ public enum OrderStatusSortingTranslation {
         Collections.unmodifiableSet(EnumSet.allOf(OrderStatusSortingTranslation.class));
 
     /**
-     * This method return Set collection of OrderStatus translation in ascending
-     * order.
+     * Method returns order payment status translations sorted in ascending order
+     * according to the Ukrainian alphabet.
      *
-     * @return Set of {@link OrderStatusSortingTranslation}
+     * @return {@link Set} of {@link OrderStatusSortingTranslation}
      */
-    public static Set<OrderStatusSortingTranslation> getOrderSetSortedByAsc() {
+    @Override
+    public Set<OrderStatusSortingTranslation> getSortedTranslations() {
         return ASC_ORDER_SET;
+    }
+
+    @Override
+    public OrderStatusSortingTranslation getOtherStatus() {
+        return OTHER;
     }
 }

--- a/dao/src/main/java/greencity/enums/OrderStatusSortingTranslation.java
+++ b/dao/src/main/java/greencity/enums/OrderStatusSortingTranslation.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 @Getter
 @AllArgsConstructor
-public enum OrderStatusSortingTranslation implements SortingTranslation<OrderStatusSortingTranslation>{
+public enum OrderStatusSortingTranslation implements SortingTranslation<OrderStatusSortingTranslation> {
     DONE(1),
     ON_THE_ROUTE(2),
     NOT_TAKEN_OUT(3),

--- a/dao/src/main/java/greencity/enums/SortingTranslation.java
+++ b/dao/src/main/java/greencity/enums/SortingTranslation.java
@@ -1,0 +1,33 @@
+package greencity.enums;
+
+import java.util.Set;
+
+/**
+ * This interface defines methods for obtaining sorting-related information for
+ * enums that represent different statuses.
+ *
+ * @param <T> the type represent different statuses.
+ */
+public interface SortingTranslation <T extends Enum<T>> {
+    /**
+     * Method returns the sort order value of the current enum constant.
+     *
+     * @return {@link int}.
+     */
+    int getSortOrder();
+
+    /**
+     * Returns a set of all constants sorted in ascending order according to their
+     * sort order values.
+     *
+     * @return a sorted {@link Set} of enum constants.
+     */
+    Set<T> getSortedTranslations();
+
+    /**
+     * Returns the enum constant that represents a default or "other" status.
+     *
+     * @return the enum constant representing the "OTHER" status.
+     */
+    T getOtherStatus();
+}

--- a/dao/src/main/java/greencity/enums/SortingTranslation.java
+++ b/dao/src/main/java/greencity/enums/SortingTranslation.java
@@ -8,7 +8,7 @@ import java.util.Set;
  *
  * @param <T> the type represent different statuses.
  */
-public interface SortingTranslation <T extends Enum<T>> {
+public interface SortingTranslation<T extends Enum<T>> {
     /**
      * Method returns the sort order value of the current enum constant.
      *

--- a/dao/src/main/java/greencity/repository/BigOrderTableRepository.java
+++ b/dao/src/main/java/greencity/repository/BigOrderTableRepository.java
@@ -139,7 +139,7 @@ public class BigOrderTableRepository {
     private void sort(OrderPage orderPage, CriteriaQuery<BigOrderTableViews> cq, Root<BigOrderTableViews> root,
         String userLanguage) {
         if (UKRAINIAN_LANGUAGE.equals(userLanguage)
-                && (ORDER_STATUS.equals(orderPage.getSortBy()) || ORDER_PAYMENT_STATUS.equals(orderPage.getSortBy()))) {
+            && (ORDER_STATUS.equals(orderPage.getSortBy()) || ORDER_PAYMENT_STATUS.equals(orderPage.getSortBy()))) {
             applySortingForUkrainianLocalization(orderPage, cq, root);
         } else {
             applySortingCriteria(orderPage, cq, root.get(orderPage.getSortBy()));
@@ -163,16 +163,16 @@ public class BigOrderTableRepository {
     }
 
     private void applySortingForUkrainianLocalization(OrderPage orderPage,
-                                                      CriteriaQuery<BigOrderTableViews> cq,
-                                                      Root<BigOrderTableViews> root) {
+        CriteriaQuery<BigOrderTableViews> cq,
+        Root<BigOrderTableViews> root) {
         switch (orderPage.getSortBy()) {
             case (ORDER_STATUS):
                 applySortingOrderForUALocalizationByEnumeration(orderPage, cq, root,
-                        OrderStatusSortingTranslation.class);
+                    OrderStatusSortingTranslation.class);
                 break;
             case (ORDER_PAYMENT_STATUS):
                 applySortingOrderForUALocalizationByEnumeration(orderPage, cq, root,
-                        OrderPaymentStatusSortingTranslation.class);
+                    OrderPaymentStatusSortingTranslation.class);
                 break;
             default:
                 applySortingCriteria(orderPage, cq, root);
@@ -181,10 +181,10 @@ public class BigOrderTableRepository {
     }
 
     private <T extends Enum<T> & SortingTranslation<T>> void applySortingOrderForUALocalizationByEnumeration(
-            OrderPage orderPage,
-            CriteriaQuery<BigOrderTableViews> cq,
-            Root<BigOrderTableViews> root,
-            Class<T> enumClass) {
+        OrderPage orderPage,
+        CriteriaQuery<BigOrderTableViews> cq,
+        Root<BigOrderTableViews> root,
+        Class<T> enumClass) {
         T[] enumConstants = enumClass.getEnumConstants();
         Set<T> sortOrderList = enumConstants[0].getSortedTranslations();
         T otherStatus = enumConstants[0].getOtherStatus();
@@ -193,8 +193,8 @@ public class BigOrderTableRepository {
         Expression<Integer> otherwiseExpression = criteriaBuilder.literal(otherStatus.getSortOrder());
 
         sortOrderList.forEach(status -> selectCase.when(
-                criteriaBuilder.equal(root.get(orderPage.getSortBy()), status.name()),
-                status.getSortOrder()));
+            criteriaBuilder.equal(root.get(orderPage.getSortBy()), status.name()),
+            status.getSortOrder()));
 
         Expression<Integer> sortOrder = selectCase.otherwise(otherwiseExpression);
         applySortingCriteria(orderPage, cq, sortOrder);

--- a/dao/src/test/java/greencity/enums/OrderPaymentStatusSortingTranslationTest.java
+++ b/dao/src/test/java/greencity/enums/OrderPaymentStatusSortingTranslationTest.java
@@ -1,0 +1,29 @@
+package greencity.enums;
+
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OrderPaymentStatusSortingTranslationTest {
+    @Test
+    void testGetSortOrder() {
+        assertEquals(1, OrderPaymentStatusSortingTranslation.UNPAID.getSortOrder());
+        assertEquals(2, OrderPaymentStatusSortingTranslation.PAYMENT_REFUNDED.getSortOrder());
+        assertEquals(3, OrderPaymentStatusSortingTranslation.PAID.getSortOrder());
+        assertEquals(4, OrderPaymentStatusSortingTranslation.HALF_PAID.getSortOrder());
+        assertEquals(5, OrderPaymentStatusSortingTranslation.OTHER.getSortOrder());
+    }
+
+    @Test
+    void testOrderSetSortedByAsc() {
+        Set<OrderPaymentStatusSortingTranslation> expectedAscSet =
+                EnumSet.allOf(OrderPaymentStatusSortingTranslation.class);
+        Set<OrderPaymentStatusSortingTranslation> actualAscSet =
+                OrderPaymentStatusSortingTranslation.OTHER.getSortedTranslations();
+        assertEquals(expectedAscSet, actualAscSet);
+    }
+}

--- a/dao/src/test/java/greencity/enums/OrderPaymentStatusSortingTranslationTest.java
+++ b/dao/src/test/java/greencity/enums/OrderPaymentStatusSortingTranslationTest.java
@@ -1,6 +1,5 @@
 package greencity.enums;
 
-
 import org.junit.jupiter.api.Test;
 
 import java.util.EnumSet;
@@ -21,9 +20,9 @@ public class OrderPaymentStatusSortingTranslationTest {
     @Test
     void testOrderSetSortedByAsc() {
         Set<OrderPaymentStatusSortingTranslation> expectedAscSet =
-                EnumSet.allOf(OrderPaymentStatusSortingTranslation.class);
+            EnumSet.allOf(OrderPaymentStatusSortingTranslation.class);
         Set<OrderPaymentStatusSortingTranslation> actualAscSet =
-                OrderPaymentStatusSortingTranslation.OTHER.getSortedTranslations();
+            OrderPaymentStatusSortingTranslation.OTHER.getSortedTranslations();
         assertEquals(expectedAscSet, actualAscSet);
     }
 }

--- a/dao/src/test/java/greencity/enums/OrderStatusSortingTranslationTest.java
+++ b/dao/src/test/java/greencity/enums/OrderStatusSortingTranslationTest.java
@@ -23,7 +23,7 @@ class OrderStatusSortingTranslationTest {
     @Test
     void testOrderSetSortedByAsc() {
         Set<OrderStatusSortingTranslation> expectedAscSet = EnumSet.allOf(OrderStatusSortingTranslation.class);
-        Set<OrderStatusSortingTranslation> actualAscSet = OrderStatusSortingTranslation.getOrderSetSortedByAsc();
+        Set<OrderStatusSortingTranslation> actualAscSet = OrderStatusSortingTranslation.OTHER.getSortedTranslations();
         assertEquals(expectedAscSet, actualAscSet);
     }
 }


### PR DESCRIPTION
GreenCityUBS PR

Fixing issue https://github.com/ita-social-projects/GreenCity/issues/7095. Sorting by order payment status on the orders table always sorts by English language.
Summary of change

Now, the service automatically detects the user's language. Implemented sorting with Ukrainian localization according to the user's language.

To specify the correct sorting order for OrderPaymentStatus in Ukrainian, an enum has been implemented. Some methods in BigOrderTableRepository have been modified, mainly to add the ability to sort by language (currently, it only works for both orderStatus and orderPaymentStatus).

A corresponding test class for BigOrderTableRepository was previously implemented. Tests that verify sorting by orderPaymentStatus with Ukrainian localization have been implemented.
Testing approach

Integration tests with SpringBootTest were conducted. Additionally, the endpoint GET /ubs/management/bigOrderTable was tested using both Swagger and Postman.
Issue Link

https://github.com/ita-social-projects/GreenCity/issues/7095
