### PR TITLE
Add Spring AccessDeniedException to CustomExceptionHandler

### DIFF
--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -153,11 +153,11 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
      * @return ResponseEntity which contain http status and body with message of
      *         exception.
      */
-    @ExceptionHandler(AccessDeniedException.class)
-    public final ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException ex,
-        WebRequest request) {
+    @ExceptionHandler({AccessDeniedException.class,
+            org.springframework.security.access.AccessDeniedException.class})
+    public final ResponseEntity<Object> handleAccessDeniedException(WebRequest request) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
-        log.trace(ex.getMessage(), ex);
+        log.trace(exceptionResponse.getMessage(), exceptionResponse.getTrace());
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse);
     }
 

--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -148,13 +148,12 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     /**
      * Method interceptor exception {@link AccessDeniedException}.
      *
-     * @param ex      Exception which should be intercepted.
      * @param request contain detail about occur exception.
      * @return ResponseEntity which contain http status and body with message of
      *         exception.
      */
     @ExceptionHandler({AccessDeniedException.class,
-            org.springframework.security.access.AccessDeniedException.class})
+        org.springframework.security.access.AccessDeniedException.class})
     public final ResponseEntity<Object> handleAccessDeniedException(WebRequest request) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
         log.trace(exceptionResponse.getMessage(), exceptionResponse.getTrace());

--- a/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
+++ b/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
@@ -59,9 +59,6 @@ class CustomExceptionHandlerTest {
     FoundException foundException;
 
     @Mock
-    AccessDeniedException accessDeniedException;
-
-    @Mock
     HttpStatus status;
 
     @InjectMocks
@@ -150,7 +147,7 @@ class CustomExceptionHandlerTest {
         ExceptionResponse exceptionResponse = new ExceptionResponse(objectMap);
         when(errorAttributes.getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class)))
             .thenReturn(objectMap);
-        assertEquals(customExceptionHandler.handleAccessDeniedException(accessDeniedException, webRequest),
+        assertEquals(customExceptionHandler.handleAccessDeniedException(webRequest),
             ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
         verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
     }


### PR DESCRIPTION
# GreenCityUBS PR
When user without required permission try to send request by endpoint  /admin/ubs-employee/save-employee the response has status code 401 Unauthorized instead of 403 Forbidden.

## Summary Of Changes :fire:
- Changed method handleAccessDeniedException in CustomChangeHandler to handle also org.springframework.security.access.AccessDeniedException
- Removed the 'AccessDeniedException ex'  parameter from the method signature
- Updated unit test

 # PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers