### PR TITLE
Fix regex to create address

### DIFF
--- a/dao/src/main/java/greencity/entity/user/ubs/Address.java
+++ b/dao/src/main/java/greencity/entity/user/ubs/Address.java
@@ -30,7 +30,7 @@ public class Address {
     @ManyToOne
     private User user;
 
-    @Size(min = 1, max = 20, message = "Invalid region name")
+    @Size(min = 1, max = 30, message = "Invalid region name")
     @Column(columnDefinition = "varchar(30)", nullable = false)
     private String region;
 

--- a/service-api/src/main/java/greencity/dto/CreateAddressRequestDto.java
+++ b/service-api/src/main/java/greencity/dto/CreateAddressRequestDto.java
@@ -24,26 +24,26 @@ public class CreateAddressRequestDto {
     private static final String notEmptyValidationMessage = "Name must not be empty";
     private static final String houseNumberNotValid = "House number is invalid";
 
-    @Pattern(regexp = "[-A-Za-zА-Яа-яЁёЇїІіЄєҐґ0-9.,ʼ'`ʹ—/\"\\s]*", message = validationMessage)
+    @Pattern(regexp = "[-A-Za-zА-Яа-яЁёЇїІіЄєҐґ0-9.,ʼ'`ʹ’—/\"\\s]*", message = validationMessage)
     private String searchAddress;
 
-    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ .,ʼ'`ʹ]*", message = validationMessage)
+    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ .,ʼ'`ʹ’]*", message = validationMessage)
     @NotEmpty(message = notEmptyValidationMessage)
     private String districtEn;
 
-    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ .,ʼ'`ʹ]*", message = validationMessage)
+    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ .,ʼ'`ʹ’]*", message = validationMessage)
     @NotEmpty(message = notEmptyValidationMessage)
     private String district;
 
-    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ ʼ'`ʹ]*", message = validationMessage)
+    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ ʼ'`ʹ’]*", message = validationMessage)
     @NotEmpty(message = notEmptyValidationMessage)
     private String regionEn;
 
-    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ ʼ'`ʹ]*", message = validationMessage)
+    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ ʼ'`ʹ’]*", message = validationMessage)
     @NotEmpty(message = notEmptyValidationMessage)
     private String region;
 
-    @Pattern(regexp = "[-A-Za-zА-Яа-яЁёЇїІіЄєҐґ0-9.,ʼ'`ʹ—/\"\\s]" + "{1,10}", message = houseNumberNotValid)
+    @Pattern(regexp = "[-A-Za-zА-Яа-яЁёЇїІіЄєҐґ0-9.,ʼ'`ʹ’—/\"\\s]" + "{1,10}", message = houseNumberNotValid)
     @NotBlank(message = notEmptyValidationMessage)
     private String houseNumber;
 
@@ -51,16 +51,16 @@ public class CreateAddressRequestDto {
 
     private String houseCorpus;
 
-    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ 0-9.,ʼ'`ʹ!?]*", message = validationMessage)
+    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ 0-9.,ʼ'`ʹ!?’]*", message = validationMessage)
     private String addressComment;
 
     private String placeId;
 
-    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ .,ʼ'`ʹ]*", message = validationMessage)
+    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ .,ʼ'`ʹ’]*", message = validationMessage)
     @NotEmpty(message = notEmptyValidationMessage)
     private String city;
 
-    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ .,ʼ'`ʹ]*", message = validationMessage)
+    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ .,ʼ'`ʹ’]*", message = validationMessage)
     @NotEmpty(message = notEmptyValidationMessage)
     private String cityEn;
 


### PR DESCRIPTION
# GreenCityUBS PR    dev
## Issue description: 
Error occurs during validation of field due to coma that was absent in regex for district.
Error ("Invalid region name") occurs when long region is to be saved. 

## Summary Of Changes :fire:
-Updated regex for all fields in /CreateAddressRequestDto to include new symbol.
-Updated Address entity region field validation, to have max 30 characters. 
# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells ar duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers

