### PR TITLE
Commented sql dialect variable for prod application.properties;

### DIFF
--- a/core/src/main/resources/application-prod.properties
+++ b/core/src/main/resources/application-prod.properties
@@ -18,7 +18,7 @@ spring.liquibase.change-log=${LIQUIBASE_LOG}
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto=${HIBERNATE_CONFIG}
-spring.jpa.properties.hibernate.dialect=${DIALECT}
+#spring.jpa.properties.hibernate.dialect=${DIALECT}
 #spring.jpa.show-sql=${SHOW_SQL}
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=${JDBC_LOB}
 


### PR DESCRIPTION
## PR Description

Currently, we encounter the following error during deployment:  
`Unable to resolve name [org.hibernate.dialect.PostgreSQL9Dialect] as a strategy [org.hibernate.dialect.Dialect].`


The issue occurs because `PostgreSQL9Dialect` was removed in **Hibernate 6**.  

In this PR, the following line has been **commented out**:  

```properties
spring.jpa.properties.hibernate.dialect=${DIALECT}
```


This allows Hibernate to automatically determine the appropriate dialect.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the internal database configuration to rely on system defaults for handling SQL interactions. This adjustment streamlines the process without affecting the day-to-day operations you experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->