### PR TITLE
Bug/8248_8249/fixed null values in response dtos

### DIFF
--- a/service/src/main/java/greencity/mapping/event/EventToEventDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/event/EventToEventDtoMapper.java
@@ -10,10 +10,10 @@ public class EventToEventDtoMapper extends AbstractConverter<Event, EventDto> {
     @Override
     protected EventDto convert(Event event) {
         return EventDto.builder()
-                .eventDate(event.getEventDate())
-                .id(event.getId())
-                .eventName(event.getEventNameUk())
-                .authorName(event.getAuthorNameUk())
-                .build();
+            .eventDate(event.getEventDate())
+            .id(event.getId())
+            .eventName(event.getEventNameUk())
+            .authorName(event.getAuthorNameUk())
+            .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/event/EventToEventDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/event/EventToEventDtoMapper.java
@@ -1,0 +1,19 @@
+package greencity.mapping.event;
+
+import greencity.dto.order.EventDto;
+import greencity.entity.order.Event;
+import org.modelmapper.AbstractConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventToEventDtoMapper extends AbstractConverter<Event, EventDto> {
+    @Override
+    protected EventDto convert(Event event) {
+        return EventDto.builder()
+                .eventDate(event.getEventDate())
+                .id(event.getId())
+                .eventName(event.getEventNameUk())
+                .authorName(event.getAuthorNameUk())
+                .build();
+    }
+}

--- a/service/src/main/java/greencity/mapping/location/api/LocationToDistrictDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/location/api/LocationToDistrictDtoMapper.java
@@ -17,7 +17,7 @@ public class LocationToDistrictDtoMapper extends AbstractConverter<LocationDto, 
     @Override
     public DistrictDto convert(LocationDto locationDto) {
         return DistrictDto.builder()
-            .nameUk(locationDto.getLocationNameMap().get("name"))
+            .nameUk(locationDto.getLocationNameMap().get("name_uk"))
             .nameEn(locationDto.getLocationNameMap().get("name_en"))
             .build();
     }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -5929,4 +5929,24 @@ public class ModelUtils {
             .amountBeforePayment(120d)
             .build();
     }
+
+    public static Event getEvent3() {
+        return Event.builder()
+                .eventDate(LocalDateTime.of(2025, 3, 12, 20, 20))
+                .eventNameEn("Event 3")
+                .eventNameUk("Івент 3")
+                .authorNameEn("Author 3")
+                .authorNameUk("Автор 3")
+                .id(1L)
+                .build();
+    }
+
+    public static EventDto getEventDto() {
+        return EventDto.builder()
+                .eventDate(LocalDateTime.of(2025, 3, 12, 20, 20))
+                .eventName("Івент 3")
+                .authorName("Автор 3")
+                .id(1L)
+                .build();
+    }
 }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -5932,21 +5932,21 @@ public class ModelUtils {
 
     public static Event getEvent3() {
         return Event.builder()
-                .eventDate(LocalDateTime.of(2025, 3, 12, 20, 20))
-                .eventNameEn("Event 3")
-                .eventNameUk("Івент 3")
-                .authorNameEn("Author 3")
-                .authorNameUk("Автор 3")
-                .id(1L)
-                .build();
+            .eventDate(LocalDateTime.of(2025, 3, 12, 20, 20))
+            .eventNameEn("Event 3")
+            .eventNameUk("Івент 3")
+            .authorNameEn("Author 3")
+            .authorNameUk("Автор 3")
+            .id(1L)
+            .build();
     }
 
     public static EventDto getEventDto() {
         return EventDto.builder()
-                .eventDate(LocalDateTime.of(2025, 3, 12, 20, 20))
-                .eventName("Івент 3")
-                .authorName("Автор 3")
-                .id(1L)
-                .build();
+            .eventDate(LocalDateTime.of(2025, 3, 12, 20, 20))
+            .eventName("Івент 3")
+            .authorName("Автор 3")
+            .id(1L)
+            .build();
     }
 }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -1860,7 +1860,7 @@ public class ModelUtils {
 
     public static LocationDto getLocationApiDto() {
         return LocationDto.builder()
-            .locationNameMap(Map.of("name", "Вінниця", "name_en", "Vinnytsa"))
+            .locationNameMap(Map.of("name_uk", "Вінниця", "name_en", "Vinnytsa"))
             .build();
     }
 

--- a/service/src/test/java/greencity/mapping/event/EventToEventDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/event/EventToEventDtoMapperTest.java
@@ -9,7 +9,6 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
 @ExtendWith(MockitoExtension.class)
 class EventToEventDtoMapperTest {
     @InjectMocks

--- a/service/src/test/java/greencity/mapping/event/EventToEventDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/event/EventToEventDtoMapperTest.java
@@ -1,0 +1,28 @@
+package greencity.mapping.event;
+
+import greencity.ModelUtils;
+import greencity.dto.order.EventDto;
+import greencity.entity.order.Event;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@ExtendWith(MockitoExtension.class)
+class EventToEventDtoMapperTest {
+    @InjectMocks
+    private EventToEventDtoMapper mapper;
+
+    @Test
+    void convertTest() {
+        Event event = ModelUtils.getEvent3();
+        EventDto expectedEventDto = ModelUtils.getEventDto();
+        EventDto actualEventDto = mapper.convert(event);
+        assertEquals(actualEventDto.getEventDate(), expectedEventDto.getEventDate());
+        assertEquals(actualEventDto.getEventName(), expectedEventDto.getEventName());
+        assertEquals(actualEventDto.getId(), expectedEventDto.getId());
+        assertEquals(actualEventDto.getAuthorName(), expectedEventDto.getAuthorName());
+    }
+}


### PR DESCRIPTION
Tasks [#8249](https://github.com/orgs/ita-social-projects/projects/43/views/1?pane=issue&itemId=102213626&issue=ita-social-projects%7CGreenCity%7C8249) and [#8248](https://github.com/orgs/ita-social-projects/projects/43/views/1?pane=issue&itemId=102212452&issue=ita-social-projects%7CGreenCity%7C8248)

Fixed the null values in response dtos that occurred after the renaming due to the incorrect mapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new component that transforms event information into a standardized, display-ready format.
  
- **Bug Fixes**
  - Updated the mapping logic to ensure accurate retrieval of Ukrainian names in location data.
  
- **Tests**
  - Enhanced testing utilities with additional methods and added tests to verify the reliability of event conversion and location mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->