### PR TITLE
Deleted the explicit creation of the settings xml file from the workflow on github

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,21 +40,6 @@ jobs:
 #         with:
 #           go-version: 1.18
 
-      - name: Set up Maven settings
-        run: |
-            mkdir -p ~/.m2
-            cat > ~/.m2/settings.xml <<EOF
-            <settings>
-              <servers>
-                <server>
-                  <id>github</id>
-                  <username>ita-social-projects</username>
-                  <password>${{ secrets.LOGGING_ITA_TOKEN }}</password>
-                </server>
-              </servers>
-            </settings>
-            EOF
-
       - name: Run a multi-line script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Deleted the explicit creation of the settings xml file from the workflow on github to run the experiment: maybe we don't need this action on github and can leave it only on Azure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated workflow by removing the Maven settings configuration step. No changes to the user experience or visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->