### PR TITLE
200-insted-of-404-when-non-existing-location

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -2069,6 +2069,7 @@ public class UBSClientServiceImpl implements UBSClientService {
     @Override
     public List<Long> getTariffIdByLocationId(Long locationId) {
         return tariffsInfoRepository.findTariffIdByLocationId(locationId)
+            .filter(list -> !list.isEmpty())
             .orElseThrow(() -> new NotFoundException(String.format(TARIFF_NOT_FOUND_BY_LOCATION_ID, locationId)));
     }
 


### PR DESCRIPTION
dev
## GitHub
[https://github.com/ita-social-projects/GreenCity/issues/7589](https://github.com/ita-social-projects/GreenCity/issues/7589
)
## Summary of issue
- orElseThrow was checking Optional of empty list if by location id was not found any tariffs, so it couldn't throw an exception.

## Summary of change
- add filter() to check that list is not empty.
![image](https://github.com/user-attachments/assets/931bfce0-f6ab-4556-8d1b-b29c56516e23)

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions