### PR TITLE
Disable hibernate sql logs

### DIFF
--- a/core/src/main/resources/application-dev.properties
+++ b/core/src/main/resources/application-dev.properties
@@ -7,7 +7,7 @@ server.port=8050
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto=validate
-spring.jpa.show-sql=true
+spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 
 # Liquibase

--- a/core/src/main/resources/application-docker.properties
+++ b/core/src/main/resources/application-docker.properties
@@ -7,7 +7,7 @@ server.port=8050
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto=validate
-spring.jpa.show-sql=true
+spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 
 # Liquibase

--- a/core/src/main/resources/application-prod.properties
+++ b/core/src/main/resources/application-prod.properties
@@ -18,7 +18,8 @@ spring.liquibase.change-log=${LIQUIBASE_LOG}
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto=${HIBERNATE_CONFIG}
-spring.jpa.show-sql=${SHOW_SQL}
+#spring.jpa.show-sql=${SHOW_SQL}
+spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=${JDBC_LOB}
 
 #RestTemplate

--- a/core/src/main/resources/application-test.properties
+++ b/core/src/main/resources/application-test.properties
@@ -1,6 +1,6 @@
 # Hibernate
 spring.jpa.hibernate.ddl-auto=validate
-spring.jpa.show-sql=true
+spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Changes**
	- Disabled SQL logging across development, docker, production, and test environments
	- Updated `spring.jpa.show-sql` property to `false` in all configuration files
	- Removed environment-specific SQL logging settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->