### PR TITLE
Response status in /remove-custom-template/{id} changed from 204 to 200 and corrected documentation

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementNotificationController.java
+++ b/core/src/main/java/greencity/controller/ManagementNotificationController.java
@@ -140,7 +140,7 @@ public class ManagementNotificationController {
      */
     @Operation(summary = "Remove custom notification template")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "204", description = HttpStatuses.NO_CONTENT, content = @Content),
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK, content = @Content),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content),
@@ -149,6 +149,6 @@ public class ManagementNotificationController {
     @DeleteMapping("/remove-custom-template/{id}")
     public ResponseEntity<HttpStatus> removeNotificationTemplate(@PathVariable Long id) {
         notificationTemplateService.removeNotificationTemplate(id);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }


### PR DESCRIPTION
# GreenCityUBS PR

## Summary Of Changes :fire:
In ManagementNotificationController in /remove-custom-template/{id} response status changed from 204 to 200 as in other delete endponts. and documentation is corrected

## Issue Link :clipboard:
https://github.com/ita-social-projects/GreenCity/issues/7260

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-7260: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers