### PR TITLE
7272-Remove-custom-notification-template - Add handler for TemplateDe…

### DIFF
--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -215,9 +215,9 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
      * @return {@link ResponseEntity} with HTTP status 403 and exception message.
      */
     @ExceptionHandler(TemplateDeleteException.class)
-    public final ResponseEntity<Object> handleTemplateDeleteException(WebRequest request) {
+    public final ResponseEntity<Object> handleTemplateDeleteException(TemplateDeleteException ex, WebRequest request) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
-        log.trace(exceptionResponse.getMessage(), exceptionResponse.getTrace());
+        log.trace(ex.getMessage(), ex);
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse);
     }
 }

--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -214,9 +214,9 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
      * @return {@link ResponseEntity} with HTTP status 403 and exception message.
      */
     @ExceptionHandler(TemplateDeleteException.class)
-    public final ResponseEntity<Object> handleTemplateDeleteException(WebRequest request) {
+    public final ResponseEntity<Object> handleTemplateDeleteException(TemplateDeleteException ex, WebRequest request) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
-        log.trace(exceptionResponse.getMessage(), exceptionResponse.getTrace());
+        log.trace(ex.getMessage(), ex);
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse);
     }
 }

--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -145,15 +145,20 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     /**
-     * Method interceptor exception {@link AccessDeniedException}.
+     * Method intercepts exceptions of types {@link AccessDeniedException},
+     * {@link org.springframework.security.access.AccessDeniedException} and
+     * {@link TemplateDeleteException}.
      *
-     * @param request contain detail about occur exception.
-     * @return ResponseEntity which contain http status and body with message of
-     *         exception.
+     * @param request Contains details about the occurred exception.
+     * @return ResponseEntity which contains http status FORBIDDEN (403) and a body
+     *         with the message of the exception.
      */
-    @ExceptionHandler({AccessDeniedException.class,
-        org.springframework.security.access.AccessDeniedException.class})
-    public final ResponseEntity<Object> handleAccessDeniedException(WebRequest request) {
+    @ExceptionHandler({
+        TemplateDeleteException.class,
+        AccessDeniedException.class,
+        org.springframework.security.access.AccessDeniedException.class
+    })
+    public final ResponseEntity<Object> handleForbiddenExceptions(WebRequest request) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
         log.trace(exceptionResponse.getMessage(), exceptionResponse.getTrace());
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse);
@@ -205,18 +210,5 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     public final ResponseEntity<Object> handleEntityNotFoundException(WebRequest request) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
-    }
-
-    /**
-     * Exception handler for {@link TemplateDeleteException}.
-     *
-     * @param request {@link WebRequest} with error details.
-     * @return {@link ResponseEntity} with HTTP status 403 and exception message.
-     */
-    @ExceptionHandler(TemplateDeleteException.class)
-    public final ResponseEntity<Object> handleTemplateDeleteException(TemplateDeleteException ex, WebRequest request) {
-        ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
-        log.trace(ex.getMessage(), ex);
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse);
     }
 }

--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -56,8 +56,7 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
         MappingException.class,
         CourierAlreadyExists.class,
         ServiceAlreadyExistsException.class,
-        IncorrectTemplateException.class,
-        TemplateDeleteException.class
+        IncorrectTemplateException.class
     })
     public final ResponseEntity<Object> handleBadRequestException(WebRequest request) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
@@ -207,5 +206,18 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     public final ResponseEntity<Object> handleEntityNotFoundException(WebRequest request) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
+    }
+
+    /**
+     * Exception handler for {@link TemplateDeleteException}.
+     *
+     * @param request {@link WebRequest} with error details.
+     * @return {@link ResponseEntity} with HTTP status 403 and exception message.
+     */
+    @ExceptionHandler(TemplateDeleteException.class)
+    public final ResponseEntity<Object> handleTemplateDeleteException(WebRequest request) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
+        log.trace(exceptionResponse.getMessage(), exceptionResponse.getTrace());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse);
     }
 }

--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -56,8 +56,7 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
         MappingException.class,
         CourierAlreadyExists.class,
         ServiceAlreadyExistsException.class,
-        IncorrectTemplateException.class,
-        TemplateDeleteException.class
+        IncorrectTemplateException.class
     })
     public final ResponseEntity<Object> handleBadRequestException(WebRequest request) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
@@ -206,5 +205,18 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     public final ResponseEntity<Object> handleEntityNotFoundException(WebRequest request) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
+    }
+
+    /**
+     * Exception handler for {@link TemplateDeleteException}.
+     *
+     * @param request {@link WebRequest} with error details.
+     * @return {@link ResponseEntity} with HTTP status 403 and exception message.
+     */
+    @ExceptionHandler(TemplateDeleteException.class)
+    public final ResponseEntity<Object> handleTemplateDeleteException(WebRequest request) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
+        log.trace(exceptionResponse.getMessage(), exceptionResponse.getTrace());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse);
     }
 }

--- a/core/src/test/java/greencity/controller/ManagementNotificationControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementNotificationControllerTest.java
@@ -204,12 +204,12 @@ class ManagementNotificationControllerTest {
     }
 
     @Test
-    void removeNotificationTemplateBadRequestTest() throws Exception {
+    void removeNotificationTemplateForbiddenTest() throws Exception {
         doThrow(TemplateDeleteException.class).when(notificationTemplateService).removeNotificationTemplate(anyLong());
 
         mockMvc.perform(MockMvcRequestBuilders.delete(url + "/remove-custom-template/{id}", 1L)
             .principal(principal))
-            .andExpect(MockMvcResultMatchers.status().isBadRequest());
+            .andExpect(MockMvcResultMatchers.status().isForbidden());
 
         verify(notificationTemplateService).removeNotificationTemplate(any());
     }

--- a/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
+++ b/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
@@ -191,4 +191,14 @@ class CustomExceptionHandlerTest {
             ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse));
         verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
     }
+
+    @Test
+    void handleTemplateDeleteExceptionTest() {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(objectMap);
+        when(errorAttributes.getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class)))
+                .thenReturn(objectMap);
+        assertEquals(customExceptionHandler.handleTemplateDeleteException(webRequest),
+                ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
+        verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
+    }
 }

--- a/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
+++ b/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
@@ -196,9 +196,9 @@ class CustomExceptionHandlerTest {
     void handleTemplateDeleteExceptionTest() {
         ExceptionResponse exceptionResponse = new ExceptionResponse(objectMap);
         when(errorAttributes.getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class)))
-                .thenReturn(objectMap);
+            .thenReturn(objectMap);
         assertEquals(customExceptionHandler.handleTemplateDeleteException(webRequest),
-                ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
+            ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
         verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
     }
 }

--- a/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
+++ b/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
@@ -3,8 +3,6 @@ package greencity.exception.handler;
 import greencity.exceptions.FoundException;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.UnprocessableEntityException;
-import greencity.exceptions.http.AccessDeniedException;
-import greencity.exceptions.notification.TemplateDeleteException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,9 +56,6 @@ class CustomExceptionHandlerTest {
 
     @Mock
     FoundException foundException;
-
-    @Mock
-    TemplateDeleteException templateDeleteException;
 
     @Mock
     HttpStatus status;

--- a/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
+++ b/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
@@ -4,6 +4,7 @@ import greencity.exceptions.FoundException;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.UnprocessableEntityException;
 import greencity.exceptions.http.AccessDeniedException;
+import greencity.exceptions.notification.TemplateDeleteException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,6 +58,12 @@ class CustomExceptionHandlerTest {
 
     @Mock
     FoundException foundException;
+
+    @Mock
+    AccessDeniedException accessDeniedException;
+
+    @Mock
+    TemplateDeleteException templateDeleteException;
 
     @Mock
     HttpStatus status;
@@ -147,7 +154,7 @@ class CustomExceptionHandlerTest {
         ExceptionResponse exceptionResponse = new ExceptionResponse(objectMap);
         when(errorAttributes.getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class)))
             .thenReturn(objectMap);
-        assertEquals(customExceptionHandler.handleAccessDeniedException(webRequest),
+        assertEquals(customExceptionHandler.handleAccessDeniedException(accessDeniedException, webRequest),
             ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
         verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
     }
@@ -197,7 +204,7 @@ class CustomExceptionHandlerTest {
         ExceptionResponse exceptionResponse = new ExceptionResponse(objectMap);
         when(errorAttributes.getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class)))
             .thenReturn(objectMap);
-        assertEquals(customExceptionHandler.handleTemplateDeleteException(webRequest),
+        assertEquals(customExceptionHandler.handleTemplateDeleteException(templateDeleteException, webRequest),
             ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
         verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
     }

--- a/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
+++ b/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
@@ -199,9 +199,9 @@ class CustomExceptionHandlerTest {
     void handleTemplateDeleteExceptionTest() {
         ExceptionResponse exceptionResponse = new ExceptionResponse(objectMap);
         when(errorAttributes.getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class)))
-                .thenReturn(objectMap);
+            .thenReturn(objectMap);
         assertEquals(customExceptionHandler.handleTemplateDeleteException(webRequest),
-                ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
+            ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
         verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
     }
 }

--- a/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
+++ b/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
@@ -194,4 +194,14 @@ class CustomExceptionHandlerTest {
             ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse));
         verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
     }
+
+    @Test
+    void handleTemplateDeleteExceptionTest() {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(objectMap);
+        when(errorAttributes.getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class)))
+                .thenReturn(objectMap);
+        assertEquals(customExceptionHandler.handleTemplateDeleteException(webRequest),
+                ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
+        verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
+    }
 }

--- a/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
+++ b/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
@@ -60,9 +60,6 @@ class CustomExceptionHandlerTest {
     FoundException foundException;
 
     @Mock
-    AccessDeniedException accessDeniedException;
-
-    @Mock
     TemplateDeleteException templateDeleteException;
 
     @Mock
@@ -154,7 +151,7 @@ class CustomExceptionHandlerTest {
         ExceptionResponse exceptionResponse = new ExceptionResponse(objectMap);
         when(errorAttributes.getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class)))
             .thenReturn(objectMap);
-        assertEquals(customExceptionHandler.handleAccessDeniedException(accessDeniedException, webRequest),
+        assertEquals(customExceptionHandler.handleAccessDeniedException(webRequest),
             ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
         verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
     }

--- a/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
+++ b/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
@@ -147,11 +147,11 @@ class CustomExceptionHandlerTest {
     }
 
     @Test
-    void handleAccessDeniedExceptionTest() {
+    void handleForbiddenExceptionsTest() {
         ExceptionResponse exceptionResponse = new ExceptionResponse(objectMap);
         when(errorAttributes.getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class)))
             .thenReturn(objectMap);
-        assertEquals(customExceptionHandler.handleAccessDeniedException(webRequest),
+        assertEquals(customExceptionHandler.handleForbiddenExceptions(webRequest),
             ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
         verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
     }
@@ -193,16 +193,6 @@ class CustomExceptionHandlerTest {
             .thenReturn(objectMap);
         assertEquals(customExceptionHandler.handleEntityNotFoundException(webRequest),
             ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse));
-        verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
-    }
-
-    @Test
-    void handleTemplateDeleteExceptionTest() {
-        ExceptionResponse exceptionResponse = new ExceptionResponse(objectMap);
-        when(errorAttributes.getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class)))
-            .thenReturn(objectMap);
-        assertEquals(customExceptionHandler.handleTemplateDeleteException(templateDeleteException, webRequest),
-            ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
         verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
     }
 }

--- a/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
+++ b/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
@@ -4,6 +4,7 @@ import greencity.exceptions.FoundException;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.UnprocessableEntityException;
 import greencity.exceptions.http.AccessDeniedException;
+import greencity.exceptions.notification.TemplateDeleteException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,6 +61,9 @@ class CustomExceptionHandlerTest {
 
     @Mock
     AccessDeniedException accessDeniedException;
+
+    @Mock
+    TemplateDeleteException templateDeleteException;
 
     @Mock
     HttpStatus status;
@@ -200,7 +204,7 @@ class CustomExceptionHandlerTest {
         ExceptionResponse exceptionResponse = new ExceptionResponse(objectMap);
         when(errorAttributes.getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class)))
             .thenReturn(objectMap);
-        assertEquals(customExceptionHandler.handleTemplateDeleteException(webRequest),
+        assertEquals(customExceptionHandler.handleTemplateDeleteException(templateDeleteException, webRequest),
             ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
         verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
     }

--- a/service-api/src/main/java/greencity/exceptions/notification/TemplateDeleteException.java
+++ b/service-api/src/main/java/greencity/exceptions/notification/TemplateDeleteException.java
@@ -1,6 +1,11 @@
 package greencity.exceptions.notification;
 
 public class TemplateDeleteException extends RuntimeException {
+    /**
+     * Constructor with message.
+     *
+     * @param message message, that explains cause of the exception.
+     */
     public TemplateDeleteException(String message) {
         super(message);
     }


### PR DESCRIPTION
…leteException

Implement a dedicated handler for TemplateDeleteException to return a 403 status code. Update relevant tests to ensure proper handling and validation of the new exception.

dev
## JIRA

https://github.com/ita-social-projects/GreenCity/issues/7272

## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

An issue was found in the removeNotificationTemplateForbiddenTest controller test, where the test wasn't handling TemplateDeleteException exceptions properly and returning an incorrect HTTP status.

## Summary of change

Updated the removeNotificationTemplateForbiddenTest to appropriately handle TemplateDeleteException exceptions. The test now returns an expected HTTP status of 403 (Forbidden).

## Testing approach

Testing was done with a unit testing approach. This involved mocking the notificationTemplateService to simulate behavior at the service level, and using MockMvc to perform HTTP requests at the controller level. As a result of the update, the isForbidden() status is now correctly returned in the test.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions