### PR TITLE
Bugfix #8343 - Fixed saving comment for address on the User Data page.

### DIFF
--- a/service/src/main/java/greencity/mapping/address/OrderAddressDtoRequestToAddressMapper.java
+++ b/service/src/main/java/greencity/mapping/address/OrderAddressDtoRequestToAddressMapper.java
@@ -29,6 +29,7 @@ public class OrderAddressDtoRequestToAddressMapper extends AbstractConverter<Ord
                 .houseNumber(orderAddressDtoRequest.getHouseNumber())
                 .houseCorpus(orderAddressDtoRequest.getHouseCorpus())
                 .entranceNumber(orderAddressDtoRequest.getEntranceNumber())
+                .addressComment(orderAddressDtoRequest.getAddressComment())
                 .build())
             .build();
     }

--- a/service/src/test/java/greencity/mapping/address/OrderAddressDtoRequestToAddressMapperTest.java
+++ b/service/src/test/java/greencity/mapping/address/OrderAddressDtoRequestToAddressMapperTest.java
@@ -28,5 +28,6 @@ class OrderAddressDtoRequestToAddressMapperTest {
         assertEquals(orderAddressDtoRequest.getHouseNumber(), address.getBaseAddress().getHouseNumber());
         assertEquals(orderAddressDtoRequest.getHouseCorpus(), address.getBaseAddress().getHouseCorpus());
         assertEquals(orderAddressDtoRequest.getEntranceNumber(), address.getBaseAddress().getEntranceNumber());
+        assertEquals(orderAddressDtoRequest.getAddressComment(), address.getBaseAddress().getAddressComment());
     }
 }


### PR DESCRIPTION
Added filling the field for addressComment in the OrderAddressDtoRequestToAddressMapper;

# GreenCityUBS PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/8343">#8343</a>

## Changed
- Refactored `OrderAddressDtoRequestToAddressMapper` by adding filling for the missing field _addressComment_;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Address comments are now included when processing address information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->