### PR TITLE
Changed keyVaultName to the existing one

### DIFF
--- a/az-cd-pipeline.yml
+++ b/az-cd-pipeline.yml
@@ -42,7 +42,7 @@ stages:
           - task: AzureKeyVault@1
             inputs:
               azureSubscription: '$(azureSub)'
-              KeyVaultName: 'greencity-app'
+              KeyVaultName: '$(azKeyVault)'
               SecretsFilter: 'LOGGING-ITA-TOKEN'
               RunAsPreJob: false
 


### PR DESCRIPTION
Changed KeyVaultName to the existing one to check if the token was put to the needed secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated pipeline configuration to use a variable for the Azure Key Vault name, ensuring consistent and flexible usage across tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->