### PR TITLE
Added endpoint for receivint total number of orders.

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -19,6 +19,7 @@ import greencity.dto.order.ExportDetailsDtoUpdate;
 import greencity.dto.order.GroupedOrderDto;
 import greencity.dto.order.NotTakenOrderReasonDto;
 import greencity.dto.order.OrderCancellationReasonDto;
+import greencity.dto.order.OrderCountDto;
 import greencity.dto.order.OrderDetailInfoDto;
 import greencity.dto.order.OrderDetailStatusDto;
 import greencity.dto.order.OrderDetailStatusRequestDto;
@@ -578,6 +579,24 @@ public class ManagementOrderController {
     public ResponseEntity<List<OrderInfoDto>> getAllDataForOrder(
         @PathVariable("uuid") String uuid) {
         return ResponseEntity.status(HttpStatus.OK).body(ubsManagementService.getOrdersForUser(uuid));
+    }
+
+    /**
+     * Endpoint for getting total amount of orders.
+     *
+     * @return {@link List OrderCountDto}.
+     * @author Chernenko Vitaliy
+     */
+    @Operation(summary = "Returns the total number of orders.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = Long.class)))),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content),
+    })
+    @GetMapping("/orders/count")
+    public ResponseEntity<OrderCountDto> getOrdersCount() {
+        return ResponseEntity.status(HttpStatus.OK).body(ubsManagementService.getTotalNumberOfOrders());
     }
 
     /**

--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -589,8 +589,7 @@ public class ManagementOrderController {
      */
     @Operation(summary = "Returns the total number of orders.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
-            content = @Content(array = @ArraySchema(schema = @Schema(implementation = OrderCountDto.class)))),
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content),
     })

--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -590,7 +590,7 @@ public class ManagementOrderController {
     @Operation(summary = "Returns the total number of orders.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
-            content = @Content(array = @ArraySchema(schema = @Schema(implementation = Long.class)))),
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = OrderCountDto.class)))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content),
     })

--- a/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
@@ -213,6 +213,15 @@ class ManagementOrderControllerTest {
     }
 
     @Test
+    void getOrdersTotalAmountTest() throws Exception {
+        this.mockMvc.perform(get(ubsLink + "/orders/count")
+            .principal(principal))
+            .andExpect(status().isOk());
+
+        verify(ubsManagementService, times(1)).getTotalNumberOfOrders();
+    }
+
+    @Test
     void getDataForOrderStatusPageTest() throws Exception {
         this.mockMvc.perform(get(ubsLink + "/get-data-for-order/{id}", 1L)
             .principal(principal));

--- a/service-api/src/main/java/greencity/dto/order/OrderCountDto.java
+++ b/service-api/src/main/java/greencity/dto/order/OrderCountDto.java
@@ -1,0 +1,9 @@
+package greencity.dto.order;
+
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+public class OrderCountDto {
+    private long orderCount;
+}

--- a/service-api/src/main/java/greencity/dto/order/OrderCountDto.java
+++ b/service-api/src/main/java/greencity/dto/order/OrderCountDto.java
@@ -1,6 +1,7 @@
 package greencity.dto.order;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
 @Data
 @AllArgsConstructor

--- a/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
@@ -7,6 +7,7 @@ import greencity.dto.employee.EmployeePositionDtoRequest;
 import greencity.dto.order.AdminCommentDto;
 import greencity.dto.order.BigOrderTableDTO;
 import greencity.dto.order.CounterOrderDetailsDto;
+import greencity.dto.order.OrderCountDto;
 import greencity.dto.order.DetailsOrderInfoDto;
 import greencity.dto.order.EcoNumberDto;
 import greencity.dto.order.ExportDetailsDto;
@@ -131,6 +132,15 @@ public interface UBSManagementService {
      * @author Mahdziak Orest
      */
     OrderDetailStatusDto getOrderDetailStatus(Long id);
+
+    /**
+     * Method that returns total number of orders.
+     *
+     * @return {@link Long}.
+     *
+     * @author Chernenko Vitaliy
+     */
+    OrderCountDto getTotalNumberOfOrders();
 
     /**
      * Method that update order and payment status by id.

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -30,6 +30,7 @@ import greencity.dto.order.NotTakenOrderReasonDto;
 import greencity.dto.order.OrderAddressDtoResponse;
 import greencity.dto.order.OrderAddressExportDetailsDtoUpdate;
 import greencity.dto.order.OrderCancellationReasonDto;
+import greencity.dto.order.OrderCountDto;
 import greencity.dto.order.OrderDetailDto;
 import greencity.dto.order.OrderDetailInfoDto;
 import greencity.dto.order.OrderDetailStatusDto;
@@ -818,6 +819,14 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             throw new NotFoundException(PAYMENT_NOT_FOUND + id);
         }
         return buildStatuses(order, payment.getFirst());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OrderCountDto getTotalNumberOfOrders() {
+        return new OrderCountDto(orderRepository.count());
     }
 
     /**

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -13,6 +13,7 @@ import greencity.dto.certificate.CertificateDtoForSearching;
 import greencity.dto.employee.EmployeePositionDtoRequest;
 import greencity.dto.order.AdminCommentDto;
 import greencity.dto.order.CounterOrderDetailsDto;
+import greencity.dto.order.OrderCountDto;
 import greencity.dto.order.DetailsOrderInfoDto;
 import greencity.dto.order.EcoNumberDto;
 import greencity.dto.order.ExportDetailsDto;
@@ -663,6 +664,17 @@ class UBSManagementServiceImplTest {
 
         assertThrows(NotFoundException.class,
                 () -> ubsManagementService.getOrderDetailStatus(1L));
+    }
+
+    @Test
+    void getTotalNumberOfOrdersTest() {
+        when(orderRepository.count()).thenReturn(10L);
+
+        OrderCountDto result = ubsManagementService.getTotalNumberOfOrders();
+
+        assertEquals(result.getOrderCount(), 10L);
+
+        verify(orderRepository, times(1)).count();
     }
 
     @Test

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -668,11 +668,12 @@ class UBSManagementServiceImplTest {
 
     @Test
     void getTotalNumberOfOrdersTest() {
-        when(orderRepository.count()).thenReturn(10L);
+        final long expectedTotalNumberOfOrders = 10L;
+        when(orderRepository.count()).thenReturn(expectedTotalNumberOfOrders);
 
         OrderCountDto result = ubsManagementService.getTotalNumberOfOrders();
 
-        assertEquals(result.getOrderCount(), 10L);
+        assertEquals(expectedTotalNumberOfOrders, result.getOrderCount());
 
         verify(orderRepository, times(1)).count();
     }


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
[#8170](https://github.com/ita-social-projects/GreenCity/issues/8170)

## Added

- Added implementation for method _getTotalNumberOfOrders_ in the `UBSManagementServiceImpl`;
- Created `OrderCountDto` for passing order total number;
- Added method _getOrdersCount_ into `ManagementOrderController`;
- Added unit tests for method _getOrdersCount_ in the `ManagementOrderControllerTest`;
- Added unit tests for method _getTotalNumberOfOrders_ in the `UBSManagementServiceImplTest`;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint for retrieving the total order count.
  - Added functionality in the service layer complemented by a new data structure to encapsulate the order count.

- **Tests**
  - Implemented tests to ensure the new endpoint and associated service reliably return the accurate total number of orders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->