### PR TITLE
Bugfix #8332 Replaced java version from 22 to 21 in the Dockerfile in the Greencity UBS prod branch;

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:22-ea-21-jdk-slim as runner
+FROM openjdk:21-slim as runner
 WORKDIR runner
 COPY **/target/app.jar runner/
 CMD java -jar runner/app.jar


### PR DESCRIPTION
# GreenCity UBS PR `prod` branch
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/8332">#8332</a>

## Changed
- Replaced Java version from 22 to 21 in the `Dockerfile` in the Greencity UBS **prod** branch;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the base Docker image to use a stable OpenJDK 21 slim version instead of an early access OpenJDK 22 image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->