### PR TITLE
add check that order status is not canceled

### DIFF
--- a/dao/src/main/java/greencity/repository/OrderRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderRepository.java
@@ -249,4 +249,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query("UPDATE Order o SET o.blocked = false, o.blockedByEmployee = NULL,"
         + "o.blockedAt = NULL WHERE o.blockedAt < :expirationTime")
     void unlockExpiredOrders(@Param("expirationTime") LocalDateTime expirationTime);
+
+    List<Order> findAllByOrderStatusNotAndOrderPaymentStatus(OrderStatus orderStatus,
+        OrderPaymentStatus orderPaymentStatus);
 }

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -118,9 +118,9 @@ public class NotificationServiceImpl implements NotificationService {
      */
     @Override
     public void notifyUnpaidOrders() {
-        for (Order order : orderRepository.findAllByOrderPaymentStatus(OrderPaymentStatus.UNPAID)) {
-            if (checkIfOrderNeedsNewNotification(order, NotificationType.UNPAID_ORDER)
-                && !order.getOrderStatus().equals(OrderStatus.CANCELED)) {
+        for (Order order : orderRepository.findAllByOrderStatusNotAndOrderPaymentStatus(OrderStatus.CANCELED,
+            OrderPaymentStatus.UNPAID)) {
+            if (checkIfOrderNeedsNewNotification(order, NotificationType.UNPAID_ORDER)) {
                 UserNotification userNotification = new UserNotification();
                 userNotification.setUser(order.getUser());
                 Double amountToPay = getAmountToPay(order);

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -119,7 +119,8 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     public void notifyUnpaidOrders() {
         for (Order order : orderRepository.findAllByOrderPaymentStatus(OrderPaymentStatus.UNPAID)) {
-            if (checkIfOrderNeedsNewNotification(order, NotificationType.UNPAID_ORDER)) {
+            if (checkIfOrderNeedsNewNotification(order, NotificationType.UNPAID_ORDER)
+                && !order.getOrderStatus().equals(OrderStatus.CANCELED)) {
                 UserNotification userNotification = new UserNotification();
                 userNotification.setUser(order.getUser());
                 Double amountToPay = getAmountToPay(order);

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -197,7 +197,8 @@ class NotificationServiceImplTest {
                     .amountOfBagsOrdered(new HashMap<>())
                     .build());
 
-            when(orderRepository.findAllByOrderPaymentStatus(OrderPaymentStatus.UNPAID))
+            when(orderRepository.findAllByOrderStatusNotAndOrderPaymentStatus(OrderStatus.CANCELED,
+                OrderPaymentStatus.UNPAID))
                 .thenReturn(orders);
 
             doReturn(Optional.empty()).when(userNotificationRepository)


### PR DESCRIPTION
## Summary of issue

Unpaid reminder for canceled orderes

## Summary of change

Add check that order status is not equal to canceled

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions