### PR TITLE
Bugfix #8236 - Remove deprecated and insecure properties from configuration

### DIFF
--- a/core/src/main/resources/application-prod.properties
+++ b/core/src/main/resources/application-prod.properties
@@ -18,8 +18,6 @@ spring.liquibase.change-log=${LIQUIBASE_LOG}
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto=${HIBERNATE_CONFIG}
-#spring.jpa.properties.hibernate.dialect=${DIALECT}
-#spring.jpa.show-sql=${SHOW_SQL}
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=${JDBC_LOB}
 
 #RestTemplate


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
[#8236](https://github.com/ita-social-projects/GreenCity/issues/8236)

## Deleted
- Removed next properties from `application-prod.properties`
```property
#spring.jpa.properties.hibernate.dialect=${DIALECT}
#spring.jpa.show-sql=${SHOW_SQL}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed redundant configuration notes to streamline production settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->