### PR TITLE
change regex to be from 1 to 8 digits

### DIFF
--- a/service-api/src/main/java/greencity/dto/order/OrderResponseDto.java
+++ b/service-api/src/main/java/greencity/dto/order/OrderResponseDto.java
@@ -40,7 +40,7 @@ public class OrderResponseDto implements Serializable {
     private Set<@Pattern(regexp = "(\\d{4}-\\d{4})|(^$)",
         message = "This certificate code is not valid") String> certificates;
 
-    private Set<@Pattern(regexp = "\\d{4,10}") String> additionalOrders;
+    private Set<@Pattern(regexp = "\\d{1,8}") String> additionalOrders;
 
     @Length(max = 255)
     private String orderComment;


### PR DESCRIPTION
[https://github.com/ita-social-projects/GreenCity/issues/7569](https://github.com/ita-social-projects/GreenCity/issues/7569)

According to https://github.com/ita-social-projects/GreenCity/issues/5981 user can enter order number in format from 1 to 8 digits. But system doesn't validate 1-3 digits numbers.