### PR TITLE
Fixed duplication in orders bags mapping

### DIFF
--- a/dao/src/main/java/greencity/repository/OrderBagRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderBagRepository.java
@@ -83,4 +83,14 @@ public interface OrderBagRepository extends JpaRepository<OrderBag, Long> {
         + "AND obm.bag_id = :bagId", nativeQuery = true)
     Optional<Integer> getAmountOfOrderBagsByOrderIdAndBagId(@Param("orderId") Long orderId,
         @Param("bagId") Integer bagId);
+
+    /**
+     * Deletes all order bags associated with the given order ID from the
+     * ORDER_BAG_MAPPING table.
+     *
+     * @param orderId The ID of the order for which all associated order bags should
+     *                be deleted.
+     */
+    @Modifying
+    void deleteAllByOrderId(Long orderId);
 }

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -1241,6 +1241,7 @@ public class UBSClientServiceImpl implements UBSClientService {
     private void formAndSaveOrder(Order order, Set<Certificate> orderCertificates,
         List<OrderBag> bagsOrdered, UBSuser userData,
         User currentUser, long sumToPayInCoins) {
+        orderBagRepository.deleteAllByOrderId(order.getId());
         order.setOrderStatus(OrderStatus.FORMED);
         order.setCertificates(orderCertificates);
         order.updateWithNewOrderBags(bagsOrdered);


### PR DESCRIPTION
# GreenCityUBS PR (dev)

## Summary Of Changes :fire:

# PR Checklist Forms
- refactored logic in UbsClientService to remove duplication in order_bag_mapping table.
- added new method to OrderBagRepository.

_(to be filled out by PR submitter)_
- [x] Code is up-to-date with the `dev` branch.
- [x] You've successfully built and run the tests locally.
- [x] There are new or updated unit tests validating the change.
- [x] JIRA/ Github Issue number & title in PR title (ISSUE-XXXX: Ticket title)
- [x] This template filled (above this section).
- [x] Sonar's report does not contain bugs, vulnerabilities, security issues, code smells or duplication
- [x] `NEED_REVIEW` and `READY_FOR_REVIEW` labels are added.
- [x] All files reviewed before sending to reviewers