### PR TITLE
Fix ubs admin update order details by adding all bags creating new order

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -1368,6 +1368,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         long totalSumToPayInCoins = 0L;
         long limitedSumToPayInCoins = 0L;
         int limitedBags = 0;
+        final List<Integer> bagIds = bags.stream().map(BagDto::getId).collect(toList());
         for (BagDto temp : bags) {
             Bag bag = findActiveBagById(temp.getId());
             if (Boolean.TRUE.equals(bag.getLimitIncluded())) {
@@ -1383,6 +1384,10 @@ public class UBSClientServiceImpl implements UBSClientService {
         checkSumIfCourierLimitBySumOfOrder(tariffsInfo, limitedSumToPayInCoins);
         checkAmountOfBagsIfCourierLimitByAmountOfBag(tariffsInfo, limitedBags);
         totalSumToPayInCoins += limitedSumToPayInCoins;
+        List<OrderBag> notOrderedBags = tariffsInfo.getBags().stream()
+            .filter(orderBag -> orderBag.getStatus() == BagStatus.ACTIVE && !bagIds.contains(orderBag.getId()))
+            .map(this::createOrderBag).collect(toList());
+        orderBagList.addAll(notOrderedBags.stream().peek(orderBag -> orderBag.setAmount(0)).collect(toList()));
         return totalSumToPayInCoins;
     }
 

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -1387,7 +1387,10 @@ public class UBSClientServiceImpl implements UBSClientService {
         List<OrderBag> notOrderedBags = tariffsInfo.getBags().stream()
             .filter(orderBag -> orderBag.getStatus() == BagStatus.ACTIVE && !bagIds.contains(orderBag.getId()))
             .map(this::createOrderBag).collect(toList());
-        orderBagList.addAll(notOrderedBags.stream().peek(orderBag -> orderBag.setAmount(0)).collect(toList()));
+        orderBagList.addAll(notOrderedBags.stream().map(orderBag -> {
+            orderBag.setAmount(0);
+            return orderBag;
+        }).collect(Collectors.toList()));
         return totalSumToPayInCoins;
     }
 


### PR DESCRIPTION
# GreenCityUBS PR
The issue with endpoint [PATCH]/ubs/management/update-order-page-admin-info/{id} occurs as not all the bags were saved in DB when new order created.

Solution is to get back the code where all bags added even if they are not ordered. Then the procedure of update will work correct.

## Added
-code that adds notOrderedBags to DB in method formBagsToBeSavedAndCalculateOrderSum() in UBSClientServiceImpl