### PR TITLE
8360/Allow username to start with a lowercase letter

### DIFF
--- a/service-api/src/main/java/greencity/constant/ValidationConstant.java
+++ b/service-api/src/main/java/greencity/constant/ValidationConstant.java
@@ -38,7 +38,7 @@ public class ValidationConstant {
         (?<![ЭэЁёъЪЫы])$\
         """;
     public static final String USERNAME_MESSAGE = """
-        Name must start with a capital letter, \
+        Name must start with a letter, \
         cannot end with dot \
         or contain 2 consecutive dots, dashes and special symbols. \
         Use English or Ukrainian letters, \

--- a/service-api/src/main/java/greencity/constant/ValidationConstant.java
+++ b/service-api/src/main/java/greencity/constant/ValidationConstant.java
@@ -32,7 +32,7 @@ public class ValidationConstant {
     public static final String ADDRESS_VALIDATION_ERROR_MESSAGE = "Invalid data for address";
     public static final String USERNAME_REGEXP = """
         ^(?!.*\\.\\.)(?!.*\\.$)(?!.*\\-\\-)\
-        (?=[ЄІЇҐЁА-ЯA-Z])\
+        (?=[ЄІЇҐЁєіїґёА-Яа-яA-Za-z])\
         [ЄІЇҐЁєіїґёА-Яа-яA-Za-z0-9\\s\\-'\\"’.ʼ]\
         {1,30}\
         (?<![ЭэЁёъЪЫы])$\

--- a/service-api/src/test/java/greencity/dto/user/UserProfileCreateDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/user/UserProfileCreateDtoTest.java
@@ -136,7 +136,8 @@ class UserProfileCreateDtoTest {
             Arguments.of("User123"),
             Arguments.of("Імʼя2Тест"),
             Arguments.of("ТестʼІмʼя"),
-            Arguments.of("Євген.Тест"));
+            Arguments.of("Євген.Тест"),
+            Arguments.of("lowercase-name"));
     }
 
     private static Stream<Arguments> provideInvalidUsernames() {
@@ -150,6 +151,7 @@ class UserProfileCreateDtoTest {
             Arguments.of("--"),
             Arguments.of("..Тест"),
             Arguments.of("Тест.."),
+            Arguments.of("тест.."),
             Arguments.of("Тест..Імʼя"),
             Arguments.of("Тест--Імʼя"),
             Arguments.of("Тест.."),


### PR DESCRIPTION
# GreenCityUBS PR
[Board](https://github.com/orgs/ita-social-projects/projects/43/views/1?filterQuery=8360&pane=issue&itemId=108108426&issue=ita-social-projects%7CGreenCity%7C8360)

## Summary Of Changes :fire:
Allowed username to start with a lowercase letter 

## Issue Link :clipboard:
[#8360](https://github.com/ita-social-projects/GreenCity/issues/8360)

## Changed
The part of the username regex that required first letter to be upper case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated username validation to allow usernames to start with both uppercase and lowercase Cyrillic and Latin letters.
  - Expanded username validation tests to include new valid and invalid username examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->