### PR TITLE
Marking and deleting notification

### DIFF
--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -100,7 +100,7 @@ public class NotificationController {
      *
      * @param notificationId id of notification, that should be marked as viewed
      */
-    @Operation(summary = "Get single Notification.")
+    @Operation(summary = "Read single Notification.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -19,7 +19,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -91,5 +93,63 @@ public class NotificationController {
         @Parameter(hidden = true) @CurrentUserUuid String userUuid) {
         return ResponseEntity.status(HttpStatus.OK)
             .body(notificationService.getUnreadenNotifications(userUuid));
+    }
+
+    /**
+     * Method to mark Notification as viewed.
+     *
+     * @param notificationId id of notification, that should be marked as viewed
+     */
+    @Operation(summary = "Get single Notification.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @PatchMapping("/{notificationId}/viewNotification")
+    public ResponseEntity<Object> viewNotification(@PathVariable Long notificationId,
+        @Parameter(hidden = true) @CurrentUserUuid String userUuid) {
+        notificationService.viewNotification(notificationId, userUuid);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /**
+     * Method to mark specific Notification as not viewed.
+     *
+     * @param notificationId id of notification, that should be marked as not viewed
+     */
+    @Operation(summary = "Unread single Notification.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @PatchMapping("/{notificationId}/unreadNotification")
+    public ResponseEntity<Object> unreadNotification(@PathVariable Long notificationId,
+        @Parameter(hidden = true) @CurrentUserUuid String userUuid) {
+        notificationService.unreadNotification(notificationId, userUuid);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /**
+     * Method to delete specific Notification.
+     *
+     * @param userUuid       User
+     * @param notificationId id of notification, that should be deleted
+     */
+    @Operation(summary = "Delete single Notification.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @DeleteMapping("/{notificationId}")
+    public ResponseEntity<Object> deleteNotification(@PathVariable Long notificationId,
+        @Parameter(hidden = true) @CurrentUserUuid String userUuid) {
+        notificationService.deleteNotification(notificationId, userUuid);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/core/src/test/java/greencity/controller/NotificationControllerTest.java
+++ b/core/src/test/java/greencity/controller/NotificationControllerTest.java
@@ -20,7 +20,9 @@ import java.security.Principal;
 import java.util.List;
 import static greencity.ModelUtils.getNotificationDto;
 import static greencity.ModelUtils.getUuid;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -73,5 +75,25 @@ class NotificationControllerTest {
             .principal(principal)
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void viewNotificationTest() throws Exception {
+        mockMvc.perform(patch(notificationLink + "/{notificationId}/viewNotification", 1L)
+            .principal(principal))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void unreadNotificationTest() throws Exception {
+        mockMvc.perform(patch(notificationLink + "/{notificationId}/unreadNotification", 1L))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void deleteNotificationTest() throws Exception {
+        mockMvc.perform(delete(notificationLink + "/{notificationId}", 1L)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
     }
 }

--- a/core/src/test/java/greencity/controller/NotificationControllerTest.java
+++ b/core/src/test/java/greencity/controller/NotificationControllerTest.java
@@ -80,19 +80,23 @@ class NotificationControllerTest {
     @Test
     void viewNotificationTest() throws Exception {
         mockMvc.perform(patch(notificationLink + "/{notificationId}/viewNotification", 1L)
-            .principal(principal))
+            .principal(principal)
+            .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
     }
 
     @Test
     void unreadNotificationTest() throws Exception {
-        mockMvc.perform(patch(notificationLink + "/{notificationId}/unreadNotification", 1L))
+        mockMvc.perform(patch(notificationLink + "/{notificationId}/unreadNotification", 1L)
+            .principal(principal)
+            .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
     }
 
     @Test
     void deleteNotificationTest() throws Exception {
         mockMvc.perform(delete(notificationLink + "/{notificationId}", 1L)
+            .principal(principal)
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
     }

--- a/dao/src/main/java/greencity/repository/UserNotificationRepository.java
+++ b/dao/src/main/java/greencity/repository/UserNotificationRepository.java
@@ -6,8 +6,10 @@ import greencity.entity.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -46,4 +48,42 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
         + "WHERE CAST(notification_time AS DATE) > :dateOfLastNotification AND "
         + "notification_type = :type")
     List<Long> getUserIdByDateOfLastNotificationAndNotificationType(LocalDate dateOfLastNotification, String type);
+
+    /**
+     * Changes {@link UserNotification} `read` as true.
+     *
+     * @param notificationId to change
+     */
+    @Transactional
+    @Modifying
+    @Query("UPDATE UserNotification n SET n.read = true WHERE n.id = :notificationId")
+    void markNotificationAsViewed(Long notificationId);
+
+    /**
+     * Changes {@link UserNotification} `viewed` as false.
+     *
+     * @param notificationId to change
+     */
+    @Transactional
+    @Modifying
+    @Query("UPDATE UserNotification n SET n.read = false WHERE n.id = :notificationId")
+    void markNotificationAsNotViewed(Long notificationId);
+
+    /**
+     * Method to delete specific Notification.
+     *
+     * @param notificationId id of searched Notification
+     * @param userId         id of user
+     */
+    void deleteUserNotificationByIdAndUserId(Long notificationId, Long userId);
+
+    /**
+     * Checks if a notification with the specified ID exists for the specified user.
+     *
+     * @param notificationId the ID of the notification to check
+     * @param userId         the ID of the user for whom the notification belongs
+     * @return true if the notification with the specified ID exists for the user,
+     *         false otherwise
+     */
+    boolean existsByIdAndUserId(Long notificationId, Long userId);
 }

--- a/service-api/src/main/java/greencity/service/ubs/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/ubs/NotificationService.java
@@ -206,4 +206,31 @@ public interface NotificationService {
      * @author Kizerov Dmytro
      */
     void notifyCreatedOrder(Order order);
+
+    /**
+     * Method to mark specific UserNotification as read.
+     *
+     * @param notificationId id of userNotification, that should be marked
+     *
+     * @author Roman Kasarab
+     */
+    void viewNotification(Long notificationId, String userUuid);
+
+    /**
+     * Method to mark specific UserNotification as unread.
+     *
+     * @param notificationId id of userNotification, that should be marked
+     *
+     * @author Roman Kasarab
+     */
+    void unreadNotification(Long notificationId, String userUuid);
+
+    /**
+     * Method to delete specific Notification.
+     *
+     * @param notificationId id of notification, that should be deleted
+     * @param userUuid       user
+     * @author Roman Kasarab
+     */
+    void deleteNotification(Long notificationId, String userUuid);
 }

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -2,6 +2,7 @@ package greencity.service.notification;
 
 import greencity.config.InternalUrlConfigProp;
 import greencity.constant.AppConstant;
+import greencity.constant.ErrorMessage;
 import greencity.constant.OrderHistory;
 import greencity.dto.notification.InactiveAccountDto;
 import greencity.dto.notification.NotificationDto;
@@ -747,6 +748,42 @@ public class NotificationServiceImpl implements NotificationService {
             getNotificationParametersForNewOrder(order),
             order,
             NotificationType.CREATE_NEW_ORDER);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void viewNotification(Long notificationId, String userUuid) {
+        Long userId = userRepository.findByUuid(userUuid).getId();
+        if (!userNotificationRepository.existsByIdAndUserId(notificationId, userId)) {
+            throw new NotFoundException(ErrorMessage.NOTIFICATION_DOES_NOT_BELONG_TO_USER);
+        }
+        userNotificationRepository.markNotificationAsViewed(notificationId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void unreadNotification(Long notificationId, String userUuid) {
+        Long userId = userRepository.findByUuid(userUuid).getId();
+        if (!userNotificationRepository.existsByIdAndUserId(notificationId, userId)) {
+            throw new NotFoundException(ErrorMessage.NOTIFICATION_DOES_NOT_BELONG_TO_USER);
+        }
+        userNotificationRepository.markNotificationAsNotViewed(notificationId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void deleteNotification(Long notificationId, String userUuid) {
+        Long userId = userRepository.findByUuid(userUuid).getId();
+        if (!userNotificationRepository.existsByIdAndUserId(notificationId, userId)) {
+            throw new NotFoundException(ErrorMessage.NOTIFICATION_DOES_NOT_BELONG_TO_USER);
+        }
+        userNotificationRepository.deleteUserNotificationByIdAndUserId(notificationId, userId);
     }
 
     private Set<NotificationParameter> getNotificationParametersForNewOrder(Order order) {

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -3,6 +3,7 @@ package greencity.service.notification;
 import com.google.common.util.concurrent.MoreExecutors;
 import greencity.ModelUtils;
 import greencity.config.InternalUrlConfigProp;
+import greencity.constant.ErrorMessage;
 import greencity.dto.notification.NotificationDto;
 import greencity.dto.notification.NotificationShortDto;
 import greencity.dto.pageble.PageableDto;
@@ -62,6 +63,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import static greencity.ModelUtils.TEST_UUID;
 import static greencity.ModelUtils.TEST_DTO;
 import static greencity.ModelUtils.TEST_NOTIFICATION_DTO;
 import static greencity.ModelUtils.TEST_NOTIFICATION_PARAMETER_SET;
@@ -97,6 +99,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
@@ -984,6 +987,108 @@ class NotificationServiceImplTest {
 
         assertThrows(NotFoundException.class,
             () -> notificationService.getNotification("abc", 1L, "ua"));
+    }
+
+    @Test
+    void viewNotificationTest() {
+        Long notificationId = TEST_NOTIFICATION_TEMPLATE.getId();
+        Long userId = TEST_USER.getId();
+
+        when(userRepository.findByUuid(any())).thenReturn(TEST_USER);
+        when(userNotificationRepository.existsByIdAndUserId(notificationId, userId)).thenReturn(true);
+
+        notificationService.viewNotification(notificationId, TEST_UUID);
+
+        verify(userRepository).findByUuid(any());
+        verify(userNotificationRepository).existsByIdAndUserId(notificationId, userId);
+        verify(userNotificationRepository).markNotificationAsViewed(notificationId);
+    }
+
+    @Test
+    void readNonExistentNotificationAndGetNotFoundExceptionTest() {
+        Long notificationId = TEST_NOTIFICATION_TEMPLATE.getId();
+        Long userId = TEST_USER.getId();
+
+        when(userRepository.findByUuid(TEST_UUID)).thenReturn(TEST_USER);
+        when(userNotificationRepository.existsByIdAndUserId(notificationId, userId)).thenReturn(false);
+
+        NotFoundException exception = assertThrows(NotFoundException.class,
+            () -> notificationService.viewNotification(notificationId, TEST_UUID));
+
+        assertEquals(ErrorMessage.NOTIFICATION_DOES_NOT_BELONG_TO_USER, exception.getMessage());
+
+        verify(userRepository).findByUuid(TEST_UUID);
+        verify(userNotificationRepository).existsByIdAndUserId(notificationId, userId);
+        verify(userNotificationRepository, never()).markNotificationAsViewed(notificationId);
+
+    }
+
+    @Test
+    void unreadNotificationTest() {
+        Long notificationId = TEST_NOTIFICATION_TEMPLATE.getId();
+        Long userId = TEST_USER.getId();
+
+        when(userRepository.findByUuid(any())).thenReturn(TEST_USER);
+        when(userNotificationRepository.existsByIdAndUserId(notificationId, userId)).thenReturn(true);
+
+        notificationService.unreadNotification(notificationId, TEST_UUID);
+
+        verify(userRepository).findByUuid(any());
+        verify(userNotificationRepository).existsByIdAndUserId(notificationId, userId);
+        verify(userNotificationRepository).markNotificationAsNotViewed(notificationId);
+    }
+
+    @Test
+    void unreadNonExistentNotificationAndGetNotFoundExceptionTest() {
+        Long notificationId = TEST_NOTIFICATION_TEMPLATE.getId();
+        Long userId = TEST_USER.getId();
+
+        when(userRepository.findByUuid(TEST_UUID)).thenReturn(TEST_USER);
+        when(userNotificationRepository.existsByIdAndUserId(notificationId, userId)).thenReturn(false);
+
+        NotFoundException exception = assertThrows(NotFoundException.class,
+            () -> notificationService.unreadNotification(notificationId, TEST_UUID));
+
+        assertEquals(ErrorMessage.NOTIFICATION_DOES_NOT_BELONG_TO_USER, exception.getMessage());
+
+        verify(userRepository).findByUuid(TEST_UUID);
+        verify(userNotificationRepository).existsByIdAndUserId(notificationId, userId);
+        verify(userNotificationRepository, never()).markNotificationAsNotViewed(notificationId);
+
+    }
+
+    @Test
+    void deleteNotificationTest() {
+        Long notificationId = TEST_NOTIFICATION_TEMPLATE.getId();
+        Long userId = TEST_USER.getId();
+
+        when(userRepository.findByUuid(any())).thenReturn(TEST_USER);
+        when(userNotificationRepository.existsByIdAndUserId(notificationId, userId)).thenReturn(true);
+
+        notificationService.deleteNotification(notificationId, TEST_UUID);
+
+        verify(userRepository).findByUuid(any());
+        verify(userNotificationRepository).existsByIdAndUserId(notificationId, userId);
+        verify(userNotificationRepository).deleteUserNotificationByIdAndUserId(notificationId, userId);
+    }
+
+    @Test
+    void deleteNonExistentNotificationAndGetNotFoundExceptionTest() {
+        Long notificationId = TEST_NOTIFICATION_TEMPLATE.getId();
+        Long userId = TEST_USER.getId();
+
+        when(userRepository.findByUuid(TEST_UUID)).thenReturn(TEST_USER);
+        when(userNotificationRepository.existsByIdAndUserId(notificationId, userId)).thenReturn(false);
+
+        NotFoundException exception = assertThrows(NotFoundException.class,
+            () -> notificationService.deleteNotification(notificationId, TEST_UUID));
+
+        assertEquals(ErrorMessage.NOTIFICATION_DOES_NOT_BELONG_TO_USER, exception.getMessage());
+
+        verify(userRepository).findByUuid(TEST_UUID);
+        verify(userNotificationRepository).existsByIdAndUserId(notificationId, userId);
+        verify(userNotificationRepository, never()).deleteUserNotificationByIdAndUserId(notificationId, userId);
+
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUBS PR (dev)
Feature sending notification after liking a comment

## Issue Link :clipboard:
#[7669](https://github.com/ita-social-projects/GreenCity/issues/7669)

## Summary Of Changes :fire:

## Added
* Added new end-points to NotificationController.java;
* Added new methods - viewNotification(), unreadNotification(), and deleteNotification() for reed, unread, and delete user's notification into NotificationService.java and NotificationServiceImpl.java;
* Added new methods markNotificationAsViewed(), markNotificationAsNotViewed(), deleteUserNotificationByIdAndUserId() and existsByIdAndUserId into UserNotificationRepository.java;
* Added test cases.

# PR Checklist Forms

_(to be filled out by PR submitter)_
- [ ] Code is up-to-date with the dev branch.
- [X] You've successfully built and run the tests locally.
- [X] New or updated unit tests validate the change.
- [X] JIRA/ Github Issue number & title in PR title (ISSUE-#[7669](https://github.com/ita-social-projects/GreenCity/issues/7669))
- [X] This template is filled (above this section).
- [X] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [X] NEED_REVIEW and READY_FOR_REVIEW labels are added.
- [X] All files reviewed before sending to reviewers