### PR TITLE
Fixed bug when ubs-admin could not delete order's violation

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -289,7 +289,7 @@ public class ManagementOrderController {
         @RequestPart(required = false) @Nullable MultipartFile[] files,
         Principal principal) {
         violationService.addUserViolation(add, files, principal.getName());
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     /**

--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -271,14 +271,20 @@ public class ManagementOrderController {
     /**
      * Adds a violation record to a user.
      *
-     * <p>This endpoint processes a violation addition request by accepting a violation DTO and optional supporting files.
-     * The user is identified from the authenticated principal, and upon successful processing, the method returns an
-     * HTTP 201 (Created) status.
+     * <p>
      *
-     * @param add the violation details, including order reference and description, to be added to the user record
-     * @param files optional attachments supporting the violation
+     * This endpoint processes a violation addition request by accepting a violation
+     * DTO and optional supporting files. The user is identified from the
+     * authenticated principal, and upon successful processing, the method returns
+     * an HTTP 201 (Created) status.
+     * </p>
+     *
+     * @param add       the violation details, including order reference and
+     *                  description, to be added to the user record
+     * @param files     optional attachments supporting the violation
      * @param principal the authenticated user's security principal
-     * @return a ResponseEntity with HTTP 201 (Created) status indicating the violation was successfully recorded
+     * @return a ResponseEntity with HTTP 201 (Created) status indicating the
+     *         violation was successfully recorded
      */
     @Operation(summary = "Add Violation to User")
     @ApiResponses(value = {

--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -269,11 +269,16 @@ public class ManagementOrderController {
     }
 
     /**
-     * Controller for adding User violation.
+     * Adds a violation record to a user.
      *
-     * @return {@link AddingViolationsToUserDto} count of Users violations with
-     *         order id descriptions.
-     * @author Bohdan Melnyk
+     * <p>This endpoint processes a violation addition request by accepting a violation DTO and optional supporting files.
+     * The user is identified from the authenticated principal, and upon successful processing, the method returns an
+     * HTTP 201 (Created) status.
+     *
+     * @param add the violation details, including order reference and description, to be added to the user record
+     * @param files optional attachments supporting the violation
+     * @param principal the authenticated user's security principal
+     * @return a ResponseEntity with HTTP 201 (Created) status indicating the violation was successfully recorded
      */
     @Operation(summary = "Add Violation to User")
     @ApiResponses(value = {

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -694,6 +694,14 @@ public class ModelUtils {
             .build();
     }
 
+    /**
+     * Returns a preconfigured CertificateDtoForAdding instance.
+     *
+     * <p>This method builds a CertificateDtoForAdding object using default values:
+     * 10 points, a month count of 1, an initial points value of 2000, and the certificate code "4444-4444".</p>
+     *
+     * @return a CertificateDtoForAdding instance with preset certificate values
+     */
     public static CertificateDtoForAdding getCertificateDtoForAdding() {
         return CertificateDtoForAdding
             .builder()
@@ -704,6 +712,15 @@ public class ModelUtils {
             .build();
     }
 
+    /**
+     * Constructs an AddingViolationsToUserDto with default violation details.
+     *
+     * <p>This method creates an AddingViolationsToUserDto using its builder pattern, 
+     * setting the order ID to 1, the violation description to "Violation description", 
+     * and the violation level to "LOW".</p>
+     *
+     * @return an AddingViolationsToUserDto instance populated with preset values
+     */
     public static AddingViolationsToUserDto getAddingViolationsToUserDto() {
         return AddingViolationsToUserDto.builder()
             .orderID(1L)

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -60,6 +60,7 @@ import greencity.dto.user.UserProfileCreateDto;
 import greencity.dto.user.UserProfileDto;
 import greencity.dto.useragreement.UserAgreementDetailDto;
 import greencity.dto.useragreement.UserAgreementDto;
+import greencity.dto.violation.AddingViolationsToUserDto;
 import greencity.dto.violation.ViolationDetailInfoDto;
 import greencity.entity.coords.Coordinates;
 import greencity.enums.CancellationReason;
@@ -700,6 +701,14 @@ public class ModelUtils {
             .monthCount(1)
             .initialPointsValue(2000)
             .code("4444-4444")
+            .build();
+    }
+
+    public static AddingViolationsToUserDto getAddingViolationsToUserDto() {
+        return AddingViolationsToUserDto.builder()
+            .orderID(1L)
+            .violationDescription("Violation description")
+            .violationLevel("LOW")
             .build();
     }
 }

--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -697,8 +697,12 @@ public class ModelUtils {
     /**
      * Returns a preconfigured CertificateDtoForAdding instance.
      *
-     * <p>This method builds a CertificateDtoForAdding object using default values:
-     * 10 points, a month count of 1, an initial points value of 2000, and the certificate code "4444-4444".</p>
+     * <p>
+     *
+     * This method builds a CertificateDtoForAdding object using default values: 10
+     * points, a month count of 1, an initial points value of 2000, and the
+     * certificate code "4444-4444".
+     * </p>
      *
      * @return a CertificateDtoForAdding instance with preset certificate values
      */
@@ -715,9 +719,13 @@ public class ModelUtils {
     /**
      * Constructs an AddingViolationsToUserDto with default violation details.
      *
-     * <p>This method creates an AddingViolationsToUserDto using its builder pattern, 
-     * setting the order ID to 1, the violation description to "Violation description", 
-     * and the violation level to "LOW".</p>
+     * <p>
+     *
+     * This method creates an AddingViolationsToUserDto using its builder pattern,
+     * setting the order ID to 1, the violation description to "Violation
+     * description", and the violation level to "LOW".
+     *
+     * </p>
      *
      * @return an AddingViolationsToUserDto instance populated with preset values
      */

--- a/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
@@ -11,6 +11,7 @@ import greencity.dto.order.UpdateAllOrderPageDto;
 import greencity.dto.order.UpdateOrderPageAdminDto;
 import greencity.dto.payment.ManualPaymentRequestDto;
 import greencity.dto.user.AddingPointsToUserDto;
+import greencity.dto.violation.AddingViolationsToUserDto;
 import greencity.dto.violation.ViolationDetailInfoDto;
 import greencity.filters.CertificateFilterCriteria;
 import greencity.filters.CertificatePage;
@@ -37,6 +38,8 @@ import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequ
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static greencity.ModelUtils.getAddingViolationsToUserDto;
 import static greencity.ModelUtils.getEcoNumberDto;
 import static greencity.ModelUtils.getManualPaymentRequestDto;
 import static greencity.ModelUtils.getUpdateOrderPageAdminDto;
@@ -466,5 +469,26 @@ class ManagementOrderControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().string("<Boolean>true</Boolean>"));
         verify(ubsManagementService).checkIfOrderStatusIsFormedToCanceled(orderId);
+    }
+
+    @Test
+    void addViolationToUserReturnsCreatedForValidDataTest() throws Exception {
+        AddingViolationsToUserDto dto = getAddingViolationsToUserDto();
+        String jsonDto = objectMapper.writeValueAsString(dto);
+        MockMultipartFile file = new MockMultipartFile(
+            "add",
+            "",
+            "application/json",
+            jsonDto.getBytes());
+        MockMultipartHttpServletRequestBuilder builder =
+            MockMvcRequestBuilders.multipart(ubsManagementLink + "/addViolationToUser");
+        builder.with(request -> {
+            request.setMethod("POST");
+            return request;
+        });
+        mockMvc.perform(builder.file(file)
+            .principal(principal)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated());
     }
 }

--- a/dao/src/main/java/greencity/repository/ViolationRepository.java
+++ b/dao/src/main/java/greencity/repository/ViolationRepository.java
@@ -40,19 +40,22 @@ public interface ViolationRepository extends CrudRepository<Violation, Long> {
     Long getNumberOfViolationsByUser(@Param(value = "userId") Long userId);
 
     /**
-     * Method returns active violation by order id.
+     * Retrieves the active violation for the specified order ID.
      *
-     * @param orderId {@link Long} .
-     * @return optional of {@link Violation} .
+     * @param orderId the unique identifier of the order to find the active violation for
+     * @return an Optional containing the active Violation if found, or an empty Optional if none exists
      */
     @Query(value = "SELECT v FROM Violation v WHERE v.order.id = ?1 AND v.violationStatus = 'ACTIVE'")
     Optional<Violation> findActiveViolationByOrderId(Long orderId);
 
     /**
-     * Method returns deleted violation by order id.
+     * Retrieves an optional canceled violation for the specified order ID.
      *
-     * @param orderId {@link Long} .
-     * @return optional of {@link Violation} .
+     * <p>This method uses a JPQL query to fetch the Violation associated with the given order ID
+     * where the violation status is marked as 'DELETED', indicating a canceled violation.</p>
+     *
+     * @param orderId the identifier of the order to search for its canceled violation
+     * @return an Optional containing the Violation if a matching canceled violation is found, or an empty Optional otherwise
      */
     @Query(value = "SELECT v FROM Violation v WHERE v.order.id = ?1 AND v.violationStatus = 'DELETED'")
     Optional<Violation> findCanceledViolationByOrderId(Long orderId);

--- a/dao/src/main/java/greencity/repository/ViolationRepository.java
+++ b/dao/src/main/java/greencity/repository/ViolationRepository.java
@@ -45,8 +45,15 @@ public interface ViolationRepository extends CrudRepository<Violation, Long> {
      * @param orderId {@link Long} .
      * @return optional of {@link Violation} .
      */
-    @Query(value = "select * from violations_description_mapping v"
-        + " where v.order_id = :orderId"
-        + " and v.violation_status = 'ACTIVE'", nativeQuery = true)
+    @Query(value = "SELECT v FROM Violation v WHERE v.order.id = ?1 AND v.violationStatus = 'ACTIVE'")
     Optional<Violation> findActiveViolationByOrderId(@Param(value = "orderId") Long orderId);
+
+    /**
+     * Method returns deleted violation by order id.
+     *
+     * @param orderId {@link Long} .
+     * @return optional of {@link Violation} .
+     */
+    @Query(value = "SELECT v FROM Violation v WHERE v.order.id = ?1 AND v.violationStatus = 'DELETED'")
+    Optional<Violation> findCanceledViolationByOrderId(@Param(value = "orderId") Long orderId);
 }

--- a/dao/src/main/java/greencity/repository/ViolationRepository.java
+++ b/dao/src/main/java/greencity/repository/ViolationRepository.java
@@ -46,7 +46,7 @@ public interface ViolationRepository extends CrudRepository<Violation, Long> {
      * @return optional of {@link Violation} .
      */
     @Query(value = "SELECT v FROM Violation v WHERE v.order.id = ?1 AND v.violationStatus = 'ACTIVE'")
-    Optional<Violation> findActiveViolationByOrderId(@Param(value = "orderId") Long orderId);
+    Optional<Violation> findActiveViolationByOrderId(Long orderId);
 
     /**
      * Method returns deleted violation by order id.
@@ -55,5 +55,5 @@ public interface ViolationRepository extends CrudRepository<Violation, Long> {
      * @return optional of {@link Violation} .
      */
     @Query(value = "SELECT v FROM Violation v WHERE v.order.id = ?1 AND v.violationStatus = 'DELETED'")
-    Optional<Violation> findCanceledViolationByOrderId(@Param(value = "orderId") Long orderId);
+    Optional<Violation> findCanceledViolationByOrderId(Long orderId);
 }

--- a/dao/src/main/java/greencity/repository/ViolationRepository.java
+++ b/dao/src/main/java/greencity/repository/ViolationRepository.java
@@ -42,8 +42,10 @@ public interface ViolationRepository extends CrudRepository<Violation, Long> {
     /**
      * Retrieves the active violation for the specified order ID.
      *
-     * @param orderId the unique identifier of the order to find the active violation for
-     * @return an Optional containing the active Violation if found, or an empty Optional if none exists
+     * @param orderId the unique identifier of the order to find the active
+     *                violation for
+     * @return an Optional containing the active Violation if found, or an empty
+     *         Optional if none exists
      */
     @Query(value = "SELECT v FROM Violation v WHERE v.order.id = ?1 AND v.violationStatus = 'ACTIVE'")
     Optional<Violation> findActiveViolationByOrderId(Long orderId);
@@ -51,11 +53,16 @@ public interface ViolationRepository extends CrudRepository<Violation, Long> {
     /**
      * Retrieves an optional canceled violation for the specified order ID.
      *
-     * <p>This method uses a JPQL query to fetch the Violation associated with the given order ID
-     * where the violation status is marked as 'DELETED', indicating a canceled violation.</p>
+     * <p>
+     * This method uses a JPQL query to fetch the Violation associated with the
+     * given order ID where the violation status is marked as 'DELETED', indicating
+     * a canceled violation.
+     * </p>
      *
-     * @param orderId the identifier of the order to search for its canceled violation
-     * @return an Optional containing the Violation if a matching canceled violation is found, or an empty Optional otherwise
+     * @param orderId the identifier of the order to search for its canceled
+     *                violation
+     * @return an Optional containing the Violation if a matching canceled violation
+     *         is found, or an empty Optional otherwise
      */
     @Query(value = "SELECT v FROM Violation v WHERE v.order.id = ?1 AND v.violationStatus = 'DELETED'")
     Optional<Violation> findCanceledViolationByOrderId(Long orderId);

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -470,7 +470,7 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     public void notifyDeleteViolation(Long orderId) {
         Set<NotificationParameter> parameters = new HashSet<>();
-        Violation violation = violationRepository.findActiveViolationByOrderId(orderId)
+        Violation violation = violationRepository.findCanceledViolationByOrderId(orderId)
             .orElseThrow(() -> new NotFoundException(VIOLATION_DOES_NOT_EXIST));
         parameters.add(NotificationParameter.builder()
             .key(ORDER_NUMBER_KEY)

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -465,7 +465,14 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     /**
-     * {@inheritDoc}
+     * Notifies the user about a canceled violation associated with a specific order.
+     * <p>
+     * Retrieves the canceled violation for the given order identifier. If the violation does not exist,
+     * a NotFoundException is thrown. Otherwise, constructs notification parameters (including the order number)
+     * and sends a notification using the cancellation violation notification type.
+     *
+     * @param orderId the identifier of the order linked to the canceled violation
+     * @throws NotFoundException if no canceled violation is found for the provided order identifier
      */
     @Override
     public void notifyDeleteViolation(Long orderId) {

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -465,14 +465,19 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     /**
-     * Notifies the user about a canceled violation associated with a specific order.
+     * Notifies the user about a canceled violation associated with a specific
+     * order.
      * <p>
-     * Retrieves the canceled violation for the given order identifier. If the violation does not exist,
-     * a NotFoundException is thrown. Otherwise, constructs notification parameters (including the order number)
-     * and sends a notification using the cancellation violation notification type.
+     *
+     * Retrieves the canceled violation for the given order identifier. If the
+     * violation does not exist, a NotFoundException is thrown. Otherwise,
+     * constructs notification parameters (including the order number) and sends a
+     * notification using the cancellation violation notification type.
+     * </p>
      *
      * @param orderId the identifier of the order linked to the canceled violation
-     * @throws NotFoundException if no canceled violation is found for the provided order identifier
+     * @throws NotFoundException if no canceled violation is found for the provided
+     *                           order identifier
      */
     @Override
     public void notifyDeleteViolation(Long orderId) {

--- a/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
@@ -182,16 +182,19 @@ public class ViolationServiceImpl implements ViolationService {
     /**
      * Deletes an active violation associated with the specified order.
      * <p>
-     * This method retrieves the employee corresponding to the provided uuid and locates the active violation 
-     * for the given order id. If found, it marks the violation as deleted by updating its status and deletion timestamp,
-     * notifies relevant systems, refreshes the user's violation count, and logs the deletion event. If either the 
-     * employee or the active violation is not found, the method throws an appropriate exception.
+     * This method retrieves the employee corresponding to the provided uuid and
+     * locates the active violation for the given order id. If found, it marks the
+     * violation as deleted by updating its status and deletion timestamp, notifies
+     * relevant systems, refreshes the user's violation count, and logs the deletion
+     * event. If either the employee or the active violation is not found, the
+     * method throws an appropriate exception.
      * </p>
      *
      * @param id   the order id whose active violation is to be deleted
      * @param uuid the unique identifier of the employee performing the deletion
      * @throws UserNotFoundException if no employee is found with the provided uuid
-     * @throws NotFoundException     if no active violation exists for the given order id
+     * @throws NotFoundException     if no active violation exists for the given
+     *                               order id
      */
     @Override
     @Transactional

--- a/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
@@ -44,6 +44,7 @@ import static greencity.constant.ErrorMessage.ORDER_ALREADY_HAS_VIOLATION;
 import static greencity.constant.ErrorMessage.ORDER_HAS_NOT_VIOLATION;
 import static greencity.constant.ErrorMessage.ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST;
 import static greencity.constant.ErrorMessage.USER_WITH_CURRENT_ID_DOES_NOT_EXIST;
+import static greencity.constant.ErrorMessage.USER_WITH_CURRENT_UUID_DOES_NOT_EXIST;
 import static greencity.constant.ErrorMessage.VIOLATION_DOES_NOT_EXIST;
 
 @Service
@@ -182,7 +183,7 @@ public class ViolationServiceImpl implements ViolationService {
     @Transactional
     public void deleteViolation(Long id, String uuid) {
         Employee currentUser = employeeRepository.findByUuid(uuid)
-            .orElseThrow(() -> new UserNotFoundException(USER_WITH_CURRENT_ID_DOES_NOT_EXIST));
+            .orElseThrow(() -> new UserNotFoundException(USER_WITH_CURRENT_UUID_DOES_NOT_EXIST));
 
         Optional<Violation> violationOptional = violationRepository.findActiveViolationByOrderId(id);
         if (violationOptional.isPresent()) {

--- a/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
@@ -179,6 +179,20 @@ public class ViolationServiceImpl implements ViolationService {
             .build());
     }
 
+    /**
+     * Deletes an active violation associated with the specified order.
+     * <p>
+     * This method retrieves the employee corresponding to the provided uuid and locates the active violation 
+     * for the given order id. If found, it marks the violation as deleted by updating its status and deletion timestamp,
+     * notifies relevant systems, refreshes the user's violation count, and logs the deletion event. If either the 
+     * employee or the active violation is not found, the method throws an appropriate exception.
+     * </p>
+     *
+     * @param id   the order id whose active violation is to be deleted
+     * @param uuid the unique identifier of the employee performing the deletion
+     * @throws UserNotFoundException if no employee is found with the provided uuid
+     * @throws NotFoundException     if no active violation exists for the given order id
+     */
     @Override
     @Transactional
     public void deleteViolation(Long id, String uuid) {

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -455,12 +455,11 @@ class NotificationServiceImplTest {
                 .value("46")
                 .build());
             Violation violation = TEST_VIOLATION.setOrder(TEST_ORDER_4);
-            when(violationRepository.findActiveViolationByOrderId(TEST_ORDER_4.getId()))
+            when(violationRepository.findCanceledViolationByOrderId(TEST_ORDER_4.getId()))
                 .thenReturn(Optional.of(violation));
             when(userNotificationRepository.save(TEST_USER_NOTIFICATION_7)).thenReturn(TEST_USER_NOTIFICATION_7);
             parameters.forEach(p -> p.setUserNotification(TEST_USER_NOTIFICATION_7));
             when(notificationParameterRepository.saveAll(parameters)).thenReturn(new LinkedList<>(parameters));
-
             notificationService.notifyDeleteViolation(TEST_ORDER_4.getId());
 
             verify(userNotificationRepository).save(any());


### PR DESCRIPTION
## GIT 

* [Main GIT ticket](https://github.com/ita-social-projects/GreenCity/issues/8151)


## Summary of issue

UBS-admin unable to delete existing order's violation.

## Summary of change
Changed logic of deleteUserViolation method, added corresponding JPQL queries to ViolationsRepository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new method for creating populated violation data transfer objects.
  - Added a test case to verify the addition of violations to users, ensuring correct API response.

- **Bug Fixes**
  - Updated API responses to indicate successful resource creation.
  - Adjusted notification workflows to properly handle canceled violations.

- **Refactor**
  - Modernized data retrieval queries for more consistent behavior.
  - Improved error messaging to provide clearer feedback during user validation.

- **Tests**
  - Revised tests to verify the updated violation handling and notification behavior.
  - Enhanced tests to ensure correct processing of adding violations to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->