### PR TITLE
BugFix #8182 Refactored funtionality for receiving total number of orders for employees.

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -582,20 +582,22 @@ public class ManagementOrderController {
     }
 
     /**
-     * Endpoint for getting total amount of orders.
+     * Endpoint for getting total amount of orders by employee.
      *
-     * @return {@link List OrderCountDto}.
+     * @return {@link OrderCountDto}.
      * @author Chernenko Vitaliy
      */
-    @Operation(summary = "Returns the total number of orders.")
+    @Operation(summary = "Returns the total number of orders by employee.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content),
     })
     @GetMapping("/orders/count")
-    public ResponseEntity<OrderCountDto> getOrdersCount() {
-        return ResponseEntity.status(HttpStatus.OK).body(ubsManagementService.getTotalNumberOfOrders());
+    public ResponseEntity<OrderCountDto> getOrdersCount(Principal principal) {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(bigOrderTableService.getTotalNumberOfOrdersByEmployee(principal.getName()));
     }
 
     /**

--- a/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
@@ -17,7 +17,6 @@ import greencity.filters.CertificatePage;
 import greencity.service.ubs.CertificateService;
 import greencity.service.ubs.CoordinateService;
 import greencity.service.ubs.PaymentService;
-import greencity.service.ubs.UBSClientService;
 import greencity.service.ubs.UBSManagementService;
 import greencity.service.ubs.ViolationService;
 import greencity.service.ubs.manager.BigOrderTableServiceView;
@@ -76,9 +75,6 @@ class ManagementOrderControllerTest {
 
     @Mock
     CertificateService certificateService;
-
-    @Mock
-    UBSClientService ubsClientService;
 
     @Mock
     private Validator mockValidator;
@@ -218,7 +214,7 @@ class ManagementOrderControllerTest {
             .principal(principal))
             .andExpect(status().isOk());
 
-        verify(ubsManagementService, times(1)).getTotalNumberOfOrders();
+        verify(bigOrderTableServiceView, times(1)).getTotalNumberOfOrdersByEmployee(principal.getName());
     }
 
     @Test

--- a/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
+++ b/core/src/test/java/greencity/repository/BigOrderTableRepositoryTest.java
@@ -29,6 +29,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 @Sql(scripts = "/sqlFiles/bigOrderTableRepository/insert.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 @Sql(scripts = "/sqlFiles/bigOrderTableRepository/delete.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 @ExtendWith(SpringExtension.class)
@@ -340,7 +342,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
             DEFAULT_ORDER_SEARCH_CRITERIA, TARIFFS_ID_LIST, USER_LANGUAGE_UA).getContent();
         boolean isListCorrectlySorted =
             Comparators.isInOrder(bigOrderTableViewsList, orderStatusTranslationComparator(false));
-        Assertions.assertTrue(isListCorrectlySorted);
+        assertTrue(isListCorrectlySorted);
     }
 
     @Test
@@ -351,7 +353,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
             DEFAULT_ORDER_SEARCH_CRITERIA, TARIFFS_ID_LIST, USER_LANGUAGE_UA).getContent();
         boolean isListCorrectlySorted =
             Comparators.isInOrder(bigOrderTableViewsList, orderStatusTranslationComparator(true));
-        Assertions.assertTrue(isListCorrectlySorted);
+        assertTrue(isListCorrectlySorted);
     }
 
     @Test
@@ -455,7 +457,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
             DEFAULT_ORDER_SEARCH_CRITERIA, TARIFFS_ID_LIST, USER_LANGUAGE_UA).getContent();
         boolean isListCorrectlySorted =
             Comparators.isInOrder(bigOrderTableViewsList, orderPaymentStatusTranslationComparator(false));
-        Assertions.assertTrue(isListCorrectlySorted);
+        assertTrue(isListCorrectlySorted);
     }
 
     @Test
@@ -466,7 +468,7 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
             DEFAULT_ORDER_SEARCH_CRITERIA, TARIFFS_ID_LIST, USER_LANGUAGE_UA).getContent();
         boolean isListCorrectlySorted =
             Comparators.isInOrder(bigOrderTableViewsList, orderPaymentStatusTranslationComparator(true));
-        Assertions.assertTrue(isListCorrectlySorted);
+        assertTrue(isListCorrectlySorted);
     }
 
     @Test
@@ -483,6 +485,15 @@ class BigOrderTableRepositoryTest extends IntegrationTestBase {
             bigOrderTableRepository.findAll(DEFAULT_ORDER_PAGE_DESC, filter, TARIFFS_ID_LIST, USER_LANGUAGE_ENG)
                 .getContent();
         Assertions.assertEquals(expectedValue, actualValue);
+    }
+
+    @Test
+    void getOrdersCountByTariffsTest() {
+        List<Long> tariffsInfoIds = List.of(1L, 2L, 3L);
+
+        long result = bigOrderTableRepository.getOrdersCountByTariffs(tariffsInfoIds);
+
+        assertTrue(result > 0);
     }
 
     private Comparator<BigOrderTableViews> orderStatusTranslationComparator(boolean descending) {

--- a/dao/src/main/java/greencity/repository/BigOrderTableRepository.java
+++ b/dao/src/main/java/greencity/repository/BigOrderTableRepository.java
@@ -91,6 +91,23 @@ public class BigOrderTableRepository {
             .orElse(null);
     }
 
+    /**
+     * Method returns total number of orders by list of tariffs.
+     *
+     * @param tariffsInfoIds {@link List} list of tariff ids.
+     * @return the total number of orders, represented as a {@code long}.
+     */
+    public long getOrdersCountByTariffs(List<Long> tariffsInfoIds) {
+        var countQuery = criteriaBuilder.createQuery(Long.class);
+        var countOrderRoot = countQuery.from(BigOrderTableViews.class);
+        var predicates = new ArrayList<Predicate>();
+
+        getPredicateByTariffsInfoId(predicates, tariffsInfoIds, countOrderRoot);
+        var countPredicate = criteriaBuilder.and(predicates.toArray(Predicate[]::new));
+        countQuery.select(criteriaBuilder.count(countOrderRoot)).where(countPredicate);
+        return entityManager.createQuery(countQuery).getSingleResult();
+    }
+
     private Predicate getPredicate(OrderSearchCriteria sc, Root<BigOrderTableViews> orderRoot,
         List<Long> tariffsInfoIds) {
         var predicates = new ArrayList<Predicate>();

--- a/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSManagementService.java
@@ -7,7 +7,6 @@ import greencity.dto.employee.EmployeePositionDtoRequest;
 import greencity.dto.order.AdminCommentDto;
 import greencity.dto.order.BigOrderTableDTO;
 import greencity.dto.order.CounterOrderDetailsDto;
-import greencity.dto.order.OrderCountDto;
 import greencity.dto.order.DetailsOrderInfoDto;
 import greencity.dto.order.EcoNumberDto;
 import greencity.dto.order.ExportDetailsDto;
@@ -132,15 +131,6 @@ public interface UBSManagementService {
      * @author Mahdziak Orest
      */
     OrderDetailStatusDto getOrderDetailStatus(Long id);
-
-    /**
-     * Method that returns total number of orders.
-     *
-     * @return {@link Long}.
-     *
-     * @author Chernenko Vitaliy
-     */
-    OrderCountDto getTotalNumberOfOrders();
 
     /**
      * Method that update order and payment status by id.

--- a/service-api/src/main/java/greencity/service/ubs/manager/BigOrderTableServiceView.java
+++ b/service-api/src/main/java/greencity/service/ubs/manager/BigOrderTableServiceView.java
@@ -1,6 +1,7 @@
 package greencity.service.ubs.manager;
 
 import greencity.dto.order.BigOrderTableDTO;
+import greencity.dto.order.OrderCountDto;
 import greencity.dto.table.CustomTableViewDto;
 import greencity.entity.table.TableColumnWidthForEmployee;
 import greencity.filters.OrderPage;
@@ -40,4 +41,14 @@ public interface BigOrderTableServiceView {
      * @author Hrenevych Ivan
      */
     TableColumnWidthForEmployee changeIsFreezeStatus(String uuid, Boolean value);
+
+    /**
+     * Method returns total number of orders by employee email.
+     *
+     * @param email employee email.
+     * @return {@link OrderCountDto} object for representing count of orders.
+     *
+     * @author Chernenko Vitaliy.
+     */
+    OrderCountDto getTotalNumberOfOrdersByEmployee(String email);
 }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -30,7 +30,6 @@ import greencity.dto.order.NotTakenOrderReasonDto;
 import greencity.dto.order.OrderAddressDtoResponse;
 import greencity.dto.order.OrderAddressExportDetailsDtoUpdate;
 import greencity.dto.order.OrderCancellationReasonDto;
-import greencity.dto.order.OrderCountDto;
 import greencity.dto.order.OrderDetailDto;
 import greencity.dto.order.OrderDetailInfoDto;
 import greencity.dto.order.OrderDetailStatusDto;
@@ -819,14 +818,6 @@ public class UBSManagementServiceImpl implements UBSManagementService {
             throw new NotFoundException(PAYMENT_NOT_FOUND + id);
         }
         return buildStatuses(order, payment.getFirst());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public OrderCountDto getTotalNumberOfOrders() {
-        return new OrderCountDto(orderRepository.count());
     }
 
     /**

--- a/service/src/main/java/greencity/service/ubs/manager/BigOrderTableViewServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/manager/BigOrderTableViewServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import greencity.client.UserRemoteClient;
 import greencity.constant.ErrorMessage;
+import greencity.dto.order.OrderCountDto;
 import greencity.dto.user.UserVO;
 import greencity.entity.table.TableColumnWidthForEmployee;
 import greencity.entity.user.employee.Employee;
@@ -102,6 +103,15 @@ public class BigOrderTableViewServiceImpl implements BigOrderTableServiceView {
             throw new EntityNotFoundException(TABLE_COLUMN_WIDTH_BY_EMPLOYEE_ID_NOT_FOUND);
         }
         throw new EntityNotFoundException(EMPLOYEE_WITH_UUID_NOT_FOUND);
+    }
+
+    @Override
+    public OrderCountDto getTotalNumberOfOrdersByEmployee(String email) {
+        Long employeeId = employeeRepository.findByEmail(email)
+            .orElseThrow(() -> new EntityNotFoundException(EMPLOYEE_NOT_FOUND)).getId();
+        List<Long> tariffsInfoIds = employeeRepository.findTariffsInfoForEmployee(employeeId);
+
+        return new OrderCountDto(bigOrderTableRepository.getOrdersCountByTariffs(tariffsInfoIds));
     }
 
     private CustomTableViewDto castTableViewToDto(String titles) {

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -13,7 +13,6 @@ import greencity.dto.certificate.CertificateDtoForSearching;
 import greencity.dto.employee.EmployeePositionDtoRequest;
 import greencity.dto.order.AdminCommentDto;
 import greencity.dto.order.CounterOrderDetailsDto;
-import greencity.dto.order.OrderCountDto;
 import greencity.dto.order.DetailsOrderInfoDto;
 import greencity.dto.order.EcoNumberDto;
 import greencity.dto.order.ExportDetailsDto;
@@ -664,18 +663,6 @@ class UBSManagementServiceImplTest {
 
         assertThrows(NotFoundException.class,
                 () -> ubsManagementService.getOrderDetailStatus(1L));
-    }
-
-    @Test
-    void getTotalNumberOfOrdersTest() {
-        final long expectedTotalNumberOfOrders = 10L;
-        when(orderRepository.count()).thenReturn(expectedTotalNumberOfOrders);
-
-        OrderCountDto result = ubsManagementService.getTotalNumberOfOrders();
-
-        assertEquals(expectedTotalNumberOfOrders, result.getOrderCount());
-
-        verify(orderRepository, times(1)).count();
     }
 
     @Test

--- a/service/src/test/java/greencity/service/ubs/manager/BigOrderTableViewServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/manager/BigOrderTableViewServiceImplTest.java
@@ -29,12 +29,19 @@ import java.util.Optional;
 import static greencity.ModelUtils.getEmployee;
 import static greencity.ModelUtils.getTestTableColumnWidth;
 import static greencity.ModelUtils.getTestTableColumnWidthWithIsTableFreezeTrue;
+import static greencity.constant.ErrorMessage.EMPLOYEE_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
-class BigOrderTableServiceImplTest {
+class BigOrderTableViewServiceImplTest {
+    private static final String USER_EMAIL = "test@gmail.com";
+    private static final String NOT_EXISTS_USER_EMAIL = "not_exists_email@some.com";
     @InjectMocks
     private BigOrderTableViewServiceImpl bigOrderTableService;
     @Mock
@@ -54,13 +61,13 @@ class BigOrderTableServiceImplTest {
         var orderSearchCriteria = getOrderSearchCriteria();
         Optional<Employee> employee = Optional.of(getEmployee());
         List<Long> tariffsInfoIds = new ArrayList<>();
-        when(employeeRepository.findByEmail("test@gmail.com")).thenReturn(employee);
+        when(employeeRepository.findByEmail(USER_EMAIL)).thenReturn(employee);
         UserVO userVO = new UserVO().setLanguageVO(new LanguageVO(null, "eng"));
-        when(userRemoteClient.findNotDeactivatedByEmail("test@gmail.com")).thenReturn(Optional.of(userVO));
+        when(userRemoteClient.findNotDeactivatedByEmail(USER_EMAIL)).thenReturn(Optional.of(userVO));
         when(bigOrderTableRepository.findAll(orderPage, orderSearchCriteria, tariffsInfoIds, "eng"))
             .thenReturn(Page.empty());
 
-        bigOrderTableService.getOrders(orderPage, orderSearchCriteria, "test@gmail.com");
+        bigOrderTableService.getOrders(orderPage, orderSearchCriteria, USER_EMAIL);
 
         verify(bigOrderTableRepository).findAll(orderPage, orderSearchCriteria, tariffsInfoIds, "eng");
     }
@@ -97,7 +104,7 @@ class BigOrderTableServiceImplTest {
         when(tableColumnWidthForEmployeeRepository.findByEmployeeId(getEmployee().getId()))
             .thenReturn(Optional.ofNullable(getTestTableColumnWidthWithIsTableFreezeTrue()));
 
-        Assertions.assertThrows(BadRequestException.class,
+        assertThrows(BadRequestException.class,
             () -> bigOrderTableService.changeOrderTableView(uuid, "titles1,titles2"),
             "should throw BadRequestException");
 
@@ -163,7 +170,7 @@ class BigOrderTableServiceImplTest {
         String nonExistUuid = "Non_Exist";
         when(employeeRepository.findByUuid(nonExistUuid)).thenReturn(Optional.empty());
 
-        Assertions.assertThrows(
+        assertThrows(
             EntityNotFoundException.class,
             () -> bigOrderTableService.changeIsFreezeStatus(nonExistUuid, true),
             "Should throw EntityNotFoundException");
@@ -181,7 +188,7 @@ class BigOrderTableServiceImplTest {
         when(tableColumnWidthForEmployeeRepository.findByEmployeeId(getEmployee().getId()))
             .thenReturn(Optional.empty());
 
-        Assertions.assertThrows(
+        assertThrows(
             EntityNotFoundException.class,
             () -> bigOrderTableService.changeIsFreezeStatus(uuid, true),
             "Should throw EntityNotFoundException");
@@ -189,6 +196,34 @@ class BigOrderTableServiceImplTest {
         verify(employeeRepository).findByUuid(uuid);
         verify(tableColumnWidthForEmployeeRepository, times(1)).findByEmployeeId(getEmployee().getId());
 
+    }
+
+    @Test
+    void getTotalNumberOfOrdersByEmployeeWithValidEmailTest() {
+        Employee employee = ModelUtils.getEmployee();
+        List<Long> tariffsInfoIds = List.of(1L, 2L, 3L);
+        when(employeeRepository.findByEmail(USER_EMAIL)).thenReturn(Optional.of(employee));
+        when(employeeRepository.findTariffsInfoForEmployee(employee.getId())).thenReturn(tariffsInfoIds);
+        when(bigOrderTableRepository.getOrdersCountByTariffs(tariffsInfoIds)).thenReturn(10L);
+
+        bigOrderTableService.getTotalNumberOfOrdersByEmployee(USER_EMAIL);
+
+        verify(employeeRepository, times(1)).findByEmail(USER_EMAIL);
+        verify(employeeRepository, times(1)).findTariffsInfoForEmployee(employee.getId());
+        verify(bigOrderTableRepository, times(1)).getOrdersCountByTariffs(tariffsInfoIds);
+    }
+
+    @Test
+    void getTotalNumberOfOrdersByEmployeeWithNotValidEmailTest() {
+        when(employeeRepository.findByEmail(NOT_EXISTS_USER_EMAIL))
+            .thenThrow(new EntityNotFoundException(EMPLOYEE_NOT_FOUND));
+
+        assertThrows(EntityNotFoundException.class,
+            () -> bigOrderTableService.getTotalNumberOfOrdersByEmployee(NOT_EXISTS_USER_EMAIL));
+
+        verify(employeeRepository, times(1)).findByEmail(anyString());
+        verify(employeeRepository, times(0)).findTariffsInfoForEmployee(anyLong());
+        verify(bigOrderTableRepository, times(0)).getOrdersCountByTariffs(anyList());
     }
 
     private OrderPage getOrderPage() {


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
[#8182](https://github.com/ita-social-projects/GreenCity/issues/8182)

## Changed

- Added method _getOrdersCountByTariffs_ for receiving total numbers of orders by a list of tariffs in the `BigOrderTableRepository`;
- Added tests for _getOrdersCountByTariffs_ method in the `BigOrderTableRepositoryTest`; 
- Added method _getTotalNumberOfOrdersByEmployee_ in the `BigOrderTableServiceView` and created realization for it in the `BigOrderTableViewServiceImpl`; 
- Added unit tests for method _getTotalNumberOfOrdersByEmployee_ into `BigOrderTableViewServiceImplTest`; 
- Renamed class `BigOrderTableServiceImplTest` as `BigOrderTableViewServiceImplTest`; 
- Removed old realization of receiving a total number of orders from `UBSManagementService`, `UBSManagementServiceImpl`, and `UBSManagementServiceImplTest`; 
- Refactored method _getOrdersCount_ in the `ManagementOrderController` according to new requirements; 
- Refactored tests in the `ManagementOrderControllerTest` according to changes in the controller;

## Summary Of Changes 🔥
Modified business logic for receiving total numbers of orders.
Now it returns the total numbers of orders for current employees according to requirements in the task [#8182](https://github.com/ita-social-projects/GreenCity/issues/8182)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Order metrics are now personalized, showing order counts tailored to the authenticated employee.
  - New tariff-based order insights provide enhanced visibility into orders segmented by tariff categories.
  - Improved error handling delivers clearer notifications when an employee record isn’t found.

- **Refactor**
  - Legacy order count functionality has been streamlined to improve clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->