### PR TITLE
Fixed JPA entities mapping related to tariff

### DIFF
--- a/dao/src/main/java/greencity/entity/order/TariffsInfo.java
+++ b/dao/src/main/java/greencity/entity/order/TariffsInfo.java
@@ -47,19 +47,19 @@ public class TariffsInfo {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(mappedBy = "tariffsInfo")
+    @OneToOne(mappedBy = "tariffsInfo", cascade = CascadeType.REMOVE)
     private Service service;
 
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "tariffsInfo")
     private List<Bag> bags;
 
-    @ManyToMany
+    @ManyToMany(cascade = CascadeType.REFRESH)
     @JoinTable(name = "tariffs_info_receiving_stations_mapping",
         joinColumns = @JoinColumn(name = "tariffs_info_id"),
         inverseJoinColumns = @JoinColumn(name = "receiving_station_id"))
     private Set<ReceivingStation> receivingStationList;
 
-    @OneToMany(mappedBy = "tariffsInfo")
+    @OneToMany(mappedBy = "tariffsInfo", cascade = CascadeType.ALL)
     private List<TariffsInfoRecievingEmployee> employeeAssoc;
 
     @Column


### PR DESCRIPTION
## GIT
* [This PR is related to PR 1683](https://github.com/ita-social-projects/GreenCityUBS/pull/1683)

**Summary**
During additional testing, I discovered another bug related to inability to delete tariff if it is mapped to either employee or station.

**Changes**
I fixed JPA entities. Now tariffs can be deleted with all data in related tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved management of related data when updating or deleting tariff information, ensuring associated records are handled more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->