### PR TITLE
Bugfix #8435 Refactored validation for comment input for address.

### DIFF
--- a/service-api/src/main/java/greencity/dto/CreateAddressRequestDto.java
+++ b/service-api/src/main/java/greencity/dto/CreateAddressRequestDto.java
@@ -2,6 +2,7 @@ package greencity.dto;
 
 import greencity.dto.location.CoordinatesDto;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,6 +29,9 @@ public class CreateAddressRequestDto {
     private static final String VALIDATION_MESSAGE = "Use only English, or Ukrainian letter";
     private static final String NOT_EMPTY_VALIDATION_MESSAGE = "Name must not be empty";
     private static final String HOUSE_NUMBER_NOT_VALID = "House number is invalid";
+    private static final String ADDRESS_COMMENT_LENGTH_ERROR_MESSAGE =
+        "Address comment must be 255 characters or fewer";
+    private static final String ADDRESS_COMMENT_INPUT_ERROR_MESSAGE = "Address comment must not be only whitespace";
 
     @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ .,ʼ'`ʹ’]*", message = VALIDATION_MESSAGE)
     @NotEmpty(message = NOT_EMPTY_VALIDATION_MESSAGE)
@@ -53,7 +57,8 @@ public class CreateAddressRequestDto {
 
     private String houseCorpus;
 
-    @Pattern(regexp = "[-A-Za-zА-Яа-яЇїІіЄєҐґ 0-9.,ʼ'`ʹ!?’]*", message = VALIDATION_MESSAGE)
+    @Size(max = 255, message = ADDRESS_COMMENT_LENGTH_ERROR_MESSAGE)
+    @Pattern(regexp = "^$|.*\\S.*", message = ADDRESS_COMMENT_INPUT_ERROR_MESSAGE)
     private String addressComment;
 
     private String placeId;

--- a/service-api/src/main/java/greencity/dto/CreateAddressRequestDto.java
+++ b/service-api/src/main/java/greencity/dto/CreateAddressRequestDto.java
@@ -58,7 +58,7 @@ public class CreateAddressRequestDto {
     private String houseCorpus;
 
     @Size(max = 255, message = ADDRESS_COMMENT_LENGTH_ERROR_MESSAGE)
-    @Pattern(regexp = "^$|.*\\S.*", message = ADDRESS_COMMENT_INPUT_ERROR_MESSAGE)
+    @Pattern(regexp = "^$|\\s*\\S[\\s\\S]*", message = ADDRESS_COMMENT_INPUT_ERROR_MESSAGE)
     private String addressComment;
 
     private String placeId;


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋

[#8435](https://github.com/ita-social-projects/GreenCity/issues/8435)

## Changed

-Refactored validation for the field _addressComment_ in the `CreateAddressRequestDto`;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for the address comment field to ensure it does not exceed 255 characters and is not composed solely of whitespace.
  - Enhanced error messages for invalid address comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->