### PR TITLE
Bugfix #8462 - firxed 500 error wile deleting "Tariffs for Services"

### DIFF
--- a/core/src/main/java/greencity/controller/SuperAdminController.java
+++ b/core/src/main/java/greencity/controller/SuperAdminController.java
@@ -104,7 +104,7 @@ class SuperAdminController {
 
     @Operation(summary = "Delete tariff service by Id")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK, content = @Content),
+        @ApiResponse(responseCode = "200", description = HttpStatuses.NO_CONTENT, content = @Content),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)

--- a/core/src/main/java/greencity/controller/SuperAdminController.java
+++ b/core/src/main/java/greencity/controller/SuperAdminController.java
@@ -104,7 +104,7 @@ class SuperAdminController {
 
     @Operation(summary = "Delete tariff service by Id")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.NO_CONTENT, content = @Content),
+        @ApiResponse(responseCode = "204", description = HttpStatuses.NO_CONTENT, content = @Content),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)

--- a/core/src/main/java/greencity/controller/SuperAdminController.java
+++ b/core/src/main/java/greencity/controller/SuperAdminController.java
@@ -114,7 +114,7 @@ class SuperAdminController {
     public ResponseEntity<HttpStatus> deleteTariffService(
         @Valid @PathVariable Integer id) {
         superAdminService.deleteTariffService(id);
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.noContent().build();
     }
 
     /**

--- a/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
+++ b/core/src/test/java/greencity/controller/SuperAdminControllerTest.java
@@ -186,7 +186,7 @@ class SuperAdminControllerTest {
     @Test
     void deleteTariffService() throws Exception {
         mockMvc.perform(delete(ubsLink + "/deleteTariffService/" + 1L))
-            .andExpect(status().isOk());
+            .andExpect(status().isNoContent());
         verify(superAdminService).deleteTariffService(1);
         verifyNoMoreInteractions(superAdminService);
     }

--- a/dao/src/main/java/greencity/entity/order/Bag.java
+++ b/dao/src/main/java/greencity/entity/order/Bag.java
@@ -87,8 +87,7 @@ public class Bag {
     @JoinColumn
     private Employee editedBy;
 
-    @ManyToOne(cascade = CascadeType.REMOVE,
-        fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(nullable = false)
     private TariffsInfo tariffsInfo;
 

--- a/dao/src/main/java/greencity/entity/order/Bag.java
+++ b/dao/src/main/java/greencity/entity/order/Bag.java
@@ -20,7 +20,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.CascadeType;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import java.time.LocalDate;


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/8462">#8462</a>

## Changed

- Removed ambiguous _cascadeType_ for the `TariffsInfo` in the `Bag` class;
- Replaced returning status code for the _deleteTariffService_ method in the `SuperAdminController`;

## Summary Of Changes 🔥
Fixed an error while deleting the "Tariffs for Services" item on the tariff page.
Additionally, changed the returning HTTP status code to be more relevant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Deleting a tariff now returns a 204 No Content status instead of 200 OK, providing a more accurate HTTP response.

- **Refactor**
  - Adjusted the relationship between bags and tariffs so that deleting a bag will no longer automatically delete the associated tariff information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->