### PR TITLE
PDF file of exported order has null fields.

### DIFF
--- a/service/src/main/java/greencity/service/ubs/pdf/exporter/OrdersDataPdfFileExporterImpl.java
+++ b/service/src/main/java/greencity/service/ubs/pdf/exporter/OrdersDataPdfFileExporterImpl.java
@@ -111,7 +111,7 @@ public class OrdersDataPdfFileExporterImpl implements FileExporter<OrdersDataFor
         table.addCell(createCell(orderInfo.getDateForm().format(
             Objects.equals(LOCALE_UK_NAME, locale.getLanguage()) ? DATE_FORMATTER_UK : DATE_FORMATTER_EN),
             DEFAULT_FONT_NAME, fontSize, DEFAULT_CELL_BACKGROUND_COLOR, false));
-        if (locale.getLanguage().equals(LOCALE_EN_NAME)) {
+        if (Objects.equals(LOCALE_EN_NAME, locale.getLanguage())) {
             table.addCell(createCell(orderInfo.getOrderStatusEn(), DEFAULT_FONT_NAME, fontSize,
                 DEFAULT_CELL_BACKGROUND_COLOR, false));
             table.addCell(createCell(orderInfo.getPaymentStatusEn(), DEFAULT_FONT_NAME, fontSize,
@@ -212,14 +212,18 @@ public class OrdersDataPdfFileExporterImpl implements FileExporter<OrdersDataFor
             addParagraph(document, orderDetails.getAddress().getAddressDistinctUk(),
                 DEFAULT_FONT_NAME, DEFAULT_PARAGRAPH_FONT_SIZE, false, Element.ALIGN_LEFT);
         }
-        addParagraph(document, String.join(" ",
-            PdfAddressConstants.getByLocale(PdfAddressConstants.HOUSE_CORPUS_NUMBER, locale),
-            orderDetails.getAddress().getHouseCorpus()), DEFAULT_FONT_NAME,
-            DEFAULT_PARAGRAPH_FONT_SIZE, false, Element.ALIGN_LEFT);
-        addParagraph(document, String.join(" ",
-            PdfAddressConstants.getByLocale(PdfAddressConstants.ENTRANCE_NUMBER, locale),
-            orderDetails.getAddress().getEntranceNumber()), DEFAULT_FONT_NAME,
-            DEFAULT_PARAGRAPH_FONT_SIZE, false, Element.ALIGN_LEFT);
+        if (Objects.nonNull(orderDetails.getAddress().getHouseCorpus())) {
+            addParagraph(document, String.join(" ",
+                PdfAddressConstants.getByLocale(PdfAddressConstants.HOUSE_CORPUS_NUMBER, locale),
+                orderDetails.getAddress().getHouseCorpus()), DEFAULT_FONT_NAME,
+                DEFAULT_PARAGRAPH_FONT_SIZE, false, Element.ALIGN_LEFT);
+            if (Objects.nonNull(orderDetails.getAddress().getEntranceNumber())) {
+                addParagraph(document, String.join(" ",
+                    PdfAddressConstants.getByLocale(PdfAddressConstants.ENTRANCE_NUMBER, locale),
+                    orderDetails.getAddress().getEntranceNumber()), DEFAULT_FONT_NAME,
+                    DEFAULT_PARAGRAPH_FONT_SIZE, false, Element.ALIGN_LEFT);
+            }
+        }
     }
 
     private void addHeader(String text, Document document) {


### PR DESCRIPTION
**Short summary**
Previously, a PDF file with an order could have null values ​​in house corpus and entrance number. This commit fixes this bug.

**Changed**
Added branching to validate that house corpus and entrance number are not null.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of address details in PDF exports to prevent empty or null values from appearing.
  - Enhanced language selection logic for better reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->