### PR TITLE
[8099] - Fixed - The date in the past is accepted in the 'Export date' (added checking if date is before dateNow)

### DIFF
--- a/service/src/main/java/greencity/service/ubs/OrdersAdminsPageServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/OrdersAdminsPageServiceImpl.java
@@ -806,11 +806,9 @@ public class OrdersAdminsPageServiceImpl implements OrdersAdminsPageService {
     public synchronized List<Long> dateOfExportForDevelopStage(List<Long> ordersId, String value, Long employeeId) {
         LocalDate date = LocalDate.parse(value.substring(0, 10), DateTimeFormatter.ISO_LOCAL_DATE);
         LocalDate dateNow = LocalDate.now();
-
-        if(date.isBefore(dateNow)) {
+        if (date.isBefore(dateNow)) {
             throw new BadRequestException("Export date cannot be in the past: " + date);
         }
-
         List<Long> unresolvedGoals = new ArrayList<>();
         for (Long orderId : ordersId) {
             try {

--- a/service/src/main/java/greencity/service/ubs/OrdersAdminsPageServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/OrdersAdminsPageServiceImpl.java
@@ -805,6 +805,12 @@ public class OrdersAdminsPageServiceImpl implements OrdersAdminsPageService {
     @Override
     public synchronized List<Long> dateOfExportForDevelopStage(List<Long> ordersId, String value, Long employeeId) {
         LocalDate date = LocalDate.parse(value.substring(0, 10), DateTimeFormatter.ISO_LOCAL_DATE);
+        LocalDate dateNow = LocalDate.now();
+
+        if(date.isBefore(dateNow)) {
+            throw new BadRequestException("Export date cannot be in the past: " + date);
+        }
+
         List<Long> unresolvedGoals = new ArrayList<>();
         for (Long orderId : ordersId) {
             try {

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -168,6 +168,7 @@ import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.json.JSONObject;
 import org.modelmapper.ModelMapper;
@@ -231,6 +232,7 @@ import static java.util.stream.Collectors.toMap;
 /**
  * Implementation of {@link UBSClientService}.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UBSClientServiceImpl implements UBSClientService {
@@ -832,6 +834,7 @@ public class UBSClientServiceImpl implements UBSClientService {
             newAddress.setAddressStatus(address.getAddressStatus());
             newAddress.setActual(address.getActual());
 
+            log.info("ADDRESS TO SAVE{}", newAddress);
             addressRepo.save(newAddress);
         } else {
             address.setAddressStatus(AddressStatus.DELETED);

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -63,7 +63,6 @@ import greencity.dto.user.UserProfileCreateDto;
 import greencity.dto.user.UserProfileDto;
 import greencity.dto.user.UserProfileUpdateDto;
 import greencity.entity.coords.Coordinates;
-import greencity.entity.notifications.NotificationParameter;
 import greencity.entity.notifications.UserNotification;
 import greencity.entity.order.Bag;
 import greencity.entity.order.Certificate;
@@ -168,7 +167,6 @@ import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.json.JSONObject;
 import org.modelmapper.ModelMapper;
@@ -232,7 +230,6 @@ import static java.util.stream.Collectors.toMap;
 /**
  * Implementation of {@link UBSClientService}.
  */
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UBSClientServiceImpl implements UBSClientService {
@@ -834,7 +831,6 @@ public class UBSClientServiceImpl implements UBSClientService {
             newAddress.setAddressStatus(address.getAddressStatus());
             newAddress.setActual(address.getActual());
 
-            log.info("ADDRESS TO SAVE{}", newAddress);
             addressRepo.save(newAddress);
         } else {
             address.setAddressStatus(AddressStatus.DELETED);

--- a/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
@@ -1387,4 +1387,54 @@ class OrdersAdminsPageServiceImplTest {
         verify(userRepository).findById(anyLong());
         verify(userRepository).save(any(User.class));
     }
+
+    @Test
+    void dateOfExportForDevelopStage_ShouldThrowException_WhenDateIsInThePast() {
+        Long employeeId = 1L;
+        Long orderId = 100L;
+
+        String pastDate = "2022-12-12";
+        List<Long> ordersId = List.of(orderId);
+
+        BadRequestException exception = assertThrows(
+                BadRequestException.class,
+                () -> ordersAdminsPageService.dateOfExportForDevelopStage(ordersId, pastDate, employeeId)
+        );
+
+        assertEquals("Export date cannot be in the past: 2022-12-12", exception.getMessage());
+    }
+
+    @Test
+    void dateOfExportForDevelopStage_ShouldProcessSuccessfully_WhenDateIsInFuture() {
+        Long employeeId = 1L;
+        Long orderId = 100L;
+
+        String futureDate = LocalDate.now().plusDays(1).toString();
+        List<Long> ordersId = List.of(orderId);
+        Order mockOrder = new Order();
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(mockOrder));
+
+        List<Long> result = ordersAdminsPageService.dateOfExportForDevelopStage(ordersId, futureDate, employeeId);
+
+        assertTrue(result.isEmpty());
+        assertEquals(LocalDate.parse(futureDate), mockOrder.getDateOfExport());
+        verify(orderRepository, times(1)).findById(orderId);
+    }
+
+    @Test
+    void dateOfExportForDevelopStage_ShouldAddToUnresolvedGoals_WhenOrderDoesNotExist() {
+        Long employeeId = 1L;
+        Long orderId = 100L;
+
+        String futureDate = LocalDate.now().plusDays(1).toString();
+        List<Long> ordersId = List.of(orderId);
+        when(orderRepository.findById(orderId)).thenReturn(Optional.empty());
+
+        List<Long> result = ordersAdminsPageService.dateOfExportForDevelopStage(ordersId, futureDate, employeeId);
+
+        assertEquals(1, result.size());
+        assertEquals(orderId, result.get(0));
+        verify(orderRepository, times(1)).findById(orderId);
+    }
+
 }

--- a/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
@@ -370,7 +370,7 @@ class OrdersAdminsPageServiceImplTest {
     @Test
     void dateOfExportForDevelopStageUpdateDeliveringTimeTest() {
         var ordersId = List.of(1L);
-        var newValue = "2023-06-30T00:00:00.000Z";
+        var newValue = "2053-06-30T00:00:00.000Z";
         LocalTime timeFrom = LocalTime.parse("10:30", DateTimeFormatter.ISO_TIME);
         LocalTime timeTo = LocalTime.parse("15:00", DateTimeFormatter.ISO_TIME);
         var employeeId = 3L;
@@ -399,7 +399,7 @@ class OrdersAdminsPageServiceImplTest {
     void dateOfExportForDevelopStageBlockedByAnotherEmployeeThrowExceptionTest() {
         var orderId = 1L;
         var ordersId = List.of(orderId);
-        var newValue = "2023-06-30T00:00:00.000Z";
+        var newValue = "2053-06-30T00:00:00.000Z";
         var employeeId = 3L;
         var anotherEmployeeId = 4L;
         LocalDate exportDate = LocalDate.of(2023, 5, 23);
@@ -791,7 +791,7 @@ class OrdersAdminsPageServiceImplTest {
 
         ordersAdminsPageService.chooseOrdersDataSwitcher(email, dto);
         dto.setColumnName("dateOfExport");
-        dto.setNewValue("2022-12-12");
+        dto.setNewValue("2052-12-12");
         ordersAdminsPageService.chooseOrdersDataSwitcher(email, dto);
         dto.setColumnName("timeOfExport");
         dto.setNewValue("00:00-00:30");

--- a/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/OrdersAdminsPageServiceImplTest.java
@@ -1397,9 +1397,8 @@ class OrdersAdminsPageServiceImplTest {
         List<Long> ordersId = List.of(orderId);
 
         BadRequestException exception = assertThrows(
-                BadRequestException.class,
-                () -> ordersAdminsPageService.dateOfExportForDevelopStage(ordersId, pastDate, employeeId)
-        );
+            BadRequestException.class,
+            () -> ordersAdminsPageService.dateOfExportForDevelopStage(ordersId, pastDate, employeeId));
 
         assertEquals("Export date cannot be in the past: 2022-12-12", exception.getMessage());
     }


### PR DESCRIPTION

Ticket:
https://github.com/orgs/ita-social-projects/projects/43/views/1?filterQuery=8099&pane=issue&itemId=96218730&issue=ita-social-projects%7CGreenCity%7C8099

ToDo
UBS courier [Admin cabinet] The date in the past is accepted in the "Export date" field of the pick up detail pop up window after clicking the "Save" button

Expected result
The "Export date" field is disabled within the pick up detail pop up window upon entering the range of dates in the past

Removed the ability to add a date in the past for the export date.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced export date validation prevents users from setting export dates in the past, ensuring that only current or future dates are accepted.
- **Chores**
	- Removed unused import statement, streamlining the code.
- **Tests**
	- Added new test methods to validate export date functionality, including checks for past and future dates.
	- Updated existing test cases to use future dates for order export validation, ensuring accurate testing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->