### PR TITLE
Modify access control for fetching all notification templates

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementNotificationController.java
+++ b/core/src/main/java/greencity/controller/ManagementNotificationController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
 
@@ -38,6 +39,7 @@ public class ManagementNotificationController {
     })
     @GetMapping("/get-all-templates")
     @ApiPageable
+    @PreAuthorize("@preAuthorizer.hasAuthority('SEE_MESSAGES_PAGE', authentication)")
     public ResponseEntity<PageableDto<NotificationTemplateDto>> getAll(@ApiIgnore Pageable pageable) {
         return ResponseEntity.status(HttpStatus.OK)
             .body(notificationTemplateService.findAll(pageable));


### PR DESCRIPTION
# GreenCityUBS PR

This pull request modifies the access control for the endpoint that fetches all notification templates.

## Summary Of Changes :fire:

- Updated `@PreAuthorize` annotation to use `@preAuthorizer.hasAuthority('SEE_MESSAGES_PAGE', authentication)` for the `GET /get-all-templates` endpoint.

# Issue Link

[#6349
](https://github.com/ita-social-projects/GreenCity/issues/6349)

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `prod` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers