### PR TITLE
Fix deploy

### DIFF
--- a/core/src/main/resources/application-dev.properties
+++ b/core/src/main/resources/application-dev.properties
@@ -7,7 +7,6 @@ server.port=8050
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto=validate
-spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 
 # Liquibase

--- a/core/src/main/resources/application-docker.properties
+++ b/core/src/main/resources/application-docker.properties
@@ -7,7 +7,6 @@ server.port=8050
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto=validate
-spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 
 # Liquibase

--- a/core/src/main/resources/application-prod.properties
+++ b/core/src/main/resources/application-prod.properties
@@ -19,7 +19,6 @@ spring.liquibase.change-log=${LIQUIBASE_LOG}
 # Hibernate
 spring.jpa.hibernate.ddl-auto=${HIBERNATE_CONFIG}
 #spring.jpa.show-sql=${SHOW_SQL}
-spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=${JDBC_LOB}
 
 #RestTemplate

--- a/core/src/main/resources/application-test.properties
+++ b/core/src/main/resources/application-test.properties
@@ -1,6 +1,5 @@
 # Hibernate
 spring.jpa.hibernate.ddl-auto=validate
-spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Changes**
	- Removed `spring.jpa.show-sql=false` property across development, docker, production, and test environment configuration files
	- This may impact the logging of SQL statements in different deployment environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->