### PR TITLE
Fix typo in @PreAuthorize annotation for TELEGRAM_MANAGEMENT

### DIFF
--- a/core/src/main/java/greencity/controller/TelegramController.java
+++ b/core/src/main/java/greencity/controller/TelegramController.java
@@ -111,7 +111,7 @@ public class TelegramController {
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
-    @PreAuthorize("@preAuthorizer.hasAuthority('TELEGRAM_MANAGETMENT', authentication)")
+    @PreAuthorize("@preAuthorizer.hasAuthority('TELEGRAM_MANAGEMENT', authentication)")
     @PostMapping("/send-message/{chatId}")
     public ResponseEntity<String> sendMessage(@PathVariable(name = "chatId") String chatId,
         @RequestParam String message) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the authorization settings for sending messages via Telegram, ensuring proper permission checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->