### PR TITLE
Adjust the notifications endpoint for it to be used by GreenCity

### DIFF
--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -24,7 +24,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
 import java.util.Locale;
 
 @RestController
@@ -71,10 +73,10 @@ public class NotificationController {
     @GetMapping
     @ApiPageableWithLocale
     public ResponseEntity<PageableAdvancedDto<NotificationShortDto>> getNotificationsForCurrentUser(
-        @Parameter(hidden = true) @CurrentUserUuid String userUuid,
+        @RequestParam String email,
         @Parameter(hidden = true) @ValidLanguage Locale locale, @Parameter(hidden = true) Pageable pageable) {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(notificationService.getAllNotificationsForUser(userUuid, locale.getLanguage(), pageable));
+            .body(notificationService.getAllNotificationsForUser(email, locale.getLanguage(), pageable));
     }
 
     /**

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -26,7 +26,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
 import java.util.Locale;
 
 @RestController

--- a/core/src/test/java/greencity/controller/NotificationControllerTest.java
+++ b/core/src/test/java/greencity/controller/NotificationControllerTest.java
@@ -63,9 +63,13 @@ class NotificationControllerTest {
 
     @Test
     void getNotificationsForCurrentUser() throws Exception {
+        String emailQueryParam = "email";
+        String emailQueryParamValue = "email@email.com";
+
         mockMvc.perform(get(notificationLink)
             .principal(principal)
-            .contentType(MediaType.APPLICATION_JSON))
+            .contentType(MediaType.APPLICATION_JSON)
+            .queryParam(emailQueryParam, emailQueryParamValue))
             .andExpect(MockMvcResultMatchers.status().isOk());
     }
 

--- a/service-api/src/main/java/greencity/service/ubs/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/ubs/NotificationService.java
@@ -183,7 +183,7 @@ public interface NotificationService {
      *
      * @author Ann Sakhno
      */
-    PageableAdvancedDto<NotificationShortDto> getAllNotificationsForUser(String userUuid,
+    PageableAdvancedDto<NotificationShortDto> getAllNotificationsForUser(String email,
         String language, Pageable pageable);
 
     /**

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -1,5 +1,6 @@
 package greencity.service.notification;
 
+import greencity.client.UserRemoteClient;
 import greencity.config.InternalUrlConfigProp;
 import greencity.constant.AppConstant;
 import greencity.constant.OrderHistory;
@@ -91,6 +92,7 @@ public class NotificationServiceImpl implements NotificationService {
     private final OrderRepository orderRepository;
     private final ViolationRepository violationRepository;
     private final NotificationParameterRepository notificationParameterRepository;
+    private final UserRemoteClient userRemoteClient;
     @Autowired
     @Qualifier("kyivZonedClock")
     private Clock clock;
@@ -767,9 +769,10 @@ public class NotificationServiceImpl implements NotificationService {
      * {@inheritDoc}
      */
     @Override
-    public PageableAdvancedDto<NotificationShortDto> getAllNotificationsForUser(String userUuid,
+    public PageableAdvancedDto<NotificationShortDto> getAllNotificationsForUser(String email,
         String language,
         Pageable pageable) {
+        String userUuid = userRemoteClient.findUuidByEmail(email);
         User user = userRepository.findByUuid(userUuid);
 
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -2,6 +2,7 @@ package greencity.service.notification;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import greencity.ModelUtils;
+import greencity.client.UserRemoteClient;
 import greencity.config.InternalUrlConfigProp;
 import greencity.constant.ErrorMessage;
 import greencity.dto.notification.NotificationDto;
@@ -132,6 +133,9 @@ class NotificationServiceImplTest {
 
     @Mock
     private OrderRepository orderRepository;
+
+    @Mock
+    private UserRemoteClient userRemoteClient;
 
     @Mock
     private UserNotificationRepository userNotificationRepository;
@@ -835,6 +839,7 @@ class NotificationServiceImplTest {
                 orderRepository,
                 violationRepository,
                 notificationParameterRepository,
+                userRemoteClient,
                 clock,
                 List.of(abstractNotificationProvider),
                 templateRepository,
@@ -960,7 +965,11 @@ class NotificationServiceImplTest {
 
     @Test
     void testGetAllNotificationForUser() {
-        when(userRepository.findByUuid("Test")).thenReturn(TEST_USER);
+        String email = "email";
+        String uuid = "uuid";
+
+        when(userRemoteClient.findUuidByEmail(email)).thenReturn(uuid);
+        when(userRepository.findByUuid(uuid)).thenReturn(TEST_USER);
         when(userNotificationRepository.findAllByUserAndIsDeletedFalse(TEST_USER, TEST_PAGEABLE))
             .thenReturn(TEST_PAGE);
         when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
@@ -968,7 +977,7 @@ class NotificationServiceImplTest {
             SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
 
         PageableAdvancedDto<NotificationShortDto> actual = notificationService
-            .getAllNotificationsForUser("Test", "ua", TEST_PAGEABLE);
+            .getAllNotificationsForUser(email, "ua", TEST_PAGEABLE);
 
         assertEquals(TEST_PAGEABLE_ADVANCED_DTO, actual);
     }


### PR DESCRIPTION
## Summary of changes ##

To adjust for changes made on GreenCity, since the '/notifications' endpoint will no longer be used directly by frontend but rather by GreenCity via RestClient, the business logic of the endpoint was changed such that notifications could be retrieved for user by passing its email as query parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated how notifications are retrieved by using email addresses for user identification.
  - Integrated a lookup mechanism to dynamically resolve user details before fetching notifications.

- **Tests**
  - Revised tests to simulate real-world scenarios using email-based user identification, ensuring robust and flexible validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->