### PR TITLE
fix bug notification LETS_STAY_CONNECTED isn't sent by email

### DIFF
--- a/dao/src/main/java/greencity/repository/UserRepository.java
+++ b/dao/src/main/java/greencity/repository/UserRepository.java
@@ -104,12 +104,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
      * Return list of the inactive users depends on time limits.
      */
     @Query(nativeQuery = true,
-        value = "SELECT * FROM users "
+        value = "SELECT u.* FROM users u "
             + "INNER JOIN orders o "
-            + "ON users.id = o.users_id "
+            + "ON u.id = o.users_id "
             + "AND o.id = (SELECT o1.id FROM orders o1 "
             + "WHERE o1.users_id = o.users_id "
-            + "ORDER BY o1.order_date DESC limit 1) "
+            + "ORDER BY o1.order_date DESC LIMIT 1) "
             + "WHERE CAST(o.order_date AS DATE) = :dateOfLastOrder")
     List<User> getInactiveUsersByDateOfLastOrder(LocalDate dateOfLastOrder);
 

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -230,4 +230,5 @@
     <include file="/db/changelog/logs/ch-insert-data-into-notification-platforms-Kizerov.xml"/>
     <include file="/db/changelog/logs/ch-update-values-in-notification-templates-title-Sotnik.xml"/>
     <include file="/db/changelog/logs/ch-add-column-status-and-deleteDate-to-Violation-Chekhovska.xml"/>
+    <include file="/db/changelog/logs/ch-update-notification-templates-Herchanivska.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-update-notification-templates-Herchanivska.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-update-notification-templates-Herchanivska.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet id="Viktoriia-1" author="Herchanivska">
+        <update tableName="notification_templates">
+            <column name="schedule" value="0 0 18 * * ?"/>
+            <where>id=9</where>
+        </update>
+        <update tableName="notification_templates">
+            <column name="time" value="TWO_MONTHS_AFTER_LAST_ORDER"/>
+            <where>id=9</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Notication for inactive users(users whose last order was placed 2 or more months ago)
Notifications sent every 2 month for 1 year.
Sysmen automatically check DB dayly at 18PM and sent notification to inactive users.

- cron expression for daily schedule was set in DB
- SQL query was adjust since there was error in execution