### PR TITLE
A bug that allows receiving a list of tariffs without the necessary authority has been fixed

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementEmployeeController.java
+++ b/core/src/main/java/greencity/controller/ManagementEmployeeController.java
@@ -293,7 +293,7 @@ public class ManagementEmployeeController {
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })
-    @PreAuthorize("@preAuthorizer.hasAuthority('SEE_EMPLOYEES_PAGE', authentication)")
+    @PreAuthorize("@preAuthorizer.hasAuthority('SEE_TARIFFS', authentication)")
     @GetMapping("/getTariffs")
     public ResponseEntity<List<GetTariffInfoForEmployeeDto>> getTariffInfoForEmployee() {
         return ResponseEntity.status(HttpStatus.OK).body(employeeService.getTariffsForEmployee());


### PR DESCRIPTION
# GreenCityUBS PR

## Summary Of Changes :fire:
In ManagementEmployeeController in "/getTariffs" changed parameter of PreAuthorize annotation

## Issue Link :clipboard:
[API]GET /admin/ubs-employee/getTariffs Get all tariffs for working with employee page - return 200 status instead of 403.
https://github.com/ita-social-projects/GreenCity/issues/7269


## Changed
In PreAuthorize authority "SEE_EMPLOYEE_PAGE" replaced by "SEE_TARIFFS"

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-7269: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers