### PR TITLE
Add endpoint to retrieve notifications with images

### DIFF
--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -6,6 +6,7 @@ import greencity.annotations.CurrentUserUuid;
 import greencity.annotations.ValidLanguage;
 import greencity.constants.HttpStatuses;
 import greencity.dto.notification.NotificationDto;
+import greencity.dto.notification.NotificationFullDto;
 import greencity.dto.notification.NotificationShortDto;
 import greencity.dto.pageble.PageableAdvancedDto;
 import greencity.service.ubs.NotificationService;
@@ -84,21 +85,20 @@ public class NotificationController {
      * @return Page with notifications.
      * @author Ihor Volianskyi
      */
-    @Operation(summary = "Get page with notifications for current user")
+    @Operation(summary = "Get page with notifications for current user including images")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
-            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content)
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content)
     })
-    @GetMapping("/full")
+    @GetMapping("/images")
     @ApiPageableWithLocale
-    public ResponseEntity<PageableAdvancedDto<NotificationDto>> getNotificationsForCurrentUser(
-            @Parameter(hidden = true) @CurrentUserUuid String userUuid,
-            @Parameter(hidden = true) @ValidLanguage Locale locale, @Parameter(hidden = true) Pageable pageable) {
+    public ResponseEntity<PageableAdvancedDto<NotificationFullDto>> getNotificationsForCurrentUser(
+        @Parameter(hidden = true) @CurrentUserUuid String userUuid,
+        @Parameter(hidden = true) @ValidLanguage Locale locale, @Parameter(hidden = true) Pageable pageable) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(notificationService.getAllNotificationsForUser(userUuid, locale.getLanguage(), pageable));
+            .body(notificationService.getAllNotificationsForUser(userUuid, locale.getLanguage(), pageable));
     }
-
 
     /**
      * Controller return quantity of unread notifications for current user.

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -71,12 +71,34 @@ public class NotificationController {
     })
     @GetMapping
     @ApiPageableWithLocale
-    public ResponseEntity<PageableAdvancedDto<NotificationShortDto>> getNotificationsForCurrentUser(
+    public ResponseEntity<PageableAdvancedDto<NotificationShortDto>> getShortNotificationsForCurrentUser(
         @RequestParam String email,
         @Parameter(hidden = true) @ValidLanguage Locale locale, @Parameter(hidden = true) Pageable pageable) {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(notificationService.getAllNotificationsForUser(email, locale.getLanguage(), pageable));
+            .body(notificationService.getAllShortNotificationsForUser(email, locale.getLanguage(), pageable));
     }
+
+    /**
+     * Controller return page with notifications for current user.
+     *
+     * @return Page with notifications.
+     * @author Ihor Volianskyi
+     */
+    @Operation(summary = "Get page with notifications for current user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content)
+    })
+    @GetMapping("/full")
+    @ApiPageableWithLocale
+    public ResponseEntity<PageableAdvancedDto<NotificationDto>> getNotificationsForCurrentUser(
+            @Parameter(hidden = true) @CurrentUserUuid String userUuid,
+            @Parameter(hidden = true) @ValidLanguage Locale locale, @Parameter(hidden = true) Pageable pageable) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(notificationService.getAllNotificationsForUser(userUuid, locale.getLanguage(), pageable));
+    }
+
 
     /**
      * Controller return quantity of unread notifications for current user.

--- a/core/src/test/java/greencity/controller/NotificationControllerTest.java
+++ b/core/src/test/java/greencity/controller/NotificationControllerTest.java
@@ -78,11 +78,11 @@ class NotificationControllerTest {
         String emailQueryParam = "email";
         String emailQueryParamValue = "email@email.com";
 
-        mockMvc.perform(get(notificationLink)
-                        .principal(principal)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .queryParam(emailQueryParam, emailQueryParamValue))
-                .andExpect(MockMvcResultMatchers.status().isOk());
+        mockMvc.perform(get(notificationLink + "/images")
+            .principal(principal)
+            .contentType(MediaType.APPLICATION_JSON)
+            .queryParam(emailQueryParam, emailQueryParamValue))
+            .andExpect(MockMvcResultMatchers.status().isOk());
     }
 
     @Test

--- a/core/src/test/java/greencity/controller/NotificationControllerTest.java
+++ b/core/src/test/java/greencity/controller/NotificationControllerTest.java
@@ -62,7 +62,7 @@ class NotificationControllerTest {
     }
 
     @Test
-    void getNotificationsForCurrentUser() throws Exception {
+    void getShortNotificationsForCurrentUser() throws Exception {
         String emailQueryParam = "email";
         String emailQueryParamValue = "email@email.com";
 
@@ -71,6 +71,18 @@ class NotificationControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .queryParam(emailQueryParam, emailQueryParamValue))
             .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void getNotificationsForCurrentUser() throws Exception {
+        String emailQueryParam = "email";
+        String emailQueryParamValue = "email@email.com";
+
+        mockMvc.perform(get(notificationLink)
+                        .principal(principal)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .queryParam(emailQueryParam, emailQueryParamValue))
+                .andExpect(MockMvcResultMatchers.status().isOk());
     }
 
     @Test

--- a/service-api/src/main/java/greencity/dto/notification/NotificationFullDto.java
+++ b/service-api/src/main/java/greencity/dto/notification/NotificationFullDto.java
@@ -1,0 +1,16 @@
+package greencity.dto.notification;
+
+import lombok.Builder;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record NotificationFullDto(
+    Long id,
+    Long orderId,
+    boolean read,
+    String title,
+    String body,
+    LocalDateTime notificationTime,
+    List<String> images) {
+}

--- a/service-api/src/main/java/greencity/service/ubs/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/ubs/NotificationService.java
@@ -179,12 +179,20 @@ public interface NotificationService {
     void notifySelfPickupOrder(Order order);
 
     /**
-     * Method that returns page with notifications for user by UUID.
+     * Method that returns page with notifications for user by email.
      *
      * @author Ann Sakhno
      */
-    PageableAdvancedDto<NotificationShortDto> getAllNotificationsForUser(String email,
+    PageableAdvancedDto<NotificationShortDto> getAllShortNotificationsForUser(String email,
         String language, Pageable pageable);
+
+    /**
+     * Method that returns page with notifications for user by email.
+     *
+     * @author Maksym Kozak
+     */
+    PageableAdvancedDto<NotificationDto> getAllNotificationsForUser(String uuid,
+                                                                    String language, Pageable pageable);
 
     /**
      * Method that return notification and set status - is read.

--- a/service-api/src/main/java/greencity/service/ubs/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/ubs/NotificationService.java
@@ -1,6 +1,7 @@
 package greencity.service.ubs;
 
 import greencity.dto.notification.NotificationDto;
+import greencity.dto.notification.NotificationFullDto;
 import greencity.dto.notification.NotificationShortDto;
 import greencity.dto.order.PaymentSystemResponse;
 import greencity.dto.pageble.PageableAdvancedDto;
@@ -187,12 +188,12 @@ public interface NotificationService {
         String language, Pageable pageable);
 
     /**
-     * Method that returns page with notifications for user by email.
+     * Method that returns page with notifications for current user.
      *
      * @author Maksym Kozak
      */
-    PageableAdvancedDto<NotificationDto> getAllNotificationsForUser(String uuid,
-                                                                    String language, Pageable pageable);
+    PageableAdvancedDto<NotificationFullDto> getAllNotificationsForUser(String uuid,
+        String language, Pageable pageable);
 
     /**
      * Method that return notification and set status - is read.

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -6,6 +6,7 @@ import greencity.constant.AppConstant;
 import greencity.constant.OrderHistory;
 import greencity.dto.notification.InactiveAccountDto;
 import greencity.dto.notification.NotificationDto;
+import greencity.dto.notification.NotificationFullDto;
 import greencity.dto.notification.NotificationShortDto;
 import greencity.dto.order.PaymentSystemResponse;
 import greencity.dto.pageble.PageableAdvancedDto;
@@ -773,59 +774,56 @@ public class NotificationServiceImpl implements NotificationService {
     public PageableAdvancedDto<NotificationShortDto> getAllShortNotificationsForUser(String email,
         String language,
         Pageable pageable) {
-        Function<UserNotification, NotificationShortDto> mapUserNotificationToNotificationShortDtoFunction
-                = notification -> createNotificationShortDto(notification, language, 0L);
+        Function<UserNotification, NotificationShortDto> mapUserNotificationToNotificationShortDtoFunction =
+            notification -> createNotificationShortDto(notification, language, 0L);
         String userUuid = userRemoteClient.findUuidByEmail(email);
         return getAllNotificationsForUser(
-                userUuid,
-                pageable,
-                mapUserNotificationToNotificationShortDtoFunction
-        );
+            userUuid,
+            pageable,
+            mapUserNotificationToNotificationShortDtoFunction);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public PageableAdvancedDto<NotificationDto> getAllNotificationsForUser(String userUuid,
-                                                                                String language,
-                                                                                Pageable pageable) {
-        Function<UserNotification, NotificationDto> mapUserNotificationToNotificationDtoFunction =
-                notification -> getNotification(userUuid, notification.getId(), language);
+    public PageableAdvancedDto<NotificationFullDto> getAllNotificationsForUser(String userUuid,
+        String language,
+        Pageable pageable) {
+        Function<UserNotification, NotificationFullDto> mapUserNotificationToNotificationFullDtoFunction =
+            notification -> createNotificationFullDto(userUuid, notification, language, 0L);
         return getAllNotificationsForUser(
-                userUuid,
-                pageable,
-                mapUserNotificationToNotificationDtoFunction
-        );
+            userUuid,
+            pageable,
+            mapUserNotificationToNotificationFullDtoFunction);
     }
 
     private <T> PageableAdvancedDto<T> getAllNotificationsForUser(
-            String userUuid,
-            Pageable pageable,
-            Function<UserNotification, T> function
-    ) {
+        String userUuid,
+        Pageable pageable,
+        Function<UserNotification, T> function) {
         User user = userRepository.findByUuid(userUuid);
 
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                Sort.by("notificationTime").descending());
+            Sort.by("notificationTime").descending());
 
         Page<UserNotification> notifications =
-                userNotificationRepository.findAllByUserAndIsDeletedFalse(user, pageRequest);
+            userNotificationRepository.findAllByUserAndIsDeletedFalse(user, pageRequest);
 
         List<T> notificationShortDtoList = notifications.stream()
-                .map(function)
-                .collect(Collectors.toCollection(LinkedList::new));
+            .map(function)
+            .collect(Collectors.toCollection(LinkedList::new));
 
         return new PageableAdvancedDto<>(
-                notificationShortDtoList,
-                notifications.getTotalElements(),
-                notifications.getPageable().getPageNumber(),
-                notifications.getTotalPages(),
-                notifications.getNumber(),
-                notifications.hasPrevious(),
-                notifications.hasNext(),
-                notifications.isFirst(),
-                notifications.isLast());
+            notificationShortDtoList,
+            notifications.getTotalElements(),
+            notifications.getPageable().getPageNumber(),
+            notifications.getTotalPages(),
+            notifications.getNumber(),
+            notifications.hasPrevious(),
+            notifications.hasNext(),
+            notifications.isFirst(),
+            notifications.isLast());
     }
 
     /**
@@ -929,7 +927,6 @@ public class NotificationServiceImpl implements NotificationService {
         }
 
         NotificationDto notificationDto = createNotificationDto(notification, language, SITE, templateRepository, 0L);
-
         if (NotificationType.VIOLATION_THE_RULES.equals(notification.getNotificationType())) {
             NotificationParameter notificationParameter = notification.getParameters().stream()
                 .filter(parameter -> parameter.getKey().equals(VIOLATION_DESCRIPTION))
@@ -974,6 +971,24 @@ public class NotificationServiceImpl implements NotificationService {
             .build();
     }
 
+    private NotificationFullDto createNotificationFullDto(String userUuid, UserNotification notification,
+        String language,
+        Long monthsOfAccountInactivity) {
+        NotificationShortDto notificationShortDto =
+            createNotificationShortDto(notification, language, monthsOfAccountInactivity);
+        NotificationDto notificationDto = getNotification(userUuid, notificationShortDto.getId(), language);
+
+        return NotificationFullDto.builder()
+            .id(notificationShortDto.getId())
+            .orderId(notificationShortDto.getOrderId())
+            .read(notificationShortDto.isRead())
+            .title(notificationShortDto.getTitle())
+            .body(notificationShortDto.getBody())
+            .notificationTime(notificationShortDto.getNotificationTime())
+            .images(notificationDto.getImages())
+            .build();
+    }
+
     private void sendNotificationsForBotsAndEmail(UserNotification notification, long monthsOfAccountInactivity) {
         executor.execute(() -> notificationProviders
             .forEach(provider -> provider.sendNotification(notification, provider.getNotificationType(),
@@ -1000,10 +1015,10 @@ public class NotificationServiceImpl implements NotificationService {
         String title = language.equals("ua") ? template.getTitleUk() : template.getTitleEn();
 
         return NotificationDto.builder()
-                .title(title)
-                .body(resultBody)
-                .images(Collections.emptyList())
-                .build();
+            .title(title)
+            .body(resultBody)
+            .images(Collections.emptyList())
+            .build();
     }
 
     private static NotificationTemplate getNotificationTemplate(

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -70,6 +70,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import static greencity.constant.ErrorMessage.BAG_NOT_FOUND;
 import static greencity.constant.ErrorMessage.NOTIFICATION_DOES_NOT_BELONG_TO_USER;
@@ -769,32 +770,62 @@ public class NotificationServiceImpl implements NotificationService {
      * {@inheritDoc}
      */
     @Override
-    public PageableAdvancedDto<NotificationShortDto> getAllNotificationsForUser(String email,
+    public PageableAdvancedDto<NotificationShortDto> getAllShortNotificationsForUser(String email,
         String language,
         Pageable pageable) {
+        Function<UserNotification, NotificationShortDto> mapUserNotificationToNotificationShortDtoFunction
+                = notification -> createNotificationShortDto(notification, language, 0L);
         String userUuid = userRemoteClient.findUuidByEmail(email);
+        return getAllNotificationsForUser(
+                userUuid,
+                pageable,
+                mapUserNotificationToNotificationShortDtoFunction
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PageableAdvancedDto<NotificationDto> getAllNotificationsForUser(String userUuid,
+                                                                                String language,
+                                                                                Pageable pageable) {
+        Function<UserNotification, NotificationDto> mapUserNotificationToNotificationDtoFunction =
+                notification -> getNotification(userUuid, notification.getId(), language);
+        return getAllNotificationsForUser(
+                userUuid,
+                pageable,
+                mapUserNotificationToNotificationDtoFunction
+        );
+    }
+
+    private <T> PageableAdvancedDto<T> getAllNotificationsForUser(
+            String userUuid,
+            Pageable pageable,
+            Function<UserNotification, T> function
+    ) {
         User user = userRepository.findByUuid(userUuid);
 
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-            Sort.by("notificationTime").descending());
+                Sort.by("notificationTime").descending());
 
         Page<UserNotification> notifications =
-            userNotificationRepository.findAllByUserAndIsDeletedFalse(user, pageRequest);
+                userNotificationRepository.findAllByUserAndIsDeletedFalse(user, pageRequest);
 
-        List<NotificationShortDto> notificationShortDtoList = notifications.stream()
-            .map(n -> createNotificationShortDto(n, language, 0L))
-            .collect(Collectors.toCollection(LinkedList::new));
+        List<T> notificationShortDtoList = notifications.stream()
+                .map(function)
+                .collect(Collectors.toCollection(LinkedList::new));
 
         return new PageableAdvancedDto<>(
-            notificationShortDtoList,
-            notifications.getTotalElements(),
-            notifications.getPageable().getPageNumber(),
-            notifications.getTotalPages(),
-            notifications.getNumber(),
-            notifications.hasPrevious(),
-            notifications.hasNext(),
-            notifications.isFirst(),
-            notifications.isLast());
+                notificationShortDtoList,
+                notifications.getTotalElements(),
+                notifications.getPageable().getPageNumber(),
+                notifications.getTotalPages(),
+                notifications.getNumber(),
+                notifications.hasPrevious(),
+                notifications.hasNext(),
+                notifications.isFirst(),
+                notifications.isLast());
     }
 
     /**
@@ -968,8 +999,11 @@ public class NotificationServiceImpl implements NotificationService {
         String resultBody = sub.replace(String.format(templateBody, monthsOfAccountInactivity));
         String title = language.equals("ua") ? template.getTitleUk() : template.getTitleEn();
 
-        return NotificationDto.builder().title(title)
-            .body(resultBody).build();
+        return NotificationDto.builder()
+                .title(title)
+                .body(resultBody)
+                .images(Collections.emptyList())
+                .build();
     }
 
     private static NotificationTemplate getNotificationTemplate(

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -296,6 +296,8 @@ public class ModelUtils {
     public static final List<Map<String, Object>> TEST_MAP_ADDITIONAL_BAG_LIST =
         Collections.singletonList(TEST_MAP_ADDITIONAL_BAG);
     public static final NotificationDto TEST_NOTIFICATION_DTO = createNotificationDto();
+    public static final List<NotificationDto> TEST_NOTIFICATION_DTO_LIST = List.of(createNotificationDto());
+    public static final PageableAdvancedDto<NotificationDto> TEST_NOTIFICATION_DTO_PAGEABLE = createPageableAdvancedDtoForNotificationDto();
     public static final UpdateOrderPageAdminDto UPDATE_ORDER_PAGE_ADMIN_DTO = updateOrderPageAdminDto();
     public static final CourierUpdateDto UPDATE_COURIER_DTO = getUpdateCourierDto();
     public static final List<Bag> TEST_BAG_LIST2 = Arrays.asList(createBag(1), createBag(2), createBag(3));
@@ -2655,6 +2657,19 @@ public class ModelUtils {
             true);
     }
 
+    private static PageableAdvancedDto<NotificationDto> createPageableAdvancedDtoForNotificationDto() {
+        return new PageableAdvancedDto<>(
+                TEST_NOTIFICATION_DTO_LIST,
+                1,
+                0,
+                1,
+                0,
+                false,
+                false,
+                true,
+                true);
+    }
+
     public static NotificationTemplateWithPlatformsUpdateDto createNotificationTemplateWithPlatformsUpdateDto() {
         return NotificationTemplateWithPlatformsUpdateDto.builder()
             .notificationTemplateUpdateInfo(createNotificationTemplateUpdateInfoDto())
@@ -2978,6 +2993,7 @@ public class ModelUtils {
         return NotificationDto.builder()
             .title("Title")
             .body("Body")
+            .images(Collections.emptyList())
             .build();
     }
 

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -55,6 +55,7 @@ import greencity.dto.location.LocationsDto;
 import greencity.dto.location.RegionTranslationDto;
 import greencity.dto.location.api.DistrictDto;
 import greencity.dto.location.api.LocationDto;
+import greencity.dto.notification.NotificationFullDto;
 import greencity.dto.notification.NotificationTemplateUpdateInfoDto;
 import greencity.dto.notification.NotificationTemplateMainInfoDto;
 import greencity.dto.notification.NotificationShortDto;
@@ -296,8 +297,9 @@ public class ModelUtils {
     public static final List<Map<String, Object>> TEST_MAP_ADDITIONAL_BAG_LIST =
         Collections.singletonList(TEST_MAP_ADDITIONAL_BAG);
     public static final NotificationDto TEST_NOTIFICATION_DTO = createNotificationDto();
-    public static final List<NotificationDto> TEST_NOTIFICATION_DTO_LIST = List.of(createNotificationDto());
-    public static final PageableAdvancedDto<NotificationDto> TEST_NOTIFICATION_DTO_PAGEABLE = createPageableAdvancedDtoForNotificationDto();
+    public static final List<NotificationFullDto> TEST_NOTIFICATION_DTO_LIST = List.of(createNotificationFullDto());
+    public static final PageableAdvancedDto<NotificationFullDto> TEST_NOTIFICATION_FULL_DTO_PAGEABLE =
+        createPageableAdvancedDtoForNotificationFullDto();
     public static final UpdateOrderPageAdminDto UPDATE_ORDER_PAGE_ADMIN_DTO = updateOrderPageAdminDto();
     public static final CourierUpdateDto UPDATE_COURIER_DTO = getUpdateCourierDto();
     public static final List<Bag> TEST_BAG_LIST2 = Arrays.asList(createBag(1), createBag(2), createBag(3));
@@ -2657,17 +2659,17 @@ public class ModelUtils {
             true);
     }
 
-    private static PageableAdvancedDto<NotificationDto> createPageableAdvancedDtoForNotificationDto() {
+    private static PageableAdvancedDto<NotificationFullDto> createPageableAdvancedDtoForNotificationFullDto() {
         return new PageableAdvancedDto<>(
-                TEST_NOTIFICATION_DTO_LIST,
-                1,
-                0,
-                1,
-                0,
-                false,
-                false,
-                true,
-                true);
+            TEST_NOTIFICATION_DTO_LIST,
+            1,
+            0,
+            1,
+            0,
+            false,
+            false,
+            true,
+            true);
     }
 
     public static NotificationTemplateWithPlatformsUpdateDto createNotificationTemplateWithPlatformsUpdateDto() {
@@ -2994,6 +2996,17 @@ public class ModelUtils {
             .title("Title")
             .body("Body")
             .images(Collections.emptyList())
+            .build();
+    }
+
+    private static NotificationFullDto createNotificationFullDto() {
+        return NotificationFullDto.builder()
+            .id(0L)
+            .orderId(5L)
+            .read(false)
+            .title("Title")
+            .body("Body")
+            .images(List.of("image1", "image2", "image3"))
             .build();
     }
 

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -6,6 +6,7 @@ import greencity.client.UserRemoteClient;
 import greencity.config.InternalUrlConfigProp;
 import greencity.constant.ErrorMessage;
 import greencity.dto.notification.NotificationDto;
+import greencity.dto.notification.NotificationFullDto;
 import greencity.dto.notification.NotificationShortDto;
 import greencity.dto.order.PaymentSystemResponse;
 import greencity.dto.pageble.PageableAdvancedDto;
@@ -48,6 +49,10 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -63,6 +68,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+
+import static greencity.ModelUtils.TEST_NOTIFICATION_FULL_DTO_PAGEABLE;
 import static greencity.ModelUtils.TEST_UUID;
 import static greencity.ModelUtils.TEST_PAGEABLE_ADVANCED_DTO;
 import static greencity.ModelUtils.TEST_NOTIFICATION_DTO;
@@ -984,97 +991,132 @@ class NotificationServiceImplTest {
     }
 
     @Test
-    void testGetAllNotificationForUser() {
-        String uuid = "uuid";
-        Long notificationId = 1L;
-        UserNotification userNotification = Mockito.mock(UserNotification.class);
+    void testGetAllNotificationsForUser() {
+        String userUuid = "user uuid";
+        String language = "ua";
+        Long orderId = 5L;
+        Long notificationId = 0L;
         NotificationType notificationType = NotificationType.VIOLATION_THE_RULES;
-        User notificationOwner = Mockito.mock(User.class);
-        Set<NotificationParameter> notificationParameters = Set.of(
-                NotificationParameter.builder().key(VIOLATION_DESCRIPTION).value("aboba").build()
-        );
+        UserNotification userNotification = Mockito.mock(UserNotification.class);
+        User user = Mockito.mock(User.class);
         Order order = Mockito.mock(Order.class);
-        Long orderId = 1L;
+        Page<UserNotification> page = new PageImpl<>(
+            List.of(userNotification),
+            Mockito.mock(Pageable.class),
+            1L);
         Violation violation = Mockito.mock(Violation.class);
+        List<String> images = List.of("image1", "image2", "image3");
+        String notificationParameterValue = "value";
+        Set<NotificationParameter> notificationParameters = Set.of(
+            NotificationParameter.builder().key(VIOLATION_DESCRIPTION).value(notificationParameterValue).build());
 
-        when(userRepository.findByUuid(uuid)).thenReturn(TEST_USER);
-        when(userNotificationRepository.findAllByUserAndIsDeletedFalse(TEST_USER, TEST_PAGEABLE))
-                .thenReturn(TEST_PAGE);
+        when(user.getUuid())
+            .thenReturn(userUuid);
+        when(userRepository.findByUuid(userUuid))
+            .thenReturn(user);
+        when(userNotification.getId())
+            .thenReturn(notificationId);
+        when(userNotificationRepository.findAllByUserAndIsDeletedFalse(user, TEST_PAGEABLE))
+            .thenReturn(page);
         when(userNotificationRepository.findById(notificationId))
-                .thenReturn(Optional.of(userNotification));
+            .thenReturn(Optional.of(userNotification));
         when(userNotification.getUser())
-                .thenReturn(notificationOwner);
-        when(notificationOwner.getUuid())
-                .thenReturn(uuid);
-        when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
-                notificationType,
-                SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
+            .thenReturn(user);
         when(userNotification.getNotificationType())
-                .thenReturn(notificationType);
+            .thenReturn(notificationType);
+        when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
+            notificationType,
+            SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
         when(userNotification.getParameters())
-                .thenReturn(notificationParameters);
+            .thenReturn(notificationParameters);
         when(userNotification.getOrder())
-                .thenReturn(order);
+            .thenReturn(order);
         when(order.getId())
-                .thenReturn(orderId);
-        when(violationRepository.findByOrderIdAndDescription(orderId, "aboba"))
-                .thenReturn(Optional.of(violation));
+            .thenReturn(orderId);
+        when(violationRepository.findByOrderIdAndDescription(orderId, notificationParameterValue))
+            .thenReturn(Optional.of(violation));
+        when(violation.getImages())
+            .thenReturn(images);
 
-        PageableAdvancedDto<NotificationDto> actual = notificationService
-                .getAllNotificationsForUser(uuid, "ua", TEST_PAGEABLE);
+        PageableAdvancedDto<NotificationFullDto> actual = notificationService
+            .getAllNotificationsForUser(userUuid, language, TEST_PAGEABLE);
 
-        assertEquals(ModelUtils.TEST_NOTIFICATION_DTO_PAGEABLE, actual);
+        assertEquals(TEST_NOTIFICATION_FULL_DTO_PAGEABLE, actual);
     }
 
     @Test
     void testGetAllNotificationForUserWhenNotificationDoesNotBelongToUser() {
-        String uuid = "uuid";
-        String otherUserUuid = "other uuid";
-        Long notificationId = 1L;
-        String languageCode = "ua";
+        String userUuid = "user uuid";
+        String anotherUserUuid = "another uuid";
+        String language = "ua";
+        Long notificationId = 0L;
+        NotificationType notificationType = NotificationType.VIOLATION_THE_RULES;
         UserNotification userNotification = Mockito.mock(UserNotification.class);
-        User notificationOwner = Mockito.mock(User.class);
+        User user = Mockito.mock(User.class);
+        User anotherUser = Mockito.mock(User.class);
+        Page<UserNotification> page = new PageImpl<>(
+            List.of(userNotification),
+            Mockito.mock(Pageable.class),
+            1L);
 
-        when(userRepository.findByUuid(uuid)).thenReturn(TEST_USER);
-        when(userNotificationRepository.findAllByUserAndIsDeletedFalse(TEST_USER, TEST_PAGEABLE))
-                .thenReturn(TEST_PAGE);
+        when(userRepository.findByUuid(userUuid))
+            .thenReturn(user);
+        when(userNotificationRepository.findAllByUserAndIsDeletedFalse(user, TEST_PAGEABLE))
+            .thenReturn(page);
         when(userNotificationRepository.findById(notificationId))
-                .thenReturn(Optional.of(userNotification));
+            .thenReturn(Optional.of(userNotification));
+        when(userNotification.getNotificationType())
+            .thenReturn(notificationType);
+        when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
+            notificationType,
+            SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
         when(userNotification.getUser())
-                .thenReturn(notificationOwner);
-        when(notificationOwner.getUuid())
-                .thenReturn(otherUserUuid);
+            .thenReturn(anotherUser);
+        when(anotherUser.getUuid())
+            .thenReturn(anotherUserUuid);
 
         assertThrows(
-                AccessDeniedException.class,
-                () -> notificationService.getAllNotificationsForUser(
-                        uuid,
-                        languageCode,
-                        TEST_PAGEABLE
-                )
-        );
+            AccessDeniedException.class,
+            () -> notificationService.getAllNotificationsForUser(
+                userUuid,
+                language,
+                TEST_PAGEABLE));
     }
 
     @Test
     void testGetAllNotificationForUserWhenNotificationIsNotFound() {
-        String uuid = "uuid";
+        String userUuid = "user uuid";
+        String language = "ua";
         Long notificationId = 1L;
-        String languageCode = "ua";
+        UserNotification userNotification = Mockito.mock(UserNotification.class);
+        NotificationType notificationType = NotificationType.UNPAID_ORDER;
+        User user = Mockito.mock(User.class);
+        Page<UserNotification> page = new PageImpl<>(
+            List.of(userNotification),
+            Mockito.mock(Pageable.class),
+            1L);
+        Optional<UserNotification> notFoundNotification = Optional.empty();
 
-        when(userRepository.findByUuid(uuid)).thenReturn(TEST_USER);
-        when(userNotificationRepository.findAllByUserAndIsDeletedFalse(TEST_USER, TEST_PAGEABLE))
-                .thenReturn(TEST_PAGE);
+        when(userRepository.findByUuid(userUuid))
+            .thenReturn(user);
+        when(userNotificationRepository.findAllByUserAndIsDeletedFalse(user, TEST_PAGEABLE))
+            .thenReturn(page);
+        when(userNotification.getNotificationType())
+            .thenReturn(notificationType);
+        when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
+            notificationType,
+            SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
+        when(userNotification.getId())
+            .thenReturn(notificationId);
         when(userNotificationRepository.findById(notificationId))
-                .thenReturn(Optional.empty());
+            .thenReturn(notFoundNotification);
 
         assertThrows(
-                NotFoundException.class,
-                () -> notificationService.getAllNotificationsForUser(
-                        uuid,
-                        languageCode,
-                        TEST_PAGEABLE
-                )
-        );
+            NotFoundException.class,
+            () -> notificationService.getAllNotificationsForUser(
+                userUuid,
+                language,
+                TEST_PAGEABLE));
     }
 
     @Test

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Clock;
@@ -964,7 +965,7 @@ class NotificationServiceImplTest {
     }
 
     @Test
-    void testGetAllNotificationForUser() {
+    void testGetAllShortNotificationForUser() {
         String email = "email";
         String uuid = "uuid";
 
@@ -980,6 +981,100 @@ class NotificationServiceImplTest {
             .getAllShortNotificationsForUser(email, "ua", TEST_PAGEABLE);
 
         assertEquals(TEST_PAGEABLE_ADVANCED_DTO, actual);
+    }
+
+    @Test
+    void testGetAllNotificationForUser() {
+        String uuid = "uuid";
+        Long notificationId = 1L;
+        UserNotification userNotification = Mockito.mock(UserNotification.class);
+        NotificationType notificationType = NotificationType.VIOLATION_THE_RULES;
+        User notificationOwner = Mockito.mock(User.class);
+        Set<NotificationParameter> notificationParameters = Set.of(
+                NotificationParameter.builder().key(VIOLATION_DESCRIPTION).value("aboba").build()
+        );
+        Order order = Mockito.mock(Order.class);
+        Long orderId = 1L;
+        Violation violation = Mockito.mock(Violation.class);
+
+        when(userRepository.findByUuid(uuid)).thenReturn(TEST_USER);
+        when(userNotificationRepository.findAllByUserAndIsDeletedFalse(TEST_USER, TEST_PAGEABLE))
+                .thenReturn(TEST_PAGE);
+        when(userNotificationRepository.findById(notificationId))
+                .thenReturn(Optional.of(userNotification));
+        when(userNotification.getUser())
+                .thenReturn(notificationOwner);
+        when(notificationOwner.getUuid())
+                .thenReturn(uuid);
+        when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
+                notificationType,
+                SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
+        when(userNotification.getNotificationType())
+                .thenReturn(notificationType);
+        when(userNotification.getParameters())
+                .thenReturn(notificationParameters);
+        when(userNotification.getOrder())
+                .thenReturn(order);
+        when(order.getId())
+                .thenReturn(orderId);
+        when(violationRepository.findByOrderIdAndDescription(orderId, "aboba"))
+                .thenReturn(Optional.of(violation));
+
+        PageableAdvancedDto<NotificationDto> actual = notificationService
+                .getAllNotificationsForUser(uuid, "ua", TEST_PAGEABLE);
+
+        assertEquals(ModelUtils.TEST_NOTIFICATION_DTO_PAGEABLE, actual);
+    }
+
+    @Test
+    void testGetAllNotificationForUserWhenNotificationDoesNotBelongToUser() {
+        String uuid = "uuid";
+        String otherUserUuid = "other uuid";
+        Long notificationId = 1L;
+        String languageCode = "ua";
+        UserNotification userNotification = Mockito.mock(UserNotification.class);
+        User notificationOwner = Mockito.mock(User.class);
+
+        when(userRepository.findByUuid(uuid)).thenReturn(TEST_USER);
+        when(userNotificationRepository.findAllByUserAndIsDeletedFalse(TEST_USER, TEST_PAGEABLE))
+                .thenReturn(TEST_PAGE);
+        when(userNotificationRepository.findById(notificationId))
+                .thenReturn(Optional.of(userNotification));
+        when(userNotification.getUser())
+                .thenReturn(notificationOwner);
+        when(notificationOwner.getUuid())
+                .thenReturn(otherUserUuid);
+
+        assertThrows(
+                AccessDeniedException.class,
+                () -> notificationService.getAllNotificationsForUser(
+                        uuid,
+                        languageCode,
+                        TEST_PAGEABLE
+                )
+        );
+    }
+
+    @Test
+    void testGetAllNotificationForUserWhenNotificationIsNotFound() {
+        String uuid = "uuid";
+        Long notificationId = 1L;
+        String languageCode = "ua";
+
+        when(userRepository.findByUuid(uuid)).thenReturn(TEST_USER);
+        when(userNotificationRepository.findAllByUserAndIsDeletedFalse(TEST_USER, TEST_PAGEABLE))
+                .thenReturn(TEST_PAGE);
+        when(userNotificationRepository.findById(notificationId))
+                .thenReturn(Optional.empty());
+
+        assertThrows(
+                NotFoundException.class,
+                () -> notificationService.getAllNotificationsForUser(
+                        uuid,
+                        languageCode,
+                        TEST_PAGEABLE
+                )
+        );
     }
 
     @Test

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -977,7 +977,7 @@ class NotificationServiceImplTest {
             SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
 
         PageableAdvancedDto<NotificationShortDto> actual = notificationService
-            .getAllNotificationsForUser(email, "ua", TEST_PAGEABLE);
+            .getAllShortNotificationsForUser(email, "ua", TEST_PAGEABLE);
 
         assertEquals(TEST_PAGEABLE_ADVANCED_DTO, actual);
     }


### PR DESCRIPTION
# GreenCityUBS PR
[Board](https://github.com/orgs/ita-social-projects/projects/44/views/1?pane=issue&itemId=106164064&issue=ita-social-projects%7CGreenCity%7C8311)

## Summary Of Changes :fire:
Added endpoint to retrieve notifications that include notification images

## Issue Link :clipboard:
[8311](https://github.com/ita-social-projects/GreenCity/issues/8311)

## Added
Endpoint to retrieve notifications that include notification images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced notifications now offer two distinct views: a quick summary version for fast updates and a detailed version that includes images for richer content. This improvement delivers a more intuitive and engaging experience, allowing users to choose the format that best suits their needs.
- **Bug Fixes**
	- Improved error handling for scenarios where notifications may not belong to the user or are not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->