### PR TITLE
Changed keyVault name again

### DIFF
--- a/az-cd-pipeline.yml
+++ b/az-cd-pipeline.yml
@@ -42,7 +42,7 @@ stages:
           - task: AzureKeyVault@1
             inputs:
               azureSubscription: '$(azureSub)'
-              KeyVaultName: '$(azKeyVault)'
+              KeyVaultName: 'greencity-app'
               SecretsFilter: 'LOGGING-ITA-TOKEN'
               RunAsPreJob: false
 


### PR DESCRIPTION
Changed keyVault name again because it occurred that we need to use this one. Wait until our application gets the access. UPD The access was given

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated pipeline configuration to use a specific Key Vault for retrieving the `LOGGING-ITA-TOKEN` secret during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->