### PR TITLE
Feature/7958/add payment link to notification about unpaid order

### DIFF
--- a/core/src/main/java/greencity/UbsApplication.java
+++ b/core/src/main/java/greencity/UbsApplication.java
@@ -5,13 +5,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @EnableFeignClients
 @EnableCaching
-@EnableAsync
 public class UbsApplication {
     /**
      * Main method of SpringBoot app.

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -9,7 +9,6 @@ import greencity.dto.notification.NotificationDto;
 import greencity.dto.notification.NotificationShortDto;
 import greencity.dto.pageble.PageableDto;
 import greencity.service.ubs.NotificationService;
-import greencity.service.ubs.UBSClientServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -34,7 +33,6 @@ import java.util.Locale;
 @RequiredArgsConstructor
 public class NotificationController {
     private final NotificationService notificationService;
-    private final UBSClientServiceImpl ubsClientService;
 
     /**
      * Controller return body of the notification and set status - is read.

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -154,8 +154,9 @@ public class NotificationController {
         notificationService.deleteNotification(notificationId, userUuid);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
+
     @GetMapping("/triggerNotifyUnpaidOrder")
-    public ResponseEntity<HttpStatuses> triggerNotifyUnpaidOrder(){
+    public ResponseEntity<HttpStatuses> triggerNotifyUnpaidOrder() {
         ubsClientService.triggerNotifyUnpaidOrderPermanently();
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -154,10 +154,4 @@ public class NotificationController {
         notificationService.deleteNotification(notificationId, userUuid);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
-
-    @GetMapping("/triggerNotifyUnpaidOrder")
-    public ResponseEntity<HttpStatuses> triggerNotifyUnpaidOrder() {
-        ubsClientService.triggerNotifyUnpaidOrderPermanently();
-        return ResponseEntity.status(HttpStatus.OK).build();
-    }
 }

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -9,6 +9,7 @@ import greencity.dto.notification.NotificationDto;
 import greencity.dto.notification.NotificationShortDto;
 import greencity.dto.pageble.PageableDto;
 import greencity.service.ubs.NotificationService;
+import greencity.service.ubs.UBSClientServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -33,6 +34,7 @@ import java.util.Locale;
 @RequiredArgsConstructor
 public class NotificationController {
     private final NotificationService notificationService;
+    private final UBSClientServiceImpl ubsClientService;
 
     /**
      * Controller return body of the notification and set status - is read.
@@ -150,6 +152,11 @@ public class NotificationController {
     public ResponseEntity<Object> deleteNotification(@PathVariable Long notificationId,
         @Parameter(hidden = true) @CurrentUserUuid String userUuid) {
         notificationService.deleteNotification(notificationId, userUuid);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+    @GetMapping("/triggerNotifyUnpaidOrder")
+    public ResponseEntity<HttpStatuses> triggerNotifyUnpaidOrder(){
+        ubsClientService.triggerNotifyUnpaidOrderPermanently();
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/dao/src/main/java/greencity/repository/NotificationParameterRepository.java
+++ b/dao/src/main/java/greencity/repository/NotificationParameterRepository.java
@@ -1,9 +1,14 @@
 package greencity.repository;
 
 import greencity.entity.notifications.NotificationParameter;
+import greencity.entity.notifications.UserNotification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+import java.util.Set;
+
 @Repository
 public interface NotificationParameterRepository extends JpaRepository<NotificationParameter, Long> {
+    Optional<Set<NotificationParameter>> findNotificationParameterByUserNotification(UserNotification userNotification);
 }

--- a/dao/src/main/java/greencity/repository/NotificationParameterRepository.java
+++ b/dao/src/main/java/greencity/repository/NotificationParameterRepository.java
@@ -4,7 +4,6 @@ import greencity.entity.notifications.NotificationParameter;
 import greencity.entity.notifications.UserNotification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
 import java.util.Set;
 

--- a/dao/src/main/java/greencity/repository/UserNotificationRepository.java
+++ b/dao/src/main/java/greencity/repository/UserNotificationRepository.java
@@ -1,5 +1,6 @@
 package greencity.repository;
 
+import greencity.entity.order.Order;
 import greencity.enums.NotificationType;
 import greencity.entity.notifications.UserNotification;
 import greencity.entity.user.User;
@@ -90,4 +91,14 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
      *         false otherwise
      */
     boolean existsByIdAndUserIdAndIsDeletedFalse(Long notificationId, Long userId);
-}
+
+
+    /**
+     * Finds a {@link UserNotification} by the given {@link Order}.
+     *
+     * @param order the order to search for
+     * @return an optional containing the found notification, or an empty optional
+     *         if no notification for the given order was found
+     */
+    Optional<UserNotification> findUserNotificationByOrder(Order order);
+ }

--- a/dao/src/main/java/greencity/repository/UserNotificationRepository.java
+++ b/dao/src/main/java/greencity/repository/UserNotificationRepository.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 @Repository
 public interface UserNotificationRepository extends JpaRepository<UserNotification, Long> {
@@ -93,5 +92,13 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
      */
     boolean existsByIdAndUserIdAndIsDeletedFalse(Long notificationId, Long userId);
 
-    Optional<UserNotification> findUserNotificationByOrderAndNotificationType(Order order, NotificationType notificationType);
+    /**
+     * Finds a {@link UserNotification} by the given {@link Order}.
+     *
+     * @param order the order to search for
+     * @return an optional containing the found notification, or an empty optional
+     *         if no notification for the given order was found
+     */
+    Optional<UserNotification> findUserNotificationByOrderAndNotificationType(Order order,
+        NotificationType notificationType);
 }

--- a/dao/src/main/java/greencity/repository/UserNotificationRepository.java
+++ b/dao/src/main/java/greencity/repository/UserNotificationRepository.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface UserNotificationRepository extends JpaRepository<UserNotification, Long> {
@@ -92,12 +93,5 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
      */
     boolean existsByIdAndUserIdAndIsDeletedFalse(Long notificationId, Long userId);
 
-    /**
-     * Finds a {@link UserNotification} by the given {@link Order}.
-     *
-     * @param order the order to search for
-     * @return an optional containing the found notification, or an empty optional
-     *         if no notification for the given order was found
-     */
-    Optional<UserNotification> findUserNotificationByOrder(Order order);
+    Optional<UserNotification> findUserNotificationByOrderAndNotificationType(Order order, NotificationType notificationType);
 }

--- a/dao/src/main/java/greencity/repository/UserNotificationRepository.java
+++ b/dao/src/main/java/greencity/repository/UserNotificationRepository.java
@@ -92,7 +92,6 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
      */
     boolean existsByIdAndUserIdAndIsDeletedFalse(Long notificationId, Long userId);
 
-
     /**
      * Finds a {@link UserNotification} by the given {@link Order}.
      *
@@ -101,4 +100,4 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
      *         if no notification for the given order was found
      */
     Optional<UserNotification> findUserNotificationByOrder(Order order);
- }
+}

--- a/service-api/src/main/java/greencity/dto/payment/PaymentWayForPayRequestDto.java
+++ b/service-api/src/main/java/greencity/dto/payment/PaymentWayForPayRequestDto.java
@@ -42,4 +42,6 @@ public class PaymentWayForPayRequestDto {
     private List<Integer> productCount;
     @JsonProperty("merchantSignature")
     private String signature;
+    @JsonProperty("orderTimeout")
+    private Integer orderTimeout;
 }

--- a/service-api/src/main/java/greencity/dto/payment/monobank/MonoBankPaymentRequestDto.java
+++ b/service-api/src/main/java/greencity/dto/payment/monobank/MonoBankPaymentRequestDto.java
@@ -8,5 +8,6 @@ public record MonoBankPaymentRequestDto(
     Integer amount,
     @JsonProperty("merchantPaymInfo") MerchantPaymentInfo merchantPaymentInfo,
     String redirectUrl,
-    String webHookUrl) {
+    String webHookUrl,
+    Integer validity) {
 }

--- a/service-api/src/main/java/greencity/service/ubs/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/ubs/NotificationService.java
@@ -163,8 +163,8 @@ public interface NotificationService {
     /**
      * Method sends messages by e-mail/notification that order is unpaid.
      *
-     * @param order of {@link Order} Order which status was changed
-     * @param  paymentLink payment link
+     * @param order       of {@link Order} Order which status was changed
+     * @param paymentLink payment link
      * @author Vladyslav Haliara
      */
     void notifyUnpaidOrder(Order order, String paymentLink);

--- a/service-api/src/main/java/greencity/service/ubs/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/ubs/NotificationService.java
@@ -164,9 +164,10 @@ public interface NotificationService {
      * Method sends messages by e-mail/notification that order is unpaid.
      *
      * @param order of {@link Order} Order which status was changed
-     * @author Oleh Kulbaba
+     * @param  paymentLink payment link
+     * @author Vladyslav Haliara
      */
-    void notifyUnpaidOrder(Order order);
+    void notifyUnpaidOrder(Order order, String paymentLink);
 
     /**
      * Notifies the customer that the order status has been changed to "Brought by

--- a/service-api/src/main/java/greencity/service/ubs/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/ubs/NotificationService.java
@@ -2,6 +2,7 @@ package greencity.service.ubs;
 
 import greencity.dto.notification.NotificationDto;
 import greencity.dto.notification.NotificationShortDto;
+import greencity.dto.order.PaymentSystemResponse;
 import greencity.dto.pageble.PageableDto;
 import greencity.entity.order.Order;
 import greencity.entity.user.Violation;
@@ -238,10 +239,11 @@ public interface NotificationService {
      * Notify user that order has unpaid status when it was created and not paid.
      * This method is used one time when user create new order.
      *
-     * @param order    the order to send notification for
-     * @param sumToPay the sum to pay
+     * @param order                 the order to send notification for
+     * @param sumToPay              the sum to pay
+     * @param paymentSystemResponse payment system response with link to pay order
      *
      * @author Vladyslav Haliara
      */
-    void notifyUnpaidOrderPermanently(Order order, Long sumToPay);
+    void notifyUnpaidOrderPermanently(Order order, Long sumToPay, PaymentSystemResponse paymentSystemResponse);
 }

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -143,7 +143,7 @@ public class NotificationServiceImpl implements NotificationService {
                 notificationParameterRepository.findNotificationParameterByUserNotification(userNotification.get());
             if (notificationParameters.isPresent()) {
                 return notificationParameters.get().stream()
-                    .filter(param -> "payButton".equals(param.getKey()))
+                    .filter(param -> PAY_BUTTON.equals(param.getKey()))
                     .map(NotificationParameter::getValue)
                     .findFirst();
             }

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -126,9 +126,9 @@ public class NotificationServiceImpl implements NotificationService {
                 userNotification.setUser(order.getUser());
                 Double amountToPay = getAmountToPay(order);
                 Optional<String> paymentLink = getPaymentLink(order);
-                if (paymentLink.isPresent()){
+                if (paymentLink.isPresent()) {
                     Set<NotificationParameter> notificationParameters =
-                            initialiseNotificationParametersForUnpaidOrder(order, amountToPay, paymentLink.get());
+                        initialiseNotificationParametersForUnpaidOrder(order, amountToPay, paymentLink.get());
                     fillAndSendNotification(notificationParameters, order, NotificationType.UNPAID_ORDER);
                 }
             }

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -121,22 +121,23 @@ public class NotificationServiceImpl implements NotificationService {
     public void notifyUnpaidOrders() {
         for (Order order : orderRepository.findAllByOrderStatusNotAndOrderPaymentStatus(OrderStatus.CANCELED,
             OrderPaymentStatus.UNPAID)) {
-//            if (checkIfOrderNeedsNewNotification(order, NotificationType.UNPAID_ORDER)) {
+            if (checkIfOrderNeedsNewNotification(order, NotificationType.UNPAID_ORDER)) {
                 UserNotification userNotification = new UserNotification();
                 userNotification.setUser(order.getUser());
                 Double amountToPay = getAmountToPay(order);
                 Optional<String> paymentLink = getPaymentLink(order);
-                if (paymentLink.isPresent()) {
+                if (paymentLink.isPresent()){
                     Set<NotificationParameter> notificationParameters =
                             initialiseNotificationParametersForUnpaidOrder(order, amountToPay, paymentLink.get());
                     fillAndSendNotification(notificationParameters, order, NotificationType.UNPAID_ORDER);
                 }
-//            }
+            }
         }
     }
 
     private Optional<String> getPaymentLink(Order order) {
-        Optional<UserNotification> userNotification = userNotificationRepository.findUserNotificationByOrderAndNotificationType(order, NotificationType.UNPAID_ORDER);
+        Optional<UserNotification> userNotification = userNotificationRepository
+            .findUserNotificationByOrderAndNotificationType(order, NotificationType.UNPAID_ORDER);
         if (userNotification.isPresent()) {
             Optional<Set<NotificationParameter>> notificationParameters =
                 notificationParameterRepository.findNotificationParameterByUserNotification(userNotification.get());

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -133,24 +133,23 @@ public class NotificationServiceImpl implements NotificationService {
         }
     }
 
-    private Optional<String> getPaymentLink(Order order){
+    private Optional<String> getPaymentLink(Order order) {
         Optional<UserNotification> userNotification = userNotificationRepository.findUserNotificationByOrder(order);
         if (userNotification.isPresent()) {
             Optional<Set<NotificationParameter>> notificationParameters =
-                    notificationParameterRepository.findNotificationParameterByUserNotification(userNotification.get());
-            if (notificationParameters.isPresent()){
-                return  notificationParameters.get().stream()
-                        .filter(param -> "payButton".equals(param.getKey()))
-                        .map(NotificationParameter::getValue)
-                        .findFirst();
-
+                notificationParameterRepository.findNotificationParameterByUserNotification(userNotification.get());
+            if (notificationParameters.isPresent()) {
+                return notificationParameters.get().stream()
+                    .filter(param -> "payButton".equals(param.getKey()))
+                    .map(NotificationParameter::getValue)
+                    .findFirst();
             }
         }
         return Optional.empty();
     }
 
     private Set<NotificationParameter> initialiseNotificationParametersForUnpaidOrder(Order order, Double amountToPay,
-                                                                                      String payButtonLink) {
+        String payButtonLink) {
         Set<NotificationParameter> parameters = new HashSet<>();
 
         parameters.add(NotificationParameter.builder()
@@ -284,7 +283,8 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     public void notifyUnpaidOrder(Order order, String paymentLink) {
         Double amountToPay = getAmountToPay(order);
-        Set<NotificationParameter> parameters = initialiseNotificationParametersForUnpaidOrder(order, amountToPay, paymentLink);
+        Set<NotificationParameter> parameters =
+            initialiseNotificationParametersForUnpaidOrder(order, amountToPay, paymentLink);
 
         if (order.getOrderStatus() == OrderStatus.BROUGHT_IT_HIMSELF
             && order.getEvents().stream()

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -121,20 +121,22 @@ public class NotificationServiceImpl implements NotificationService {
     public void notifyUnpaidOrders() {
         for (Order order : orderRepository.findAllByOrderStatusNotAndOrderPaymentStatus(OrderStatus.CANCELED,
             OrderPaymentStatus.UNPAID)) {
-            if (checkIfOrderNeedsNewNotification(order, NotificationType.UNPAID_ORDER)) {
+//            if (checkIfOrderNeedsNewNotification(order, NotificationType.UNPAID_ORDER)) {
                 UserNotification userNotification = new UserNotification();
                 userNotification.setUser(order.getUser());
                 Double amountToPay = getAmountToPay(order);
-                String paymentLink = String.valueOf(getPaymentLink(order));
-                Set<NotificationParameter> notificationParameters =
-                    initialiseNotificationParametersForUnpaidOrder(order, amountToPay, paymentLink);
-                fillAndSendNotification(notificationParameters, order, NotificationType.UNPAID_ORDER);
-            }
+                Optional<String> paymentLink = getPaymentLink(order);
+                if (paymentLink.isPresent()) {
+                    Set<NotificationParameter> notificationParameters =
+                            initialiseNotificationParametersForUnpaidOrder(order, amountToPay, paymentLink.get());
+                    fillAndSendNotification(notificationParameters, order, NotificationType.UNPAID_ORDER);
+                }
+//            }
         }
     }
 
     private Optional<String> getPaymentLink(Order order) {
-        Optional<UserNotification> userNotification = userNotificationRepository.findUserNotificationByOrder(order);
+        Optional<UserNotification> userNotification = userNotificationRepository.findUserNotificationByOrderAndNotificationType(order, NotificationType.UNPAID_ORDER);
         if (userNotification.isPresent()) {
             Optional<Set<NotificationParameter>> notificationParameters =
                 notificationParameterRepository.findNotificationParameterByUserNotification(userNotification.get());

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -6,6 +6,7 @@ import greencity.constant.OrderHistory;
 import greencity.dto.notification.InactiveAccountDto;
 import greencity.dto.notification.NotificationDto;
 import greencity.dto.notification.NotificationShortDto;
+import greencity.dto.order.PaymentSystemResponse;
 import greencity.dto.pageble.PageableDto;
 import greencity.entity.notifications.NotificationPlatform;
 import greencity.entity.order.Bag;
@@ -68,6 +69,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import static greencity.constant.ErrorMessage.BAG_NOT_FOUND;
 import static greencity.constant.ErrorMessage.NOTIFICATION_DOES_NOT_BELONG_TO_USER;
@@ -131,8 +133,29 @@ public class NotificationServiceImpl implements NotificationService {
         }
     }
 
-    private Set<NotificationParameter> initialiseNotificationParametersForUnpaidOrder(Order order,
-        Double amountToPay) {
+    private Set<NotificationParameter> initialiseNotificationParametersForUnpaidOrder(Order order, Double amountToPay,
+        Supplier<String> payButtonLink) {
+        Set<NotificationParameter> parameters = new HashSet<>();
+
+        parameters.add(NotificationParameter.builder()
+            .key(AMOUNT_TO_PAY_KEY)
+            .value(String.format("%.2f", amountToPay))
+            .build());
+
+        parameters.add(NotificationParameter.builder()
+            .key(ORDER_NUMBER_KEY)
+            .value(order.getId().toString())
+            .build());
+
+        parameters.add(NotificationParameter.builder()
+            .key(PAY_BUTTON)
+            .value(payButtonLink.get())
+            .build());
+
+        return parameters;
+    }
+
+    private Set<NotificationParameter> initialiseNotificationParametersForUnpaidOrder(Order order, Double amountToPay) {
         Set<NotificationParameter> parameters = new HashSet<>();
 
         parameters.add(NotificationParameter.builder()
@@ -789,11 +812,13 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
-    public void notifyUnpaidOrderPermanently(Order order, Long amountToPay) {
+    public void notifyUnpaidOrderPermanently(Order order, Long amountToPay,
+        PaymentSystemResponse paymentSystemResponse) {
         boolean isOrderPayed = order.getOrderPaymentStatus() == OrderPaymentStatus.PAID;
         if (!isOrderPayed) {
             Double amount = amountToPay.doubleValue() / PERCENTAGE_DIVISOR;
-            Set<NotificationParameter> parameters = initialiseNotificationParametersForUnpaidOrder(order, amount);
+            Set<NotificationParameter> parameters = initialiseNotificationParametersForUnpaidOrder(order,
+                amount, () -> paymentSystemResponse.link());
             fillAndSendNotification(parameters, order, NotificationType.UNPAID_ORDER);
         }
     }

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -69,7 +69,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import static greencity.constant.ErrorMessage.BAG_NOT_FOUND;
 import static greencity.constant.ErrorMessage.NOTIFICATION_DOES_NOT_BELONG_TO_USER;
@@ -126,15 +125,32 @@ public class NotificationServiceImpl implements NotificationService {
                 UserNotification userNotification = new UserNotification();
                 userNotification.setUser(order.getUser());
                 Double amountToPay = getAmountToPay(order);
+                String paymentLink = String.valueOf(getPaymentLink(order));
                 Set<NotificationParameter> notificationParameters =
-                    initialiseNotificationParametersForUnpaidOrder(order, amountToPay);
+                    initialiseNotificationParametersForUnpaidOrder(order, amountToPay, paymentLink);
                 fillAndSendNotification(notificationParameters, order, NotificationType.UNPAID_ORDER);
             }
         }
     }
 
+    private Optional<String> getPaymentLink(Order order){
+        Optional<UserNotification> userNotification = userNotificationRepository.findUserNotificationByOrder(order);
+        if (userNotification.isPresent()) {
+            Optional<Set<NotificationParameter>> notificationParameters =
+                    notificationParameterRepository.findNotificationParameterByUserNotification(userNotification.get());
+            if (notificationParameters.isPresent()){
+                return  notificationParameters.get().stream()
+                        .filter(param -> "payButton".equals(param.getKey()))
+                        .map(NotificationParameter::getValue)
+                        .findFirst();
+
+            }
+        }
+        return Optional.empty();
+    }
+
     private Set<NotificationParameter> initialiseNotificationParametersForUnpaidOrder(Order order, Double amountToPay,
-        Supplier<String> payButtonLink) {
+                                                                                      String payButtonLink) {
         Set<NotificationParameter> parameters = new HashSet<>();
 
         parameters.add(NotificationParameter.builder()
@@ -149,7 +165,7 @@ public class NotificationServiceImpl implements NotificationService {
 
         parameters.add(NotificationParameter.builder()
             .key(PAY_BUTTON)
-            .value(payButtonLink.get())
+            .value(payButtonLink)
             .build());
 
         return parameters;
@@ -266,9 +282,9 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
-    public void notifyUnpaidOrder(Order order) {
+    public void notifyUnpaidOrder(Order order, String paymentLink) {
         Double amountToPay = getAmountToPay(order);
-        Set<NotificationParameter> parameters = initialiseNotificationParametersForUnpaidOrder(order, amountToPay);
+        Set<NotificationParameter> parameters = initialiseNotificationParametersForUnpaidOrder(order, amountToPay, paymentLink);
 
         if (order.getOrderStatus() == OrderStatus.BROUGHT_IT_HIMSELF
             && order.getEvents().stream()
@@ -818,7 +834,7 @@ public class NotificationServiceImpl implements NotificationService {
         if (!isOrderPayed) {
             Double amount = amountToPay.doubleValue() / PERCENTAGE_DIVISOR;
             Set<NotificationParameter> parameters = initialiseNotificationParametersForUnpaidOrder(order,
-                amount, () -> paymentSystemResponse.link());
+                amount, paymentSystemResponse.link());
             fillAndSendNotification(parameters, order, NotificationType.UNPAID_ORDER);
         }
     }

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -597,15 +597,6 @@ public class UBSClientServiceImpl implements UBSClientService {
         notificationServiceImpl.notifyUnpaidOrderPermanently(order, sumToPayInCoins, paymentSystemResponse);
     }
 
-    public void triggerNotifyUnpaidOrderPermanently() {
-        try {
-            Thread.sleep(3000);
-            notificationServiceImpl.notifyUnpaidOrders();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private PaymentSystemResponse processPayment(OrderResponseDto dto, Order order, long sumToPayInCoins,
         User currentUser) {
         return switch (dto.getPaymentSystem()) {

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -147,7 +147,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -581,21 +580,14 @@ public class UBSClientServiceImpl implements UBSClientService {
         getOrder(dto, currentUser, bagsOrdered, sumToPayInCoins, order, orderCertificates, userData);
         eventService.save(OrderHistory.ORDER_FORMED, OrderHistory.CLIENT, order);
         PaymentSystemResponse paymentSystemResponse = processPayment(dto, order, sumToPayInCoins, currentUser);
-
-        checkIfOrderIsNotPayedAndSendEmailAsync(order, sumToPayInCoins, paymentSystemResponse);
-
         notificationService.notifyCreatedOrder(order);
+
+        notificationServiceImpl.notifyUnpaidOrderPermanently(order, sumToPayInCoins, paymentSystemResponse);
 
         if (sumToPayInCoins <= 0 || !dto.isShouldBePaid()) {
             return getPaymentRequestDto(order, "");
         }
         return paymentSystemResponse;
-    }
-
-    @Async
-    public void checkIfOrderIsNotPayedAndSendEmailAsync(Order order, Long sumToPayInCoins,
-        PaymentSystemResponse paymentSystemResponse) {
-        notificationServiceImpl.notifyUnpaidOrderPermanently(order, sumToPayInCoins, paymentSystemResponse);
     }
 
     private PaymentSystemResponse processPayment(OrderResponseDto dto, Order order, long sumToPayInCoins,

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -151,7 +151,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
@@ -174,8 +173,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
-
-
 import static greencity.constant.AppConstant.ENROLLMENT_TO_THE_BONUS_ACCOUNT_ENG;
 import static greencity.constant.AppConstant.UBS_EMPLOYEE_WITH_PREFIX;
 import static greencity.constant.AppConstant.USER_WITH_PREFIX;
@@ -594,13 +591,13 @@ public class UBSClientServiceImpl implements UBSClientService {
         return paymentSystemResponse;
     }
 
-
     @Async
     public void checkIfOrderIsNotPayedAndSendEmailAsync(Order order, Long sumToPayInCoins,
         PaymentSystemResponse paymentSystemResponse) {
         notificationServiceImpl.notifyUnpaidOrderPermanently(order, sumToPayInCoins, paymentSystemResponse);
     }
-    public void triggerNotifyUnpaidOrderPermanently(){
+
+    public void triggerNotifyUnpaidOrderPermanently() {
         try {
             Thread.sleep(3000);
             notificationServiceImpl.notifyUnpaidOrders();

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -577,8 +577,9 @@ public class UBSClientServiceImpl implements UBSClientService {
 
         getOrder(dto, currentUser, bagsOrdered, sumToPayInCoins, order, orderCertificates, userData);
         eventService.save(OrderHistory.ORDER_FORMED, OrderHistory.CLIENT, order);
+        PaymentSystemResponse paymentSystemResponse = processPayment(dto, order, sumToPayInCoins, currentUser);
 
-        checkIfOrderIsNotPayedAndSendEmailAsync(order, sumToPayInCoins);
+        checkIfOrderIsNotPayedAndSendEmailAsync(order, sumToPayInCoins, paymentSystemResponse);
 
         notificationService.notifyCreatedOrder(order);
 
@@ -586,12 +587,13 @@ public class UBSClientServiceImpl implements UBSClientService {
             return getPaymentRequestDto(order, "");
         }
 
-        return processPayment(dto, order, sumToPayInCoins, currentUser);
+        return paymentSystemResponse;
     }
 
     @Async
-    public void checkIfOrderIsNotPayedAndSendEmailAsync(Order order, Long sumToPayInCoins) {
-        notificationServiceImpl.notifyUnpaidOrderPermanently(order, sumToPayInCoins);
+    public void checkIfOrderIsNotPayedAndSendEmailAsync(Order order, Long sumToPayInCoins,
+        PaymentSystemResponse paymentSystemResponse) {
+        notificationServiceImpl.notifyUnpaidOrderPermanently(order, sumToPayInCoins, paymentSystemResponse);
     }
 
     private PaymentSystemResponse processPayment(OrderResponseDto dto, Order order, long sumToPayInCoins,

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -231,6 +231,7 @@ import static java.util.stream.Collectors.toMap;
 public class UBSClientServiceImpl implements UBSClientService {
     private static final Long CITY_ID_KIEV = 3L;
     private static final String KYIV_CITY = "Kyiv City";
+    private static final Integer VALIDITY_DURATION_TEN_DAYS = 864000;
     private final UserRepository userRepository;
     private final BagRepository bagRepository;
     private final UBSUserRepository ubsUserRepository;
@@ -632,6 +633,7 @@ public class UBSClientServiceImpl implements UBSClientService {
                 .build())
             .redirectUrl(monoBankRedirectionUrl)
             .webHookUrl(monoBankPaymentRedirectUrl)
+            .validity(VALIDITY_DURATION_TEN_DAYS)
             .build();
     }
 

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -1267,6 +1267,7 @@ public class UBSClientServiceImpl implements UBSClientService {
             .orderDate(instant.getEpochSecond())
             .amount(convertCoinsIntoBills(sumToPayInCoins).intValue())
             .currency("UAH")
+            .orderTimeout(VALIDITY_DURATION_TEN_DAYS)
             .productName(order.getOrderBags().stream()
                 .filter(bag -> bag.getAmount() != 0)
                 .map(orderBag -> orderBag.getName().trim())

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -86,6 +86,7 @@ import greencity.entity.user.ubs.UBSuser;
 import greencity.entity.viber.ViberBot;
 import greencity.enums.AddressStatus;
 import greencity.enums.BagStatus;
+import greencity.enums.BonusReason;
 import greencity.enums.BotType;
 import greencity.enums.CertificateStatus;
 import greencity.enums.CourierLimit;
@@ -96,7 +97,6 @@ import greencity.enums.OrderStatus;
 import greencity.enums.PaymentStatus;
 import greencity.enums.PaymentType;
 import greencity.enums.TariffStatus;
-import greencity.enums.BonusReason;
 import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.address.AddressNotWithinLocationAreaException;
@@ -105,6 +105,7 @@ import greencity.exceptions.http.AccessDeniedException;
 import greencity.exceptions.user.UBSuserNotFoundException;
 import greencity.exceptions.user.UserNotFoundException;
 import greencity.mapping.location.LocationToLocationsDtoMapper;
+import greencity.notificator.UnpaidOrderNotificator;
 import greencity.repository.AddressRepository;
 import greencity.repository.BagRepository;
 import greencity.repository.CertificateRepository;
@@ -150,6 +151,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
@@ -172,6 +174,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
+
+
 import static greencity.constant.AppConstant.ENROLLMENT_TO_THE_BONUS_ACCOUNT_ENG;
 import static greencity.constant.AppConstant.UBS_EMPLOYEE_WITH_PREFIX;
 import static greencity.constant.AppConstant.USER_WITH_PREFIX;
@@ -265,6 +269,7 @@ public class UBSClientServiceImpl implements UBSClientService {
     private final DistrictRepository districtRepository;
     private final MonoBankClient monoBankClient;
     private final NotificationServiceImpl notificationServiceImpl;
+    private final UnpaidOrderNotificator unpaidOrderNotificator;
 
     @Value("${greencity.bots.viber-bot-uri}")
     private String viberBotUri;
@@ -586,14 +591,22 @@ public class UBSClientServiceImpl implements UBSClientService {
         if (sumToPayInCoins <= 0 || !dto.isShouldBePaid()) {
             return getPaymentRequestDto(order, "");
         }
-
         return paymentSystemResponse;
     }
+
 
     @Async
     public void checkIfOrderIsNotPayedAndSendEmailAsync(Order order, Long sumToPayInCoins,
         PaymentSystemResponse paymentSystemResponse) {
         notificationServiceImpl.notifyUnpaidOrderPermanently(order, sumToPayInCoins, paymentSystemResponse);
+    }
+    public void triggerNotifyUnpaidOrderPermanently(){
+        try {
+            Thread.sleep(3000);
+            notificationServiceImpl.notifyUnpaidOrders();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private PaymentSystemResponse processPayment(OrderResponseDto dto, Order order, long sumToPayInCoins,

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1298,18 +1298,17 @@ public class UBSManagementServiceImpl implements UBSManagementService {
 
             if (userNotification.isPresent()) {
                 Optional<Set<NotificationParameter>> notificationParameters =
-                        notificationParameterRepository.findNotificationParameterByUserNotification(userNotification.get());
+                    notificationParameterRepository.findNotificationParameterByUserNotification(userNotification.get());
                 if (notificationParameters.isPresent()) {
                     Optional<String> paymentLink = notificationParameters.get().stream()
-                            .filter(param -> "payButton".equals(param.getKey()))
-                            .map(NotificationParameter::getValue)
-                            .findFirst();
+                        .filter(param -> "payButton".equals(param.getKey()))
+                        .map(NotificationParameter::getValue)
+                        .findFirst();
 
                     notificationService.notifyUnpaidOrder(order, paymentLink.orElse(null));
                 }
             }
         }
-
     }
 
     /**

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -37,7 +37,6 @@ import greencity.dto.order.OrderInfoDto;
 import greencity.dto.order.OrderPaymentStatusesTranslationDto;
 import greencity.dto.order.OrderStatusPageDto;
 import greencity.dto.order.OrderStatusesTranslationDto;
-import greencity.dto.order.PaymentSystemResponse;
 import greencity.dto.order.ReadAddressByOrderDto;
 import greencity.dto.order.UpdateAllOrderPageDto;
 import greencity.dto.order.UpdateOrderPageAdminDto;
@@ -178,6 +177,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     private final OrderBagRepository orderBagRepository;
     private final UserNotificationRepository userNotificationRepository;
     private final NotificationParameterRepository notificationParameterRepository;
+    private static final String PAY_BUTTON = "payButton";
 
     /**
      * {@inheritDoc}
@@ -1295,22 +1295,17 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             }
         }
         if (order.getOrderPaymentStatus().equals(OrderPaymentStatus.UNPAID)) {
-            Optional<UserNotification> userNotification = userNotificationRepository
-                .findUserNotificationByOrderAndNotificationType(order, NotificationType.UNPAID_ORDER);
-
-            if (userNotification.isPresent()) {
-                Optional<Set<NotificationParameter>> notificationParameters =
-                    notificationParameterRepository.findNotificationParameterByUserNotification(userNotification.get());
-                if (notificationParameters.isPresent()) {
-                    Optional<String> paymentLink = notificationParameters.get().stream()
-                        .filter(param -> "payButton".equals(param.getKey()))
-                        .map(NotificationParameter::getValue)
-                        .findFirst();
-
-                    notificationService.notifyUnpaidOrder(order, paymentLink.orElse(null));
-                }
-            }
+            userNotificationRepository.findUserNotificationByOrderAndNotificationType(order, NotificationType.UNPAID_ORDER)
+                    .flatMap(userNotification ->
+                            notificationParameterRepository.findNotificationParameterByUserNotification(userNotification)
+                                    .flatMap(params ->
+                                            params.stream()
+                                                    .filter(param -> PAY_BUTTON.equals(param.getKey()))
+                                                    .map(NotificationParameter::getValue)
+                                                    .findFirst()))
+                    .ifPresent(paymentLink -> notificationService.notifyUnpaidOrder(order, paymentLink));
         }
+
     }
 
     /**

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1305,7 +1305,6 @@ public class UBSManagementServiceImpl implements UBSManagementService {
                         .findFirst()))
                 .ifPresent(paymentLink -> notificationService.notifyUnpaidOrder(order, paymentLink));
         }
-
     }
 
     /**

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -46,7 +46,6 @@ import greencity.dto.user.AddingPointsToUserDto;
 import greencity.dto.user.UserInfoDto;
 import greencity.dto.violation.ViolationsInfoDto;
 import greencity.entity.notifications.NotificationParameter;
-import greencity.entity.notifications.UserNotification;
 import greencity.entity.order.Bag;
 import greencity.entity.order.BigOrderTableViews;
 import greencity.entity.order.Certificate;

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -65,6 +65,7 @@ import greencity.entity.user.employee.ReceivingStation;
 import greencity.entity.user.ubs.Address;
 import greencity.entity.user.ubs.OrderAddress;
 import greencity.enums.CancellationReason;
+import greencity.enums.NotificationType;
 import greencity.enums.OrderPaymentStatus;
 import greencity.enums.OrderStatus;
 import greencity.enums.PaymentStatus;
@@ -1294,7 +1295,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             }
         }
         if (order.getOrderPaymentStatus().equals(OrderPaymentStatus.UNPAID)) {
-            Optional<UserNotification> userNotification = userNotificationRepository.findUserNotificationByOrder(order);
+            Optional<UserNotification> userNotification = userNotificationRepository.findUserNotificationByOrderAndNotificationType(order, NotificationType.UNPAID_ORDER);
 
             if (userNotification.isPresent()) {
                 Optional<Set<NotificationParameter>> notificationParameters =

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1295,7 +1295,8 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             }
         }
         if (order.getOrderPaymentStatus().equals(OrderPaymentStatus.UNPAID)) {
-            Optional<UserNotification> userNotification = userNotificationRepository.findUserNotificationByOrderAndNotificationType(order, NotificationType.UNPAID_ORDER);
+            Optional<UserNotification> userNotification = userNotificationRepository
+                .findUserNotificationByOrderAndNotificationType(order, NotificationType.UNPAID_ORDER);
 
             if (userNotification.isPresent()) {
                 Optional<Set<NotificationParameter>> notificationParameters =

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -1295,15 +1295,15 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             }
         }
         if (order.getOrderPaymentStatus().equals(OrderPaymentStatus.UNPAID)) {
-            userNotificationRepository.findUserNotificationByOrderAndNotificationType(order, NotificationType.UNPAID_ORDER)
-                    .flatMap(userNotification ->
-                            notificationParameterRepository.findNotificationParameterByUserNotification(userNotification)
-                                    .flatMap(params ->
-                                            params.stream()
-                                                    .filter(param -> PAY_BUTTON.equals(param.getKey()))
-                                                    .map(NotificationParameter::getValue)
-                                                    .findFirst()))
-                    .ifPresent(paymentLink -> notificationService.notifyUnpaidOrder(order, paymentLink));
+            userNotificationRepository
+                .findUserNotificationByOrderAndNotificationType(order, NotificationType.UNPAID_ORDER)
+                .flatMap(userNotification -> notificationParameterRepository
+                    .findNotificationParameterByUserNotification(userNotification)
+                    .flatMap(params -> params.stream()
+                        .filter(param -> PAY_BUTTON.equals(param.getKey()))
+                        .map(NotificationParameter::getValue)
+                        .findFirst()))
+                .ifPresent(paymentLink -> notificationService.notifyUnpaidOrder(order, paymentLink));
         }
 
     }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -37,6 +37,7 @@ import greencity.dto.order.OrderInfoDto;
 import greencity.dto.order.OrderPaymentStatusesTranslationDto;
 import greencity.dto.order.OrderStatusPageDto;
 import greencity.dto.order.OrderStatusesTranslationDto;
+import greencity.dto.order.PaymentSystemResponse;
 import greencity.dto.order.ReadAddressByOrderDto;
 import greencity.dto.order.UpdateAllOrderPageDto;
 import greencity.dto.order.UpdateOrderPageAdminDto;
@@ -45,6 +46,8 @@ import greencity.dto.position.PositionDto;
 import greencity.dto.user.AddingPointsToUserDto;
 import greencity.dto.user.UserInfoDto;
 import greencity.dto.violation.ViolationsInfoDto;
+import greencity.entity.notifications.NotificationParameter;
+import greencity.entity.notifications.UserNotification;
 import greencity.entity.order.Bag;
 import greencity.entity.order.BigOrderTableViews;
 import greencity.entity.order.Certificate;
@@ -74,6 +77,7 @@ import greencity.repository.CertificateRepository;
 import greencity.repository.EmployeeOrderPositionRepository;
 import greencity.repository.EmployeeRepository;
 import greencity.repository.EventRepository;
+import greencity.repository.NotificationParameterRepository;
 import greencity.repository.OrderAddressRepository;
 import greencity.repository.OrderBagRepository;
 import greencity.repository.OrderDetailRepository;
@@ -85,6 +89,7 @@ import greencity.repository.PositionRepository;
 import greencity.repository.ReceivingStationRepository;
 import greencity.repository.ServiceRepository;
 import greencity.repository.TariffsInfoRepository;
+import greencity.repository.UserNotificationRepository;
 import greencity.repository.UserRepository;
 import greencity.service.locations.LocationApiService;
 import greencity.service.notification.NotificationServiceImpl;
@@ -170,6 +175,8 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     static final String FORMAT_DATE = "dd-MM-yyyy";
     private final UBSClientService ubsClientService;
     private final OrderBagRepository orderBagRepository;
+    private final UserNotificationRepository userNotificationRepository;
+    private final NotificationParameterRepository notificationParameterRepository;
 
     /**
      * {@inheritDoc}
@@ -1287,8 +1294,22 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             }
         }
         if (order.getOrderPaymentStatus().equals(OrderPaymentStatus.UNPAID)) {
-            notificationService.notifyUnpaidOrder(order);
+            Optional<UserNotification> userNotification = userNotificationRepository.findUserNotificationByOrder(order);
+
+            if (userNotification.isPresent()) {
+                Optional<Set<NotificationParameter>> notificationParameters =
+                        notificationParameterRepository.findNotificationParameterByUserNotification(userNotification.get());
+                if (notificationParameters.isPresent()) {
+                    Optional<String> paymentLink = notificationParameters.get().stream()
+                            .filter(param -> "payButton".equals(param.getKey()))
+                            .map(NotificationParameter::getValue)
+                            .findFirst();
+
+                    notificationService.notifyUnpaidOrder(order, paymentLink.orElse(null));
+                }
+            }
         }
+
     }
 
     /**

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2861,6 +2861,12 @@ public class ModelUtils {
             .build();
     }
 
+    public static Set<NotificationParameter> getNotificationParameterSet() {
+        Set<NotificationParameter> parameters = new HashSet<>();
+        parameters.add(NotificationParameter.builder().key("payButton").value("https://pay.monobank.ua/api").build());
+        return parameters;
+    }
+
     private static Set<NotificationParameter> createNotificationParameterSet2() {
         Set<NotificationParameter> parameters = new HashSet<>();
 

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -293,7 +293,7 @@ class NotificationServiceImplTest {
 
             assertDoesNotThrow(() -> notificationService.notifyUnpaidOrderPermanently(mockUserNotification.getOrder(),
                 amountToPay.longValue(), PaymentSystemResponse.builder()
-                            .orderId(1L).link(paymentLink).build()));
+                    .orderId(1L).link(paymentLink).build()));
 
             verify(userNotificationRepository).save(any(UserNotification.class));
             verify(notificationParameterRepository).saveAll(any());

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -290,7 +290,6 @@ class NotificationServiceImplTest {
 
         @Test
         void notifyUnpaidOrderPermanentlyTest() {
-            String orderUrl = getUnpaidOrderUrl();
             Double amountToPay = 10000.0;
 
             when(mockOrder.getOrderPaymentStatus()).thenReturn(OrderPaymentStatus.UNPAID);

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -6,6 +6,7 @@ import greencity.config.InternalUrlConfigProp;
 import greencity.constant.ErrorMessage;
 import greencity.dto.notification.NotificationDto;
 import greencity.dto.notification.NotificationShortDto;
+import greencity.dto.order.PaymentSystemResponse;
 import greencity.dto.pageble.PageableDto;
 import greencity.entity.order.Event;
 import greencity.enums.NotificationTrigger;
@@ -277,25 +278,26 @@ class NotificationServiceImplTest {
             verify(notificationParameterRepository).saveAll(Set.of(orderNumber));
         }
 
-//        @Test
-//        void notifyUnpaidOrderPermanentlyTest() {
-//            String orderUrl = getUnpaidOrderUrl();
-//
-//            Double amountToPay = 10000.0;
-//            when(mockOrder.getOrderPaymentStatus()).thenReturn(OrderPaymentStatus.UNPAID);
-//            when(mockUserNotification.getOrder()).thenReturn(mockOrder);
-//            when(internalUrlConfigProp.getOrderUrl()).thenReturn(orderUrl);
-//            when(userNotificationRepository.save(any(UserNotification.class))).thenReturn(mockUserNotification);
-//            when(notificationParameterRepository.saveAll(any())).thenAnswer(invocation -> {
-//                return new ArrayList<>(invocation.getArgument(0));
-//            });
-//
-//            assertDoesNotThrow(() -> notificationService.notifyUnpaidOrderPermanently(mockUserNotification.getOrder(),
-//                amountToPay.longValue()));
-//
-//            verify(userNotificationRepository).save(any(UserNotification.class));
-//            verify(notificationParameterRepository).saveAll(any());
-//        }
+        @Test
+        void notifyUnpaidOrderPermanentlyTest() {
+            String orderUrl = getUnpaidOrderUrl();
+
+            Double amountToPay = 10000.0;
+            String paymentLink = "https://pay.monobank.ua/2412255Qb57omFE7dAjC";
+            when(mockOrder.getOrderPaymentStatus()).thenReturn(OrderPaymentStatus.UNPAID);
+            when(mockUserNotification.getOrder()).thenReturn(mockOrder);
+            when(userNotificationRepository.save(any(UserNotification.class))).thenReturn(mockUserNotification);
+            when(notificationParameterRepository.saveAll(any())).thenAnswer(invocation -> {
+                return new ArrayList<>(invocation.getArgument(0));
+            });
+
+            assertDoesNotThrow(() -> notificationService.notifyUnpaidOrderPermanently(mockUserNotification.getOrder(),
+                amountToPay.longValue(), PaymentSystemResponse.builder()
+                            .orderId(1L).link(paymentLink).build()));
+
+            verify(userNotificationRepository).save(any(UserNotification.class));
+            verify(notificationParameterRepository).saveAll(any());
+        }
 
         @Test
         void testNotifyCourierItineraryFormed() {

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -232,18 +232,27 @@ class NotificationServiceImplTest {
             created.setNotificationTime(LocalDateTime.now(fixedClock));
             created.setUser(getUser());
             created.setId(1L);
+            created.setOrder(orders.get(0));
 
             when(userNotificationRepository.save(any())).thenReturn(created);
 
-            List<NotificationParameter> notificationParameters = List.of(
+            Set<NotificationParameter> notificationParameters = Set.of(
                 NotificationParameter.builder().id(1L)
                     .userNotification(created).key("orderNumber")
                     .value(orders.getFirst().getId().toString()).build(),
                 NotificationParameter.builder().id(2L)
                     .userNotification(created).key("amountToPay")
-                    .value("10000").build());
-
-            when(notificationParameterRepository.saveAll(any())).thenReturn(notificationParameters);
+                    .value("10000").build(),
+                NotificationParameter.builder().id(3L)
+                    .userNotification(created).key("payButton")
+                    .value(PAYMENT_LINK).build());
+            List<NotificationParameter> notificationParameterList = new ArrayList<>(notificationParameters);
+            when(notificationParameterRepository.saveAll(any())).thenReturn(notificationParameterList);
+            when(userNotificationRepository.findUserNotificationByOrderAndNotificationType(any(Order.class),
+                any(NotificationType.class))).thenReturn(Optional.of(created));
+            when(notificationParameterRepository
+                .findNotificationParameterByUserNotification(any(UserNotification.class)))
+                .thenReturn(Optional.of(notificationParameters));
 
             notificationService.notifyUnpaidOrders();
 

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -83,7 +83,6 @@ import static greencity.ModelUtils.TEST_USER_NOTIFICATION_5;
 import static greencity.ModelUtils.TEST_USER_NOTIFICATION_6;
 import static greencity.ModelUtils.TEST_USER_NOTIFICATION_7;
 import static greencity.ModelUtils.TEST_VIOLATION;
-import static greencity.ModelUtils.getUnpaidOrderUrl;
 import static greencity.ModelUtils.getNotifyInternallyFormedOrder;
 import static greencity.ModelUtils.createUserNotificationForViolationWithParameters;
 import static greencity.ModelUtils.createViolationNotificationDto;

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -129,6 +129,7 @@ class NotificationServiceImplTest {
     private static final String END_TIME_KEY = "endTime";
     private static final String PHONE_NUMBER_KEY = "phoneNumber";
     private static final String CUSTOMER = "customerName";
+    private static final String PAYMENT_LINK = "https://pay.monobank.ua/2412255Qb57omFE7dAjC";
 
     @Mock
     private OrderRepository orderRepository;
@@ -281,9 +282,8 @@ class NotificationServiceImplTest {
         @Test
         void notifyUnpaidOrderPermanentlyTest() {
             String orderUrl = getUnpaidOrderUrl();
-
             Double amountToPay = 10000.0;
-            String paymentLink = "https://pay.monobank.ua/2412255Qb57omFE7dAjC";
+
             when(mockOrder.getOrderPaymentStatus()).thenReturn(OrderPaymentStatus.UNPAID);
             when(mockUserNotification.getOrder()).thenReturn(mockOrder);
             when(userNotificationRepository.save(any(UserNotification.class))).thenReturn(mockUserNotification);
@@ -293,7 +293,7 @@ class NotificationServiceImplTest {
 
             assertDoesNotThrow(() -> notificationService.notifyUnpaidOrderPermanently(mockUserNotification.getOrder(),
                 amountToPay.longValue(), PaymentSystemResponse.builder()
-                    .orderId(1L).link(paymentLink).build()));
+                    .orderId(1L).link(PAYMENT_LINK).build()));
 
             verify(userNotificationRepository).save(any(UserNotification.class));
             verify(notificationParameterRepository).saveAll(any());
@@ -1133,7 +1133,6 @@ class NotificationServiceImplTest {
         order.setPointsToUse(0);
         order.setCertificates(Collections.emptySet());
         Set<NotificationParameter> parameters = new HashSet<>();
-
         UserNotification notification = new UserNotification();
         notification.setNotificationType(NotificationType.ORDER_STATUS_CHANGED);
         notification.setUser(user);
@@ -1142,8 +1141,7 @@ class NotificationServiceImplTest {
         when(userNotificationRepository.save(any())).thenReturn(notification);
         when(notificationParameterRepository.saveAll(any())).thenReturn(new ArrayList<>(parameters));
         when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
-
-        notificationService.notifyUnpaidOrder(order);
+        notificationService.notifyUnpaidOrder(order, PAYMENT_LINK);
 
         verify(userNotificationRepository).save(any());
         verify(notificationParameterRepository).saveAll(any());
@@ -1173,7 +1171,7 @@ class NotificationServiceImplTest {
         when(userNotificationRepository.save(any())).thenReturn(notification);
         when(notificationParameterRepository.saveAll(any())).thenReturn(new ArrayList<>(parameters));
         when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
-        notificationService.notifyUnpaidOrder(order);
+        notificationService.notifyUnpaidOrder(order,PAYMENT_LINK);
 
         verify(userNotificationRepository).save(any());
         verify(notificationParameterRepository).saveAll(any());
@@ -1205,7 +1203,7 @@ class NotificationServiceImplTest {
         when(notificationParameterRepository.saveAll(any())).thenReturn(new ArrayList<>(parameters));
         when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
 
-        notificationService.notifyUnpaidOrder(order);
+        notificationService.notifyUnpaidOrder(order, PAYMENT_LINK);
 
         verify(userNotificationRepository).save(any());
         verify(notificationParameterRepository).saveAll(any());

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -277,25 +277,25 @@ class NotificationServiceImplTest {
             verify(notificationParameterRepository).saveAll(Set.of(orderNumber));
         }
 
-        @Test
-        void notifyUnpaidOrderPermanentlyTest() {
-            String orderUrl = getUnpaidOrderUrl();
-
-            Double amountToPay = 10000.0;
-            when(mockOrder.getOrderPaymentStatus()).thenReturn(OrderPaymentStatus.UNPAID);
-            when(mockUserNotification.getOrder()).thenReturn(mockOrder);
-            when(internalUrlConfigProp.getOrderUrl()).thenReturn(orderUrl);
-            when(userNotificationRepository.save(any(UserNotification.class))).thenReturn(mockUserNotification);
-            when(notificationParameterRepository.saveAll(any())).thenAnswer(invocation -> {
-                return new ArrayList<>(invocation.getArgument(0));
-            });
-
-            assertDoesNotThrow(() -> notificationService.notifyUnpaidOrderPermanently(mockUserNotification.getOrder(),
-                amountToPay.longValue()));
-
-            verify(userNotificationRepository).save(any(UserNotification.class));
-            verify(notificationParameterRepository).saveAll(any());
-        }
+//        @Test
+//        void notifyUnpaidOrderPermanentlyTest() {
+//            String orderUrl = getUnpaidOrderUrl();
+//
+//            Double amountToPay = 10000.0;
+//            when(mockOrder.getOrderPaymentStatus()).thenReturn(OrderPaymentStatus.UNPAID);
+//            when(mockUserNotification.getOrder()).thenReturn(mockOrder);
+//            when(internalUrlConfigProp.getOrderUrl()).thenReturn(orderUrl);
+//            when(userNotificationRepository.save(any(UserNotification.class))).thenReturn(mockUserNotification);
+//            when(notificationParameterRepository.saveAll(any())).thenAnswer(invocation -> {
+//                return new ArrayList<>(invocation.getArgument(0));
+//            });
+//
+//            assertDoesNotThrow(() -> notificationService.notifyUnpaidOrderPermanently(mockUserNotification.getOrder(),
+//                amountToPay.longValue()));
+//
+//            verify(userNotificationRepository).save(any(UserNotification.class));
+//            verify(notificationParameterRepository).saveAll(any());
+//        }
 
         @Test
         void testNotifyCourierItineraryFormed() {

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -1171,7 +1171,7 @@ class NotificationServiceImplTest {
         when(userNotificationRepository.save(any())).thenReturn(notification);
         when(notificationParameterRepository.saveAll(any())).thenReturn(new ArrayList<>(parameters));
         when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
-        notificationService.notifyUnpaidOrder(order,PAYMENT_LINK);
+        notificationService.notifyUnpaidOrder(order, PAYMENT_LINK);
 
         verify(userNotificationRepository).save(any());
         verify(notificationParameterRepository).saveAll(any());

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -36,6 +36,7 @@ import greencity.dto.pageble.PageableDto;
 import greencity.dto.payment.PaymentResponseDto;
 import greencity.dto.payment.PaymentResponseWayForPay;
 import greencity.dto.payment.PaymentWayForPayRequestDto;
+import greencity.dto.payment.monobank.CheckoutResponseFromMonoBank;
 import greencity.dto.payment.monobank.MonoBankPaymentRequestDto;
 import greencity.dto.payment.monobank.MonoBankPaymentResponseDto;
 import greencity.dto.position.PositionAuthoritiesDto;
@@ -1138,7 +1139,7 @@ class UBSClientServiceImplTest {
                 f.set(ubsService, "1");
             }
         }
-
+        Optional<Order> optionalOrder = Optional.of(order);
         when(userRepository.findByUuid("35467585763t4sfgchjfuyetf")).thenReturn(user);
         when(addressRepository.findById(anyLong())).thenReturn(Optional.of(ModelUtils.getAddress()));
         when(tariffsInfoRepository.findTariffsInfoByBagIdAndLocationId(anyList(), anyLong()))
@@ -1146,10 +1147,13 @@ class UBSClientServiceImplTest {
         when(bagRepository.findActiveBagById(any())).thenReturn(Optional.of(bag));
         when(certificateRepository.findById(anyString())).thenReturn(Optional.of(certificate));
         when(ubsUserRepository.findById(1L)).thenReturn(Optional.of(ubSuser));
-        when(modelMapper.map(dto, Order.class)).thenReturn(order);
         when(modelMapper.map(dto.getPersonalData(), UBSuser.class)).thenReturn(ubSuser);
+        when(orderRepository.findById(any()))
+            .thenReturn(optionalOrder.get().getId() != null ? optionalOrder : Optional.empty());
+        when(monoBankClient.getCheckoutResponse(any(MonoBankPaymentRequestDto.class), eq(token)))
+            .thenReturn(getCheckoutResponseFromMonoBank());
 
-        PaymentSystemResponse result = ubsService.saveFullOrderToDB(dto, "35467585763t4sfgchjfuyetf", null);
+        PaymentSystemResponse result = ubsService.saveFullOrderToDB(dto, "35467585763t4sfgchjfuyetf", order.getId());
         Assertions.assertNotNull(result);
 
     }
@@ -1440,7 +1444,9 @@ class UBSClientServiceImplTest {
         when(bagRepository.findActiveBagById(any())).thenReturn(Optional.of(bag));
         when(ubsUserRepository.findById(1L)).thenReturn(Optional.of(ubSuser));
         when(modelMapper.map(dto.getPersonalData(), UBSuser.class)).thenReturn(ubSuser);
-        when(orderRepository.findById(any())).thenReturn(Optional.of(order1));
+        when(orderRepository.findById(any())).thenReturn(Optional.of(order));
+        when(monoBankClient.getCheckoutResponse(any(MonoBankPaymentRequestDto.class), eq(token)))
+            .thenReturn(getCheckoutResponseFromMonoBank());
 
         PaymentSystemResponse result = ubsService.saveFullOrderToDB(dto, "35467585763t4sfgchjfuyetf", 1L);
         Assertions.assertNotNull(result);
@@ -1450,7 +1456,7 @@ class UBSClientServiceImplTest {
             .findTariffsInfoByBagIdAndLocationId(anyList(), anyLong());
         verify(ubsUserRepository, times(1)).findById(anyLong());
         verify(modelMapper, times(1)).map(dto.getPersonalData(), UBSuser.class);
-        verify(orderRepository, times(1)).findById(anyLong());
+        verify(orderRepository, times(2)).findById(anyLong());
     }
 
     @Test
@@ -2961,6 +2967,7 @@ class UBSClientServiceImplTest {
                 f.set(ubsService, "1");
             }
         }
+        Optional<Order> optionalOrder = Optional.of(order);
         TariffsInfo tariffsInfo = getTariffsInfo();
         bag.setTariffsInfo(tariffsInfo);
         tariffsInfo.setBags(List.of(bag));
@@ -2973,11 +2980,14 @@ class UBSClientServiceImplTest {
         when(ubsUserRepository.findById(1L)).thenReturn(Optional.of(ubSuser));
         when(addressRepository.findById(any())).thenReturn(Optional.of(address));
         when(locationRepository.findById(anyLong())).thenReturn(Optional.of(location));
-        when(modelMapper.map(dto, Order.class)).thenReturn(order);
         when(modelMapper.map(dto.getPersonalData(), UBSuser.class)).thenReturn(ubSuser);
         when(modelMapper.map(address, OrderAddress.class)).thenReturn(orderAddress);
+        when(orderRepository.findById(anyLong()))
+            .thenReturn(optionalOrder.get().getId() == null ? Optional.empty() : optionalOrder);
+        when(monoBankClient.getCheckoutResponse(any(MonoBankPaymentRequestDto.class), eq(token)))
+            .thenReturn(getCheckoutResponseFromMonoBank());
 
-        PaymentSystemResponse result = ubsService.saveFullOrderToDB(dto, "35467585763t4sfgchjfuyetf", null);
+        PaymentSystemResponse result = ubsService.saveFullOrderToDB(dto, "35467585763t4sfgchjfuyetf", order.getId());
         Assertions.assertNotNull(result);
     }
 

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -36,7 +36,6 @@ import greencity.dto.pageble.PageableDto;
 import greencity.dto.payment.PaymentResponseDto;
 import greencity.dto.payment.PaymentResponseWayForPay;
 import greencity.dto.payment.PaymentWayForPayRequestDto;
-import greencity.dto.payment.monobank.CheckoutResponseFromMonoBank;
 import greencity.dto.payment.monobank.MonoBankPaymentRequestDto;
 import greencity.dto.payment.monobank.MonoBankPaymentResponseDto;
 import greencity.dto.position.PositionAuthoritiesDto;

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -43,6 +43,7 @@ import greencity.entity.user.employee.EmployeeOrderPosition;
 import greencity.entity.user.employee.Position;
 import greencity.entity.user.employee.ReceivingStation;
 import greencity.entity.user.ubs.OrderAddress;
+import greencity.enums.NotificationType;
 import greencity.enums.OrderPaymentStatus;
 import greencity.enums.OrderStatus;
 import greencity.enums.SortingOrder;
@@ -54,6 +55,7 @@ import greencity.repository.CertificateRepository;
 import greencity.repository.EmployeeOrderPositionRepository;
 import greencity.repository.EmployeeRepository;
 import greencity.repository.EventRepository;
+import greencity.repository.NotificationParameterRepository;
 import greencity.repository.OrderAddressRepository;
 import greencity.repository.OrderBagRepository;
 import greencity.repository.OrderDetailRepository;
@@ -66,6 +68,7 @@ import greencity.repository.ReceivingStationRepository;
 import greencity.repository.RefundRepository;
 import greencity.repository.ServiceRepository;
 import greencity.repository.TariffsInfoRepository;
+import greencity.repository.UserNotificationRepository;
 import greencity.repository.UserRepository;
 import greencity.service.locations.LocationApiService;
 import greencity.service.notification.NotificationServiceImpl;
@@ -132,6 +135,7 @@ import static greencity.ModelUtils.getExportDetailsRequestToday;
 import static greencity.ModelUtils.getFormedOrder;
 import static greencity.ModelUtils.getInfoPayment;
 import static greencity.ModelUtils.getLocation;
+import static greencity.ModelUtils.getNotificationParameterSet;
 import static greencity.ModelUtils.getOrder;
 import static greencity.ModelUtils.getOrderAddress;
 import static greencity.ModelUtils.getOrderBag;
@@ -167,6 +171,7 @@ import static greencity.ModelUtils.getTariffsInfo;
 import static greencity.ModelUtils.getTestDetailsOrderInfoDto;
 import static greencity.ModelUtils.getTestOrderDetailStatusRequestDto;
 import static greencity.ModelUtils.getTestUser;
+import static greencity.ModelUtils.getUserNotificationForUnpaidOrder;
 import static greencity.ModelUtils.updateAllOrderPageDto;
 import static greencity.ModelUtils.updateOrderPageAdminDto;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -277,6 +282,10 @@ class UBSManagementServiceImplTest {
     private EventRepository eventRepository;
     @Mock
     private BigOrderTableRepository bigOrderTableRepository;
+    @Mock
+    private UserNotificationRepository userNotificationRepository;
+    @Mock
+    private NotificationParameterRepository notificationParameterRepository;
 
     @Test
     void getAllCertificates() {
@@ -1299,6 +1308,10 @@ class UBSManagementServiceImplTest {
         when(paymentRepository.findAllByOrderId(1L)).thenReturn(List.of(getPayment()));
         when(receivingStationRepository.findAll()).thenReturn(List.of(getReceivingStation()));
         when(employeeOrderPositionRepository.findAllByOrderId(1L)).thenReturn(List.of(employeeOrderPosition));
+        when(userNotificationRepository.findUserNotificationByOrderAndNotificationType(order,
+            NotificationType.UNPAID_ORDER)).thenReturn(Optional.of(getUserNotificationForUnpaidOrder()));
+        when(notificationParameterRepository.findNotificationParameterByUserNotification(any()))
+            .thenReturn(Optional.of(getNotificationParameterSet()));
 
         ubsManagementService.updateOrderAdminPageInfo(updateOrderPageAdminDto, order, "en", "test@gmail.com");
 


### PR DESCRIPTION
💪🏽 GreenCityUBS PR 💪🏽

Issue Link:
[7958](https://github.com/orgs/ita-social-projects/projects/43/views/1?pane=issue&itemId=91943062&issue=ita-social-projects%7CGreenCity%7C7958)
Changes:

    Added a payment link to scheduled unpaid order email notifications (reminding the user about an unpaid order after 3 days).
    Added a payment link to email notifications for permanently unpaid orders.
    Fixed tests related to the new logic for payment links.

Previous Behavior:

    Email notifications for unpaid orders did not include a direct link to the payment system.

![image](https://github.com/user-attachments/assets/c1bd35eb-c162-48b0-bba8-5bf3e4ee660c)

Current Behavior:

    If an order is not paid, the user immediately receives an email notification with a payment link.
    Scheduled reminders for unpaid orders now include email notifications with a payment link after 3 days.
    
![image](https://github.com/user-attachments/assets/e723fb4e-d0e7-4983-b2ff-83708d20db25)

![image](https://github.com/user-attachments/assets/e0c4d7f6-c0ec-471e-8ba8-bf200813ce60)

