### PR TITLE
Fix of quantity for bags if they are added to tariff and not present …

### DIFF
--- a/dao/src/main/java/greencity/repository/OrderBagRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderBagRepository.java
@@ -90,6 +90,6 @@ public interface OrderBagRepository extends JpaRepository<OrderBag, Long> {
         + "FROM order_bag_mapping AS obm "
         + "WHERE obm.order_id = :orderId "
         + "AND obm.bag_id = :bagId", nativeQuery = true)
-    Integer getAmountOfOrderBagsByOrderIdAndBagId(@Param("orderId") Long orderId,
+    Optional<Integer> getAmountOfOrderBagsByOrderIdAndBagId(@Param("orderId") Long orderId,
         @Param("bagId") Integer bagId);
 }

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -399,8 +399,8 @@ public class UBSClientServiceImpl implements UBSClientService {
     }
 
     private Integer getQuantityOfBagsByBagIdAndOrderId(Long orderId, Integer bagId) {
-        return orderBagRepository
-            .getAmountOfOrderBagsByOrderIdAndBagId(orderId, bagId);
+        return orderBagRepository.getAmountOfOrderBagsByOrderIdAndBagId(orderId, bagId)
+            .orElse(0);
     }
 
     private Location getLocationByOrderIdThroughLazyInitialization(Order order) {


### PR DESCRIPTION
# GreenCityUBS PR prod

## Issue Description :clipboard:
While trying to pay old orders, that has been FORMED and UNPAID. And exception has been thrown indicating that Bags quantity not found by current orderId and bagId. It occurs in orders there bags in tariff has been added, as there are no data in DB about new bags attached by current order.

## Summary Of Changes :fire:
-Instead of throwing exception if bag from tariff is not found by current order, it makes sense to still show it, but to set quantity of that bag as 0.
-Optional<Integer> added to repository method to get bag quantity ordered.

# PR Checklist Forms
_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers