### PR TITLE
Add 400 status code to swagger for /notifications

### DIFF
--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -64,6 +64,7 @@ public class NotificationController {
     @Operation(summary = "Get page with notifications for current user")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content)
     })
     @GetMapping


### PR DESCRIPTION
dev
## Issue Link 📋

[https://github.com/ita-social-projects/GreenCity/issues/7274](https://github.com/ita-social-projects/GreenCity/issues/7274)

## Summary of issue

/notifications it does not have 400 error code in documentation

## Summary of change

Add 400 status code for /notifications to swagger

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions