### PR TITLE
Fix notification templates syntax errors

### DIFF
--- a/dao/src/main/java/greencity/enums/NotificationTrigger.java
+++ b/dao/src/main/java/greencity/enums/NotificationTrigger.java
@@ -42,15 +42,15 @@ public enum NotificationTrigger {
            "Кастомна",
            "Custom"),
     ORDER_STATUS_CHANGED_FROM_FORMED_TO_BROUGHT_BY_HIMSELF(
-                                                           "Статус замовлення змінений"
+                                                           "Статус замовлення змінений "
                                                                + "з «Сформовано» на «Привезе сам»",
-                                                           "Order status changed"
+                                                           "Order status changed "
                                                                + "from «Formed» to «Brought by himself»"),
     HALF_PAID_ORDER_STATUS_BROUGHT_BY_HIMSELF(
                                               "Статус не повністю оплаченого замовлення змінено на «Привезе сам»",
                                               "Status of half paid order changed to «Brought by himself»"),
     UNDERPAYMENT_WHEN_STATUS_DONE_OR_CANCELED(
-                                              "Статус не оплаченого"
+                                              "Статус не оплаченого "
                                                   + "замовлення змінено на «Виконано» або «Скасовано»",
                                               "Status of unpaid order changed to «Done» or «Canceled»"),
     CREATED_NEW_ORDER(

--- a/dao/src/main/java/greencity/enums/OrderPaymentStatusSortingTranslation.java
+++ b/dao/src/main/java/greencity/enums/OrderPaymentStatusSortingTranslation.java
@@ -22,8 +22,8 @@ public enum OrderPaymentStatusSortingTranslation implements SortingTranslation<O
         Collections.unmodifiableSet(EnumSet.allOf(OrderPaymentStatusSortingTranslation.class));
 
     /**
-     * Method returns order status translations sorted in ascending order
-     * according to the Ukrainian alphabet.
+     * Method returns order status translations sorted in ascending order according
+     * to the Ukrainian alphabet.
      *
      * @return {@link Set} of {@link OrderPaymentStatusSortingTranslation}
      */

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -228,5 +228,5 @@
     <include file="/db/changelog/logs/ch-remove-column-hasChat-employees-Klopov.xml"/>
     <include file="/db/changelog/logs/ch-insert-data-into-notification_templates-Kizerov.xml"/>
     <include file="/db/changelog/logs/ch-insert-data-into-notification-platforms-Kizerov.xml"/>
+    <include file="/db/changelog/logs/ch-update-values-in-notification-templates-title-Sotnik.xml"/>
 </databaseChangeLog>
-

--- a/dao/src/main/resources/db/changelog/logs/ch-update-values-in-notification-templates-title-Sotnik.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-update-values-in-notification-templates-title-Sotnik.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet id="ch-update-values-in-notification-templates-title-Sotnik" author="Olena Sotnik">
+        <update tableName="notification_templates">
+            <column name="title" value="Оплатіть зміну у замовленні"/>
+            <where>id=4</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
# GreenCityUBS PR    prod
## Issue link:
[#7243](https://github.com/orgs/ita-social-projects/projects/44/views/1?pane=issue&itemId=69864483)[Admin cabinet_Notifications list] The text has spelling issues.

## Summary Of Changes :fire:
-Updated title in notification_template table for id=4;
-Added ch-update-values-in-notification-templates-title-Sotnik.xml
-Updated db.changelog-master.xml file
-Updated file NotificationTrigger to fix no spaces problem;

-one more file updated due to formatter used

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers