### PR TITLE
Feature #4401 - Added Reasons of Bonus for change of user points.

### DIFF
--- a/dao/src/main/java/greencity/entity/order/ChangeOfPoints.java
+++ b/dao/src/main/java/greencity/entity/order/ChangeOfPoints.java
@@ -1,6 +1,7 @@
 package greencity.entity.order;
 
 import greencity.entity.user.User;
+import greencity.enums.BonusReason;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -9,6 +10,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -41,4 +44,8 @@ public class ChangeOfPoints {
     @ManyToOne
     @JoinColumn(name = "order_id")
     private Order order;
+
+    @Column(nullable = false, name = "reason", length = 50)
+    @Enumerated(EnumType.STRING)
+    private BonusReason reason;
 }

--- a/dao/src/main/java/greencity/enums/BonusReason.java
+++ b/dao/src/main/java/greencity/enums/BonusReason.java
@@ -1,0 +1,15 @@
+package greencity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum BonusReason {
+    RETURN_OVERPAY("Повернення переплати за замовлення", "Refund of overpayment for the order"),
+    REFUND_CANCELED_ORDER("Зарахування оплати скасованого замовлення", "Enrollment of payment for canceled order"),
+    DEBIT_PAYMENT("Списання у рахунок оплати замовлення", "Write-off of the payment of the order");
+
+    private final String descriptionUa;
+    private final String descriptionEn;
+}

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -261,4 +261,5 @@
     <include file="db/changelog/logs/2024-12-16-hotfix-big_order_table-Kizerov.xml"/>
     <include file="db/changelog/logs/2024-11-28-change-add-column-isTableFreeze-to-column_width_for_employee-Warded120.xml"/>
     <include file="db/changelog/logs/2024-12-18-update-column_width_for_employee-Kizerov.xml"/>
+    <include file="db/changelog/logs/ch-add-column-reason-into-change-of-points-table-Chernenko.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-add-column-reason-into-change-of-points-table-Chernenko.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-column-reason-into-change-of-points-table-Chernenko.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="2024-12-19-add-column-reason" author="Chernenko Vitaliy">
+        <addColumn tableName="change_of_points">
+            <column name="reason" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/test/java/greencity/enums/BonusReasonTest.java
+++ b/dao/src/test/java/greencity/enums/BonusReasonTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class BonusReasonTest {
+class BonusReasonTest {
     @Test
     void returnOverpayConstantValidTest() {
         BonusReason reason = BonusReason.RETURN_OVERPAY;

--- a/dao/src/test/java/greencity/enums/BonusReasonTest.java
+++ b/dao/src/test/java/greencity/enums/BonusReasonTest.java
@@ -1,0 +1,31 @@
+package greencity.enums;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BonusReasonTest {
+    @Test
+    void returnOverpayConstantValidTest() {
+        BonusReason reason = BonusReason.RETURN_OVERPAY;
+
+        assertEquals("Повернення переплати за замовлення", reason.getDescriptionUa());
+        assertEquals("Refund of overpayment for the order", reason.getDescriptionEn());
+    }
+
+    @Test
+    void refundCanceledOrderConstantValidTest() {
+        BonusReason reason = BonusReason.REFUND_CANCELED_ORDER;
+
+        assertEquals("Зарахування оплати скасованого замовлення", reason.getDescriptionUa());
+        assertEquals("Enrollment of payment for canceled order", reason.getDescriptionEn());
+    }
+
+    @Test
+    void debitPaymentConstantValidTest() {
+        BonusReason reason = BonusReason.DEBIT_PAYMENT;
+
+        assertEquals("Списання у рахунок оплати замовлення", reason.getDescriptionUa());
+        assertEquals("Write-off of the payment of the order", reason.getDescriptionEn());
+    }
+}

--- a/service-api/src/main/java/greencity/dto/user/PointsForUbsUserDto.java
+++ b/service-api/src/main/java/greencity/dto/user/PointsForUbsUserDto.java
@@ -16,9 +16,10 @@ import java.time.LocalDateTime;
 @ToString
 @Builder
 @EqualsAndHashCode
-
 public class PointsForUbsUserDto {
     private LocalDateTime dateOfEnrollment;
     private Long numberOfOrder;
     private Integer amount;
+    private String reasonUa;
+    private String reasonEn;
 }

--- a/service/src/main/java/greencity/mapping/user/PointsForUbsUserDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/user/PointsForUbsUserDtoMapper.java
@@ -16,14 +16,12 @@ public class PointsForUbsUserDtoMapper extends AbstractConverter<ChangeOfPoints,
 
     @Override
     protected PointsForUbsUserDto convert(ChangeOfPoints changeOfPoints) {
-        Long numberOfOrder = null;
-        if (changeOfPoints.getOrder() != null) {
-            numberOfOrder = changeOfPoints.getOrder().getId();
-        }
         return PointsForUbsUserDto.builder()
             .dateOfEnrollment(changeOfPoints.getDate())
             .amount(changeOfPoints.getAmount())
-            .numberOfOrder(numberOfOrder)
+            .numberOfOrder(changeOfPoints.getOrder().getId())
+            .reasonUa(changeOfPoints.getReason().getDescriptionUa())
+            .reasonEn(changeOfPoints.getReason().getDescriptionEn())
             .build();
     }
 }

--- a/service/src/main/java/greencity/service/ubs/PaymentServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/PaymentServiceImpl.java
@@ -19,6 +19,7 @@ import greencity.enums.OrderPaymentStatus;
 import greencity.enums.OrderStatus;
 import greencity.enums.PaymentStatus;
 import greencity.enums.PaymentType;
+import greencity.enums.BonusReason;
 import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
 import greencity.repository.CertificateRepository;
@@ -186,7 +187,7 @@ public class PaymentServiceImpl implements PaymentService {
                 Long possibleBonusesRefundAmount =
                     Long.valueOf(order.getPointsToUse()) + PaymentUtil.calculatePaidAmount(order);
                 validateRefundAmount(refundDto.getAmount(), possibleBonusesRefundAmount);
-                refundPaymentsInBonus(order, employeeEmail, refundDto.getAmount());
+                refundPaymentsInBonus(order, employeeEmail, refundDto.getAmount(), BonusReason.RETURN_OVERPAY);
             } else if (refundDto.isReturnMoney()) {
                 validateRefundAmount(refundDto.getAmount(), PaymentUtil.calculatePaidAmount(order));
                 refundPaymentsInMoney(order, employeeEmail, refundDto.getAmount());
@@ -199,7 +200,7 @@ public class PaymentServiceImpl implements PaymentService {
             throw new BadRequestException(String.format(ORDER_CAN_NOT_BE_UPDATED, order.getOrderStatus()));
         }
         if (refundDto.isReturnBonuses()) {
-            refundPaymentsInBonus(order, employeeEmail);
+            refundPaymentsInBonus(order, employeeEmail, BonusReason.REFUND_CANCELED_ORDER);
         } else if (refundDto.isReturnMoney()) {
             Long paidAmount = PaymentUtil.calculatePaidAmount(order);
             refundPaymentsInMoney(order, employeeEmail, paidAmount);
@@ -248,21 +249,21 @@ public class PaymentServiceImpl implements PaymentService {
         eventService.saveEvent(OrderHistory.CANCELED_ORDER_MONEY_REFUND, employeeEmail, order);
     }
 
-    private void refundPaymentsInBonus(Order order, String email) {
+    private void refundPaymentsInBonus(Order order, String email, BonusReason reason) {
         CounterOrderDetailsDto prices =
             PaymentUtil.getPriceDetails(order.getId(), orderRepository, orderBagService, certificateRepository);
         Long overpaymentInCoins =
             PaymentUtil.calculateOverpayment(order,
                 PaymentUtil.convertBillsIntoCoins(PaymentUtil.setTotalPrice(prices)));
-        refundPaymentsInBonus(order, email, overpaymentInCoins);
+        refundPaymentsInBonus(order, email, overpaymentInCoins, reason);
     }
 
-    private void refundPaymentsInBonus(Order order, String email, Long amount) {
+    private void refundPaymentsInBonus(Order order, String email, Long amount, BonusReason reason) {
         checkOverpayment(amount);
         User currentUser = order.getUser();
         order.getPayment().add(
             buildPaymentForRefund(-amount, ENROLLMENT_TO_THE_BONUS_ACCOUNT_ENG, order));
-        transferPointsToUser(order, currentUser, amount);
+        transferPointsToUser(order, currentUser, amount, reason);
         order.setOrderPaymentStatus(OrderPaymentStatus.PAYMENT_REFUNDED);
         orderRepository.save(order);
         userRepository.save(currentUser);
@@ -299,7 +300,7 @@ public class PaymentServiceImpl implements PaymentService {
             .build();
     }
 
-    private void transferPointsToUser(Order order, User user, long pointsInCoins) {
+    private void transferPointsToUser(Order order, User user, long pointsInCoins, BonusReason reason) {
         int uahPoints = PaymentUtil.convertCoinsIntoBills(pointsInCoins).intValue();
         user.setCurrentPoints(user.getCurrentPoints() + uahPoints);
 
@@ -310,6 +311,7 @@ public class PaymentServiceImpl implements PaymentService {
                 .amount(uahPoints)
                 .date(LocalDateTime.now())
                 .order(order)
+                .reason(reason)
                 .build());
         notificationService.notifyBonuses(order, (long) uahPoints);
     }

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -96,6 +96,7 @@ import greencity.enums.OrderStatus;
 import greencity.enums.PaymentStatus;
 import greencity.enums.PaymentType;
 import greencity.enums.TariffStatus;
+import greencity.enums.BonusReason;
 import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.address.AddressNotWithinLocationAreaException;
@@ -924,6 +925,7 @@ public class UBSClientServiceImpl implements UBSClientService {
                 .date(order.getOrderDate())
                 .user(currentUser)
                 .order(order)
+                .reason(BonusReason.DEBIT_PAYMENT)
                 .build());
         }
         userRepository.save(currentUser);

--- a/service/src/test/java/greencity/mapping/user/PointsForUbsUserDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/user/PointsForUbsUserDtoMapperTest.java
@@ -3,6 +3,7 @@ package greencity.mapping.user;
 import greencity.ModelUtils;
 import greencity.dto.user.PointsForUbsUserDto;
 import greencity.entity.order.ChangeOfPoints;
+import greencity.enums.BonusReason;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,10 +18,13 @@ class PointsForUbsUserDtoMapperTest {
     @Test
     void convert() {
         ChangeOfPoints changeOfPoints = ModelUtils.getChangeOfPoints();
+        changeOfPoints.setReason(BonusReason.RETURN_OVERPAY);
         PointsForUbsUserDto expected = PointsForUbsUserDto.builder()
             .numberOfOrder(changeOfPoints.getOrder().getId())
             .amount(changeOfPoints.getAmount())
             .dateOfEnrollment(changeOfPoints.getDate())
+            .reasonUa(changeOfPoints.getReason().getDescriptionUa())
+            .reasonEn(changeOfPoints.getReason().getDescriptionEn())
             .build();
         PointsForUbsUserDto actual = pointsForUbsUserDtoMapper.convert(changeOfPoints);
 


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/4401">#4401</a>

## Added

- Created enum `BonusReason` with constants and short description for ua and en langs;
- Added field _reason_(BonueReason) in `ChangeOfPoints` entity;
- Created _changelog ch-add-column-reason-into-change-of-points-table-Chernenko.xml_ for creating column _reason_ in _change_of_points_ table; 
- Added changelog link into _db.changelog-master.xml_; 
- Added _reasonUa_ and _reasonEn_ string fields into `PointsForUbsUserDto`; 

## Changed

- Refactored and `PointsForUbsUserDtoMapper`;
- Refactored `PointsForUbsUserDtoMapperTest` according to changes in `PointsForUbsUserDtoMapper` class; 
- Modified methods _processRefundForBroughtItHimselfOrder_, _processRefundForDoneAndCanceledOrder_, _refundPaymentsInBonus_(both), _transferPointsToUser_ in `PaymentServiceImpl` for adding and saving reason for adding bonuses; 
- Modified method _formAndSaveUser_ in `UBSClientServiceImpl` class for writing off bonus points;

## Summary Of Changes 🔥
Added functionality for describing adding or writing off bonus points according to task <a href="https://github.com/ita-social-projects/GreenCity/issues/4401">#4401</a>;