### PR TITLE
make viberIsNotify field non-required

### DIFF
--- a/service-api/src/main/java/greencity/dto/user/UserProfileUpdateDto.java
+++ b/service-api/src/main/java/greencity/dto/user/UserProfileUpdateDto.java
@@ -41,6 +41,5 @@ public class UserProfileUpdateDto implements Serializable {
     private List<AddressDto> addressDto;
     @NotNull
     private Boolean telegramIsNotify;
-    @NotNull
     private Boolean viberIsNotify;
 }


### PR DESCRIPTION
issue link: #1610 

changed:
- removed @NotNull annotation from 'viberIsNotify' in 'UserProfileUpdateDto'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved profile update validation: users can now leave the Viber notification preference unset, ensuring a smoother experience while updating profile settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->