### PR TITLE
[FIX] Employee can select future payment date in edit popup 

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -68,6 +68,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -86,6 +87,7 @@ import org.springframework.web.server.ResponseStatusException;
 @RestController
 @RequestMapping("/ubs/management")
 @RequiredArgsConstructor
+@Validated
 public class ManagementOrderController {
     private final UBSManagementService ubsManagementService;
     private final CertificateService certificateService;

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -281,7 +281,7 @@ public class ModelUtils {
             .build();
     }
 
-    public static ManualPaymentRequestDto getRequestDto() {
+    public static ManualPaymentRequestDto getManualPaymentRequestDto() {
         return ManualPaymentRequestDto.builder()
             .amount(500L)
             .settlementdate("2021-03-07")

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -7,6 +7,7 @@ import greencity.dto.address.AddressDto;
 import greencity.dto.address.UpdateAddressDto;
 import greencity.dto.bag.BagDto;
 import greencity.dto.bag.BagLimitDto;
+import greencity.dto.certificate.CertificateDtoForAdding;
 import greencity.dto.courier.CourierDto;
 import greencity.dto.courier.CreateCourierDto;
 import greencity.dto.courier.ReceivingStationDto;
@@ -283,7 +284,7 @@ public class ModelUtils {
     public static ManualPaymentRequestDto getRequestDto() {
         return ManualPaymentRequestDto.builder()
             .amount(500L)
-            .settlementdate("09-02-2021")
+            .settlementdate("2021-03-07")
             .receiptLink("somelink.com")
             .paymentId("10l")
             .build();
@@ -689,6 +690,16 @@ public class ModelUtils {
         return UpdateAddressDto.builder()
             .orderAddressExportDetails(orderAddressDetails)
             .orderId(1L)
+            .build();
+    }
+
+    public static CertificateDtoForAdding getCertificateDtoForAdding() {
+        return CertificateDtoForAdding
+            .builder()
+            .points(10)
+            .monthCount(1)
+            .initialPointsValue(2000)
+            .code("4444-4444")
             .build();
     }
 }

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -284,7 +284,7 @@ public class ModelUtils {
     public static ManualPaymentRequestDto getManualPaymentRequestDto() {
         return ManualPaymentRequestDto.builder()
             .amount(500L)
-            .settlementdate("2021-03-07")
+            .settlementDate("2021-03-07")
             .receiptLink("somelink.com")
             .paymentId("10l")
             .build();

--- a/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
@@ -21,7 +21,10 @@ import greencity.service.ubs.UBSManagementService;
 import greencity.service.ubs.ViolationService;
 import greencity.service.ubs.manager.BigOrderTableServiceView;
 import java.security.Principal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,7 +39,6 @@ import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequ
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.validation.Validator;
 import static greencity.ModelUtils.getEcoNumberDto;
 import static greencity.ModelUtils.getRequestDto;
 import static greencity.ModelUtils.getUpdateOrderPageAdminDto;
@@ -75,9 +77,6 @@ class ManagementOrderControllerTest {
     @Mock
     CertificateService certificateService;
 
-    @Mock
-    private Validator mockValidator;
-
     @InjectMocks
     ManagementOrderController managementOrderController;
 
@@ -87,20 +86,20 @@ class ManagementOrderControllerTest {
     @Mock
     PaymentService paymentService;
 
+    private static ObjectMapper objectMapper;
+
     private final Principal principal = getUuid();
 
-    public static final String contentForaddingcontroller = """
-        {
-         "code": "1111-2222",
-         "monthCount": 8,
-         "points": 100
-        }""";
+    @BeforeAll
+    static void setUpBeforeClass() {
+        objectMapper = new ObjectMapper();
+        objectMapper.findAndRegisterModules();
+    }
 
     @BeforeEach
     void setup() {
         this.mockMvc = MockMvcBuilders.standaloneSetup(managementOrderController)
             .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
-            .setValidator(mockValidator)
             .build();
     }
 
@@ -116,15 +115,12 @@ class ManagementOrderControllerTest {
 
     @Test
     void addCertificateTest() throws Exception {
+        CertificateDtoForAdding certificateDtoForAdding = ModelUtils.getCertificateDtoForAdding();
+        String json = objectMapper.writeValueAsString(certificateDtoForAdding);
         mockMvc.perform(MockMvcRequestBuilders.post(ubsManagementLink + "/addCertificate")
-            .content(contentForaddingcontroller)
+            .content(json)
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(MockMvcResultMatchers.status().isCreated());
-        CertificateDtoForAdding certificateDtoForAdding = CertificateDtoForAdding.builder()
-            .code("1111-2222")
-            .points(100)
-            .monthCount(8)
-            .build();
         verify(certificateService, times(1)).addCertificate(certificateDtoForAdding);
     }
 
@@ -172,7 +168,7 @@ class ManagementOrderControllerTest {
     @Test
     void updateOrderStatusesDetail() throws Exception {
         OrderDetailStatusDto dto = ModelUtils.getPaidOrderDetailStatusDto();
-        ObjectMapper objectMapper = new ObjectMapper();
+
         String orderResponceDtoJSON = objectMapper.writeValueAsString(dto);
         this.mockMvc.perform(put(ubsManagementLink + "/update-order-detail-status" + "/{id}", 1L)
             .content(orderResponceDtoJSON)
@@ -227,7 +223,7 @@ class ManagementOrderControllerTest {
     @Test
     void updateOrderExportedDetail() throws Exception {
         ExportDetailsDto dto = ModelUtils.getOrderDetailExportDto();
-        ObjectMapper objectMapper = new ObjectMapper();
+
         String orderResponceDtoJSON = objectMapper.writeValueAsString(dto);
         this.mockMvc.perform(put(ubsManagementLink + "/update-order-export-details" + "/{id}", 1L)
             .content(orderResponceDtoJSON)
@@ -247,7 +243,7 @@ class ManagementOrderControllerTest {
     @Test
     void addManualPayment() throws Exception {
         ManualPaymentRequestDto dto = getRequestDto();
-        ObjectMapper objectMapper = new ObjectMapper();
+
         String responseJSON = objectMapper.writeValueAsString(dto);
         MockMultipartFile jsonFile = new MockMultipartFile("manualPaymentDto",
             "", "application/json", responseJSON.getBytes());
@@ -268,7 +264,7 @@ class ManagementOrderControllerTest {
     @Test
     void updateManualPayment() throws Exception {
         ManualPaymentRequestDto dto = getRequestDto();
-        ObjectMapper objectMapper = new ObjectMapper();
+
         String responseJSON = objectMapper.writeValueAsString(dto);
         MockMultipartFile jsonFile = new MockMultipartFile("manualPaymentDto",
             "", "application/json", responseJSON.getBytes());
@@ -305,7 +301,7 @@ class ManagementOrderControllerTest {
     @Test
     void saveAdminCommentToOrder() throws Exception {
         AdminCommentDto adminCommentDto = ModelUtils.getAdminComment();
-        ObjectMapper objectMapper = new ObjectMapper();
+
         String writeValueAsString = objectMapper.writeValueAsString(adminCommentDto);
 
         mockMvc.perform(MockMvcRequestBuilders.post(ubsManagementLink + "/save-admin-comment", 1L)
@@ -318,7 +314,7 @@ class ManagementOrderControllerTest {
     @Test
     void updateEcoNumberForOrder() throws Exception {
         EcoNumberDto ecoNumberDto = getEcoNumberDto();
-        ObjectMapper objectMapper = new ObjectMapper();
+
         String writeValueAsString = objectMapper.writeValueAsString(ecoNumberDto);
 
         mockMvc.perform(MockMvcRequestBuilders.put(ubsManagementLink + "/update-eco-store{id}", 1L)
@@ -351,7 +347,7 @@ class ManagementOrderControllerTest {
     @Test
     void addPointsToUserTest() throws Exception {
         AddingPointsToUserDto dto = ModelUtils.getAddingPointsToUserDto();
-        ObjectMapper objectMapper = new ObjectMapper();
+
         String dtoJSON = objectMapper.writeValueAsString(dto);
 
         mockMvc.perform(patch(ubsManagementLink + "/addPointsToUser")
@@ -417,7 +413,7 @@ class ManagementOrderControllerTest {
     @Test
     void getUpdateAllOrderPageAdminInfoTest() throws Exception {
         UpdateAllOrderPageDto dto = ModelUtils.getUpdateAllOrderPageDto();
-        ObjectMapper objectMapper = new ObjectMapper();
+
         String jsonDto = objectMapper.writeValueAsString(dto);
 
         mockMvc.perform(put(ubsManagementLink + "/all-order-page-admin-info")
@@ -445,7 +441,7 @@ class ManagementOrderControllerTest {
     @Test
     void updatePageAdminInfoTest() throws Exception {
         UpdateOrderPageAdminDto dto = getUpdateOrderPageAdminDto();
-        ObjectMapper objectMapper = new ObjectMapper();
+
         String responseJSON = objectMapper.writeValueAsString(dto);
 
         MockMultipartFile jsonFile = new MockMultipartFile(
@@ -478,5 +474,26 @@ class ManagementOrderControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().string("<Boolean>true</Boolean>"));
         verify(ubsManagementService).checkIfOrderStatusIsFormedToCanceled(orderId);
+    }
+
+    @Test
+    void updateManualPaymentWithFutureSettlementDateTest() throws Exception {
+        ManualPaymentRequestDto dto = getRequestDto();
+        dto.setSettlementdate(LocalDate.now().plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+
+        objectMapper.findAndRegisterModules();
+        String responseJSON = objectMapper.writeValueAsString(dto);
+        MockMultipartFile jsonFile = new MockMultipartFile("manualPaymentDto",
+            "", "application/json", responseJSON.getBytes());
+        MockMultipartHttpServletRequestBuilder builder =
+            multipart(ubsManagementLink + "/update-manual-payment/{id}", 1L);
+        builder.with(request -> {
+            request.setMethod("PUT");
+            return request;
+        });
+        mockMvc.perform(builder.file(jsonFile)
+            .principal(principal)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 }

--- a/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
@@ -40,7 +40,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import static greencity.ModelUtils.getEcoNumberDto;
-import static greencity.ModelUtils.getRequestDto;
+import static greencity.ModelUtils.getManualPaymentRequestDto;
 import static greencity.ModelUtils.getUpdateOrderPageAdminDto;
 import static greencity.ModelUtils.getUuid;
 import static greencity.ModelUtils.getViolationDetailInfoDto;
@@ -242,7 +242,7 @@ class ManagementOrderControllerTest {
 
     @Test
     void addManualPayment() throws Exception {
-        ManualPaymentRequestDto dto = getRequestDto();
+        ManualPaymentRequestDto dto = getManualPaymentRequestDto();
 
         String responseJSON = objectMapper.writeValueAsString(dto);
         MockMultipartFile jsonFile = new MockMultipartFile("manualPaymentDto",
@@ -263,7 +263,7 @@ class ManagementOrderControllerTest {
 
     @Test
     void updateManualPayment() throws Exception {
-        ManualPaymentRequestDto dto = getRequestDto();
+        ManualPaymentRequestDto dto = getManualPaymentRequestDto();
 
         String responseJSON = objectMapper.writeValueAsString(dto);
         MockMultipartFile jsonFile = new MockMultipartFile("manualPaymentDto",
@@ -478,7 +478,7 @@ class ManagementOrderControllerTest {
 
     @Test
     void updateManualPaymentWithFutureSettlementDateTest() throws Exception {
-        ManualPaymentRequestDto dto = getRequestDto();
+        ManualPaymentRequestDto dto = getManualPaymentRequestDto();
         dto.setSettlementdate(LocalDate.now().plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
 
         objectMapper.findAndRegisterModules();

--- a/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
@@ -24,7 +24,7 @@ import java.security.Principal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeAll;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -86,15 +86,9 @@ class ManagementOrderControllerTest {
     @Mock
     PaymentService paymentService;
 
-    private static ObjectMapper objectMapper;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private final Principal principal = getUuid();
-
-    @BeforeAll
-    static void setUpBeforeClass() {
-        objectMapper = new ObjectMapper();
-        objectMapper.findAndRegisterModules();
-    }
 
     @BeforeEach
     void setup() {
@@ -479,7 +473,7 @@ class ManagementOrderControllerTest {
     @Test
     void updateManualPaymentWithFutureSettlementDateTest() throws Exception {
         ManualPaymentRequestDto dto = getManualPaymentRequestDto();
-        dto.setSettlementdate(LocalDate.now().plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        dto.setSettlementDate(LocalDate.now().plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
 
         objectMapper.findAndRegisterModules();
         String responseJSON = objectMapper.writeValueAsString(dto);

--- a/service-api/src/main/java/greencity/annotations/ValidSettlementDate.java
+++ b/service-api/src/main/java/greencity/annotations/ValidSettlementDate.java
@@ -1,0 +1,37 @@
+package greencity.annotations;
+
+import greencity.validator.SettlementDateValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = {SettlementDateValidator.class})
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+public @interface ValidSettlementDate {
+    /**
+     * Defines the message that will be showed when the input data is not valid.
+     *
+     * @return message
+     */
+    String message() default "You can't set future date as settlement date!";
+
+    /**
+     * Let you select to split the annotations into different groups to apply
+     * different validations to each group.
+     *
+     * @return groups
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * Payloads are typically used to carry metadata information consumed by a
+     * validation client.
+     *
+     * @return payload
+     */
+    Class<? extends Payload>[] payload() default {};
+}

--- a/service-api/src/main/java/greencity/dto/payment/ManualPaymentRequestDto.java
+++ b/service-api/src/main/java/greencity/dto/payment/ManualPaymentRequestDto.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 public class ManualPaymentRequestDto {
     @NotEmpty
     @ValidSettlementDate
-    private String settlementdate;
+    private String settlementDate;
     @NotNull
     @Positive
     private Long amount;

--- a/service-api/src/main/java/greencity/dto/payment/ManualPaymentRequestDto.java
+++ b/service-api/src/main/java/greencity/dto/payment/ManualPaymentRequestDto.java
@@ -1,5 +1,6 @@
 package greencity.dto.payment;
 
+import greencity.annotations.ValidSettlementDate;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -16,6 +17,7 @@ import lombok.Setter;
 @Builder
 public class ManualPaymentRequestDto {
     @NotEmpty
+    @ValidSettlementDate
     private String settlementdate;
     @NotNull
     @Positive

--- a/service-api/src/main/java/greencity/validator/SettlementDateValidator.java
+++ b/service-api/src/main/java/greencity/validator/SettlementDateValidator.java
@@ -11,12 +11,12 @@ public class SettlementDateValidator implements ConstraintValidator<ValidSettlem
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     @Override
-    public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
-        if (s == null) {
+    public boolean isValid(String settlementDateToValidate, ConstraintValidatorContext constraintValidatorContext) {
+        if (settlementDateToValidate == null) {
             return false;
         }
         try {
-            return LocalDate.parse(s, formatter).isBefore(LocalDate.now().plusDays(1));
+            return LocalDate.parse(settlementDateToValidate, formatter).isBefore(LocalDate.now().plusDays(1));
         } catch (DateTimeParseException e) {
             return false;
         }

--- a/service-api/src/main/java/greencity/validator/SettlementDateValidator.java
+++ b/service-api/src/main/java/greencity/validator/SettlementDateValidator.java
@@ -1,0 +1,16 @@
+package greencity.validator;
+
+import greencity.annotations.ValidSettlementDate;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class SettlementDateValidator implements ConstraintValidator<ValidSettlementDate, String> {
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    @Override
+    public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
+        return LocalDate.parse(s, formatter).isBefore(LocalDate.now().plusDays(1));
+    }
+}

--- a/service-api/src/main/java/greencity/validator/SettlementDateValidator.java
+++ b/service-api/src/main/java/greencity/validator/SettlementDateValidator.java
@@ -5,12 +5,20 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 public class SettlementDateValidator implements ConstraintValidator<ValidSettlementDate, String> {
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     @Override
     public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
-        return LocalDate.parse(s, formatter).isBefore(LocalDate.now().plusDays(1));
+        if (s == null) {
+            return false;
+        }
+        try {
+          return LocalDate.parse(s, formatter).isBefore(LocalDate.now().plusDays(1));
+        } catch (DateTimeParseException e) {
+            return false;
+        }
     }
 }

--- a/service-api/src/main/java/greencity/validator/SettlementDateValidator.java
+++ b/service-api/src/main/java/greencity/validator/SettlementDateValidator.java
@@ -16,7 +16,7 @@ public class SettlementDateValidator implements ConstraintValidator<ValidSettlem
             return false;
         }
         try {
-          return LocalDate.parse(s, formatter).isBefore(LocalDate.now().plusDays(1));
+            return LocalDate.parse(s, formatter).isBefore(LocalDate.now().plusDays(1));
         } catch (DateTimeParseException e) {
             return false;
         }

--- a/service-api/src/test/java/greencity/validator/SettlementDateValidatorTest.java
+++ b/service-api/src/test/java/greencity/validator/SettlementDateValidatorTest.java
@@ -1,0 +1,40 @@
+package greencity.validator;
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SettlementDateValidatorTest {
+    @Mock
+    private ConstraintValidatorContext context;
+    private static final SettlementDateValidator validator = new SettlementDateValidator();
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    @Test
+    public void validateValidSettlementDate() {
+        LocalDate localDate = LocalDate.now();
+        assertTrue(validator.isValid(formatter.format(localDate), context));
+        localDate = LocalDate.of(2020, 1, 1);
+        assertTrue(validator.isValid(formatter.format(localDate), context));
+        localDate = LocalDate.now().minusDays(1);
+        assertTrue(validator.isValid(formatter.format(localDate), context));
+    }
+    @Test
+    public void validateInvalidSettlementDate() {
+        LocalDate localDate = LocalDate.now().plusDays(1);
+        assertFalse(validator.isValid(formatter.format(localDate), context));
+        localDate = LocalDate.now().plusMonths(1);
+        assertFalse(validator.isValid(formatter.format(localDate), context));
+        localDate = LocalDate.now().plusYears(1);
+        assertFalse(validator.isValid(formatter.format(localDate), context));
+        String wrongFormatDate = "05-09-2020";
+        assertFalse(validator.isValid(wrongFormatDate, context));
+        assertFalse(validator.isValid(null, context));
+    }
+}

--- a/service-api/src/test/java/greencity/validator/SettlementDateValidatorTest.java
+++ b/service-api/src/test/java/greencity/validator/SettlementDateValidatorTest.java
@@ -3,7 +3,6 @@ package greencity.validator;
 import jakarta.validation.ConstraintValidatorContext;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
@@ -25,6 +24,7 @@ public class SettlementDateValidatorTest {
         localDate = LocalDate.now().minusDays(1);
         assertTrue(validator.isValid(formatter.format(localDate), context));
     }
+
     @Test
     public void validateInvalidSettlementDate() {
         LocalDate localDate = LocalDate.now().plusDays(1);

--- a/service-api/src/test/java/greencity/validator/SettlementDateValidatorTest.java
+++ b/service-api/src/test/java/greencity/validator/SettlementDateValidatorTest.java
@@ -9,32 +9,44 @@ import java.time.format.DateTimeFormatter;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SettlementDateValidatorTest {
+class SettlementDateValidatorTest {
     @Mock
     private ConstraintValidatorContext context;
     private static final SettlementDateValidator validator = new SettlementDateValidator();
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     @Test
-    public void validateValidSettlementDate() {
+    void validateValidSettlementDate() {
         LocalDate localDate = LocalDate.now();
         assertTrue(validator.isValid(formatter.format(localDate), context));
+
         localDate = LocalDate.of(2020, 1, 1);
         assertTrue(validator.isValid(formatter.format(localDate), context));
+
         localDate = LocalDate.now().minusDays(1);
         assertTrue(validator.isValid(formatter.format(localDate), context));
     }
 
     @Test
-    public void validateInvalidSettlementDate() {
+    void validateInvalidSettlementDate() {
         LocalDate localDate = LocalDate.now().plusDays(1);
         assertFalse(validator.isValid(formatter.format(localDate), context));
+
         localDate = LocalDate.now().plusMonths(1);
         assertFalse(validator.isValid(formatter.format(localDate), context));
+
         localDate = LocalDate.now().plusYears(1);
         assertFalse(validator.isValid(formatter.format(localDate), context));
+
         String wrongFormatDate = "05-09-2020";
         assertFalse(validator.isValid(wrongFormatDate, context));
+
+        wrongFormatDate = "05/09/2020";
+        assertFalse(validator.isValid(wrongFormatDate, context));
+
+        wrongFormatDate = "05.09.2020";
+        assertFalse(validator.isValid(wrongFormatDate, context));
+
         assertFalse(validator.isValid(null, context));
     }
 }

--- a/service/src/main/java/greencity/service/ubs/PaymentServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/PaymentServiceImpl.java
@@ -353,7 +353,7 @@ public class PaymentServiceImpl implements PaymentService {
     private Payment changePaymentEntity(Payment updatePayment,
         ManualPaymentRequestDto requestDto,
         MultipartFile image) {
-        updatePayment.setSettlementDate(requestDto.getSettlementdate());
+        updatePayment.setSettlementDate(requestDto.getSettlementDate());
         updatePayment.setAmount(requestDto.getAmount());
         updatePayment.setPaymentId(requestDto.getPaymentId());
         updatePayment.setReceiptLink(requestDto.getReceiptLink());

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2122,7 +2122,7 @@ public class ModelUtils {
 
     public static ManualPaymentRequestDto getManualPaymentRequestDto() {
         return ManualPaymentRequestDto.builder()
-            .settlementdate("02-08-2021")
+            .settlementDate("02-08-2021")
             .amount(500L)
             .receiptLink("link")
             .paymentId("1")

--- a/service/src/test/java/greencity/service/ubs/PaymentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/PaymentServiceImplTest.java
@@ -448,9 +448,9 @@ class PaymentServiceImplTest {
 
     private static Stream<Arguments> provideManualPaymentRequestDto() {
         return Stream.of(Arguments.of(ManualPaymentRequestDto.builder()
-            .settlementdate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build(), null),
+            .settlementDate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build(), null),
             Arguments.of(ManualPaymentRequestDto.builder()
-                .settlementdate("02-08-2021").amount(500L).imagePath("path").paymentId("1").build(),
+                .settlementDate("02-08-2021").amount(500L).imagePath("path").paymentId("1").build(),
                 Mockito.mock(MultipartFile.class)));
     }
 
@@ -468,7 +468,7 @@ class PaymentServiceImplTest {
         payment.setAmount(0L);
         order.setPayment(singletonList(payment));
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
-            .settlementdate("02-08-2021").amount(0L).receiptLink("link").paymentId("1").build();
+            .settlementDate("02-08-2021").amount(0L).receiptLink("link").paymentId("1").build();
         Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
@@ -501,7 +501,7 @@ class PaymentServiceImplTest {
         payment.setAmount(50_00L);
         order.setPayment(singletonList(payment));
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
-            .settlementdate("02-08-2021").amount(50_00L).receiptLink("link").paymentId("1").build();
+            .settlementDate("02-08-2021").amount(50_00L).receiptLink("link").paymentId("1").build();
         Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
@@ -538,7 +538,7 @@ class PaymentServiceImplTest {
         payment.setAmount(500_00L);
         order.setPayment(singletonList(payment));
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
-            .settlementdate("02-08-2021").amount(500_00L).receiptLink("link").paymentId("1").build();
+            .settlementDate("02-08-2021").amount(500_00L).receiptLink("link").paymentId("1").build();
         Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
@@ -570,7 +570,7 @@ class PaymentServiceImplTest {
         order.setOrderPaymentStatus(OrderPaymentStatus.PAID);
         Payment payment = getManualPayment();
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
-            .settlementdate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
+            .settlementDate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
         Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
@@ -599,7 +599,7 @@ class PaymentServiceImplTest {
         order.setOrderPaymentStatus(OrderPaymentStatus.HALF_PAID);
         Payment payment = getManualPayment();
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
-            .settlementdate("02-08-2021").amount(200L).receiptLink("link").paymentId("1").build();
+            .settlementDate("02-08-2021").amount(200L).receiptLink("link").paymentId("1").build();
         Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
@@ -628,7 +628,7 @@ class PaymentServiceImplTest {
         order.setOrderPaymentStatus(OrderPaymentStatus.UNPAID);
         Payment payment = getManualPayment();
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
-            .settlementdate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
+            .settlementDate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
         Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
@@ -657,7 +657,7 @@ class PaymentServiceImplTest {
         order.setOrderPaymentStatus(OrderPaymentStatus.PAYMENT_REFUNDED);
         Payment payment = getManualPayment();
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
-            .settlementdate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
+            .settlementDate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
         Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
@@ -686,7 +686,7 @@ class PaymentServiceImplTest {
         order.setOrderPaymentStatus(OrderPaymentStatus.PAID);
         Payment payment = getManualPayment();
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
-            .settlementdate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
+            .settlementDate("02-08-2021").amount(500L).receiptLink("link").paymentId("1").build();
         Employee employee = getEmployee();
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
         when(employeeRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(employee));
@@ -709,7 +709,7 @@ class PaymentServiceImplTest {
     @Test
     void saveNewManualPaymentWithoutLinkAndImageTest() {
         ManualPaymentRequestDto paymentDetails = ManualPaymentRequestDto.builder()
-            .settlementdate("02-08-2021").amount(500L).paymentId("1").build();
+            .settlementDate("02-08-2021").amount(500L).paymentId("1").build();
         assertThrows(BadRequestException.class,
             () -> paymentServiceImpl.saveNewManualPayment(1L, paymentDetails, null, TEST_EMAIL));
     }


### PR DESCRIPTION
## GIT

* [Main GIT ticket](https://github.com/ita-social-projects/GreenCity/issues/8200)

I have introduced new SettlementDate validator to ensure that passed date is not in the future. 
Also fixed old tests which required validator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced input validation for order management and manual payment processing.
  - Enforced stricter rules to ensure settlement dates are not set in the future.
  - Introduced a new method for constructing `CertificateDtoForAdding`.

- **Bug Fixes**
  - Updated date handling in `ManualPaymentRequestDto` to ensure correct formatting.
  - Corrected method references to align with updated naming conventions.

- **Tests**
  - Added tests to verify that attempts to use future settlement dates are correctly rejected by the system.
  - Introduced a new test class for validating settlement date functionality.
  - Updated test setup for improved efficiency and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->