### PR TITLE
Make phone number and surname optional when updating the user profile

### DIFF
--- a/service-api/src/main/java/greencity/dto/user/UserProfileUpdateDto.java
+++ b/service-api/src/main/java/greencity/dto/user/UserProfileUpdateDto.java
@@ -29,12 +29,10 @@ public class UserProfileUpdateDto implements Serializable {
     @NotBlank
     @Pattern(regexp = ValidationConstant.NAME_REGEXP)
     private String recipientName;
-    @NotBlank
-    @Pattern(regexp = ValidationConstant.NAME_REGEXP)
+    @Pattern(regexp = "^$|" + ValidationConstant.NAME_REGEXP)
     private String recipientSurname;
     @Email(regexp = ValidationConstant.EMAIL_REGEXP)
     private String alternateEmail;
-    @NotBlank
     @ValidPhoneNumber
     private String recipientPhone;
     @Valid

--- a/service-api/src/main/java/greencity/validator/PhoneNumberValidation.java
+++ b/service-api/src/main/java/greencity/validator/PhoneNumberValidation.java
@@ -25,6 +25,9 @@ public class PhoneNumberValidation implements ConstraintValidator<ValidPhoneNumb
      */
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isBlank()) {
+            return true;
+        }
         PhoneNumberUtil phoneUtil = PhoneNumberUtil.getInstance();
         try {
             Phonenumber.PhoneNumber phoneNumber = phoneUtil.parse(value, "UA");

--- a/service-api/src/test/java/greencity/dto/user/UserProfileUpdateDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/user/UserProfileUpdateDtoTest.java
@@ -38,7 +38,7 @@ class UserProfileUpdateDtoTest {
 
     @ParameterizedTest
     @ValueSource(
-        strings = {"InvalidLengthOfName31Characters", "", "   ", "!?+=@#$%^&*", "тест!", "тест@123", "Hello World!"})
+        strings = {"InvalidLengthOfName31Characters", "!?+=@#$%^&*", "тест!", "тест@123", "Hello World!"})
     void testInvalidRecipientSurname(String name) throws NoSuchFieldException {
         checkRegexPattern("recipientSurname", name, false);
     }

--- a/service-api/src/test/java/greencity/validator/PhoneNumberValidationTest.java
+++ b/service-api/src/test/java/greencity/validator/PhoneNumberValidationTest.java
@@ -49,4 +49,14 @@ class PhoneNumberValidationTest {
             () -> validation.isValid(incorrectStr, context));
         assertEquals(thrown.getMessage(), ErrorMessage.PHONE_NUMBER_PARSING_FAIL + incorrectStr);
     }
+
+    @Test
+    void isValidShouldReturnTrueWhenValueIsNullTest() {
+        assertTrue(validation.isValid(null, context));
+    }
+
+    @Test
+    void isValidShouldReturnTrueWhenValueIsEmptyTest() {
+        assertTrue(validation.isValid("", context));
+    }
 }

--- a/service/src/main/java/greencity/service/phone/UAPhoneNumberUtil.java
+++ b/service/src/main/java/greencity/service/phone/UAPhoneNumberUtil.java
@@ -23,6 +23,9 @@ public class UAPhoneNumberUtil {
      */
 
     public static String getE164PhoneNumberFormat(String phoneNumberStr) {
+        if (phoneNumberStr == null || phoneNumberStr.isBlank()) {
+            return null;
+        }
         try {
             Phonenumber.PhoneNumber phoneNumber = phoneNumberUtil.parse(phoneNumberStr, "UA");
             return phoneNumberUtil.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.E164);

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -1585,7 +1585,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         List<AddressDto> addressDto =
             allAddress.stream()
                 .map(a -> modelMapper.map(a, AddressDto.class))
-                .collect(toList());
+                .toList();
         userProfileDto.setAddressDto(addressDto);
         userProfileDto.setBotList(botList);
         userProfileDto.setHasPassword(userRemoteClient.getPasswordStatus().isHasPassword());
@@ -1596,8 +1596,9 @@ public class UBSClientServiceImpl implements UBSClientService {
         user.setRecipientName(userProfileUpdateDto.getRecipientName());
         user.setRecipientSurname(userProfileUpdateDto.getRecipientSurname());
         user.setAlternateEmail(userProfileUpdateDto.getAlternateEmail());
+        String phone = userProfileUpdateDto.getRecipientPhone();
         user.setRecipientPhone(
-            UAPhoneNumberUtil.getE164PhoneNumberFormat(userProfileUpdateDto.getRecipientPhone()));
+            (phone == null || phone.isBlank()) ? null : UAPhoneNumberUtil.getE164PhoneNumberFormat(phone));
     }
 
     private void setTelegramAndViberBots(User user, Boolean telegramIsNotify, Boolean viberIsNotify) {

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -283,6 +283,7 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -1916,6 +1917,32 @@ class UBSClientServiceImplTest {
         verify(ubsClientServiceSpy, times(2)).updateCurrentAddressForOrder(updateAddressRequestDto, uuid);
         verify(userRepository).save(user);
         verify(modelMapper).map(user, UserProfileUpdateDto.class);
+    }
+
+    @Test
+    void shouldSetNullRecipientPhoneWhenEmptyTest() throws Exception {
+        User user = mock(User.class);
+        UserProfileUpdateDto userProfileUpdateDto = getUserProfileUpdateDto();
+        userProfileUpdateDto.setRecipientPhone("");
+        Method setUserDataMethod =
+            UBSClientServiceImpl.class.getDeclaredMethod("setUserData", User.class, UserProfileUpdateDto.class);
+        setUserDataMethod.setAccessible(true);
+        UBSClientServiceImpl service = mock(UBSClientServiceImpl.class);
+        setUserDataMethod.invoke(service, user, userProfileUpdateDto);
+        verify(user, times(1)).setRecipientPhone(null);
+    }
+
+    @Test
+    void shouldSetNullRecipientPhoneWhenNullTest() throws Exception {
+        User user = mock(User.class);
+        UserProfileUpdateDto userProfileUpdateDto = getUserProfileUpdateDto();
+        userProfileUpdateDto.setRecipientPhone(null);
+        Method setUserDataMethod =
+            UBSClientServiceImpl.class.getDeclaredMethod("setUserData", User.class, UserProfileUpdateDto.class);
+        setUserDataMethod.setAccessible(true);
+        UBSClientServiceImpl service = mock(UBSClientServiceImpl.class);
+        setUserDataMethod.invoke(service, user, userProfileUpdateDto);
+        verify(user, times(1)).setRecipientPhone(null);
     }
 
     @Test


### PR DESCRIPTION
GreenCityUBS prod PR

Related issue:

https://github.com/orgs/ita-social-projects/projects/43/views/1?pane=issue&itemId=103291840&issue=ita-social-projects%7CGreenCity%7C8268


Changes:
-remove not black constraint in dto
-update phone number validation
-add new tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated user profile updates now accept an optional recipient surname and phone number, reducing unnecessary input errors.

- **Bug Fixes**
  - Improved handling for blank or null phone numbers ensures consistency and avoids unintended formatting issues.

- **Refactor**
  - Streamlined the process for processing phone numbers and collecting profile address data for better clarity and performance.

- **Tests**
  - Enhanced test coverage to verify correct behavior for empty and null phone number scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->