### PR TITLE
Bugfix #8390, #8391 Added missing validation for fields in UpdateOrderPageAdmin dto.

### DIFF
--- a/service-api/src/main/java/greencity/annotations/ValidUpdateOrderPageAdmin.java
+++ b/service-api/src/main/java/greencity/annotations/ValidUpdateOrderPageAdmin.java
@@ -1,0 +1,20 @@
+package greencity.annotations;
+
+import greencity.validator.UpdateOrderPageAdminValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {UpdateOrderPageAdminValidator.class})
+public @interface ValidUpdateOrderPageAdmin {
+    String message() default "{ValidUpdateOrderPageAdmin.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/service-api/src/main/java/greencity/constant/ValidationConstant.java
+++ b/service-api/src/main/java/greencity/constant/ValidationConstant.java
@@ -37,6 +37,7 @@ public class ValidationConstant {
         {1,30}\
         (?<![ЭэЁёъЪЫы])$\
         """;
+    public static final String NAMESURNAME_REGEXP = "^[A-Za-zА-Яа-я\\-'\\s]+$";
     public static final String USERNAME_MESSAGE = """
         Name must start with a letter, \
         cannot end with dot \

--- a/service-api/src/main/java/greencity/dto/order/UpdateOrderPageAdminDto.java
+++ b/service-api/src/main/java/greencity/dto/order/UpdateOrderPageAdminDto.java
@@ -1,5 +1,6 @@
 package greencity.dto.order;
 
+import greencity.annotations.ValidUpdateOrderPageAdmin;
 import greencity.dto.customer.UbsCustomersDtoUpdate;
 import greencity.dto.employee.UpdateResponsibleEmployeeDto;
 import greencity.dto.refund.RefundDto;
@@ -17,6 +18,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@ValidUpdateOrderPageAdmin
 public class UpdateOrderPageAdminDto {
     private OrderDetailStatusRequestDto generalOrderInfo;
     private UbsCustomersDtoUpdate userInfoDto;

--- a/service-api/src/main/java/greencity/validator/UpdateOrderPageAdminValidator.java
+++ b/service-api/src/main/java/greencity/validator/UpdateOrderPageAdminValidator.java
@@ -31,7 +31,7 @@ public class UpdateOrderPageAdminValidator
                     .addPropertyNode("customerName")
                     .addConstraintViolation();
                 return false;
-            } else if (!name.matches("^[A-Za-zА-Яа-я\\- '\\s]+$")) {
+            } else if (!name.matches("^[A-Za-zА-Яа-я\\-'\\s]+$")) {
                 context.buildConstraintViolationWithTemplate(
                     "Only alphabetic characters and '-', ' ', and apostrophe are allowed")
                     .addPropertyNode("customerName")
@@ -47,7 +47,7 @@ public class UpdateOrderPageAdminValidator
                     .addPropertyNode("customerSurname")
                     .addConstraintViolation();
                 return false;
-            } else if (!surname.matches("^[A-Za-zА-Яа-я\\- '\\s]+$")) {
+            } else if (!surname.matches("^[A-Za-zА-Яа-я\\-'\\s]+$")) {
                 context.buildConstraintViolationWithTemplate(
                     "Only alphabetic characters and '-', ' ', and apostrophe are allowed")
                     .addPropertyNode("customerSurname")

--- a/service-api/src/main/java/greencity/validator/UpdateOrderPageAdminValidator.java
+++ b/service-api/src/main/java/greencity/validator/UpdateOrderPageAdminValidator.java
@@ -17,8 +17,11 @@ public class UpdateOrderPageAdminValidator
     @Override
     public boolean isValid(UpdateOrderPageAdminDto updateOrderPageAdminDto,
         ConstraintValidatorContext context) {
-        UbsCustomersDtoUpdate userInfo = updateOrderPageAdminDto.getUserInfoDto();
+        if (updateOrderPageAdminDto == null) {
+            return true;
+        }
 
+        UbsCustomersDtoUpdate userInfo = updateOrderPageAdminDto.getUserInfoDto();
         if (userInfo == null) {
             return true;
         }

--- a/service-api/src/main/java/greencity/validator/UpdateOrderPageAdminValidator.java
+++ b/service-api/src/main/java/greencity/validator/UpdateOrderPageAdminValidator.java
@@ -5,6 +5,7 @@ import greencity.dto.customer.UbsCustomersDtoUpdate;
 import greencity.dto.order.UpdateOrderPageAdminDto;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import static greencity.constant.ValidationConstant.NAMESURNAME_REGEXP;
 
 public class UpdateOrderPageAdminValidator
     implements ConstraintValidator<ValidUpdateOrderPageAdmin, UpdateOrderPageAdminDto> {
@@ -31,7 +32,7 @@ public class UpdateOrderPageAdminValidator
                     .addPropertyNode("customerName")
                     .addConstraintViolation();
                 return false;
-            } else if (!name.matches("^[A-Za-zА-Яа-я\\-'\\s]+$")) {
+            } else if (!name.matches(NAMESURNAME_REGEXP)) {
                 context.buildConstraintViolationWithTemplate(
                     "Only alphabetic characters and '-', ' ', and apostrophe are allowed")
                     .addPropertyNode("customerName")
@@ -47,7 +48,7 @@ public class UpdateOrderPageAdminValidator
                     .addPropertyNode("customerSurname")
                     .addConstraintViolation();
                 return false;
-            } else if (!surname.matches("^[A-Za-zА-Яа-я\\-'\\s]+$")) {
+            } else if (!surname.matches(NAMESURNAME_REGEXP)) {
                 context.buildConstraintViolationWithTemplate(
                     "Only alphabetic characters and '-', ' ', and apostrophe are allowed")
                     .addPropertyNode("customerSurname")

--- a/service-api/src/main/java/greencity/validator/UpdateOrderPageAdminValidator.java
+++ b/service-api/src/main/java/greencity/validator/UpdateOrderPageAdminValidator.java
@@ -1,0 +1,61 @@
+package greencity.validator;
+
+import greencity.annotations.ValidUpdateOrderPageAdmin;
+import greencity.dto.customer.UbsCustomersDtoUpdate;
+import greencity.dto.order.UpdateOrderPageAdminDto;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class UpdateOrderPageAdminValidator
+    implements ConstraintValidator<ValidUpdateOrderPageAdmin, UpdateOrderPageAdminDto> {
+    @Override
+    public void initialize(ValidUpdateOrderPageAdmin constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(UpdateOrderPageAdminDto updateOrderPageAdminDto,
+        ConstraintValidatorContext context) {
+        UbsCustomersDtoUpdate userInfo = updateOrderPageAdminDto.getUserInfoDto();
+
+        if (userInfo == null) {
+            return true;
+        }
+
+        context.disableDefaultConstraintViolation();
+
+        String name = userInfo.getCustomerName();
+        if (name != null) {
+            if (name.isBlank()) {
+                context.buildConstraintViolationWithTemplate("Customer Name cannot be blank")
+                    .addPropertyNode("customerName")
+                    .addConstraintViolation();
+                return false;
+            } else if (!name.matches("^[A-Za-zА-Яа-я\\- '\\s]+$")) {
+                context.buildConstraintViolationWithTemplate(
+                    "Only alphabetic characters and '-', ' ', and apostrophe are allowed")
+                    .addPropertyNode("customerName")
+                    .addConstraintViolation();
+                return false;
+            }
+        }
+
+        String surname = userInfo.getCustomerSurname();
+        if (surname != null) {
+            if (surname.isBlank()) {
+                context.buildConstraintViolationWithTemplate("Customer Surname cannot be blank")
+                    .addPropertyNode("customerSurname")
+                    .addConstraintViolation();
+                return false;
+            } else if (!surname.matches("^[A-Za-zА-Яа-я\\- '\\s]+$")) {
+                context.buildConstraintViolationWithTemplate(
+                    "Only alphabetic characters and '-', ' ', and apostrophe are allowed")
+                    .addPropertyNode("customerSurname")
+                    .addConstraintViolation();
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/service-api/src/test/java/greencity/validator/UpdateOrderPageAdminValidatorTest.java
+++ b/service-api/src/test/java/greencity/validator/UpdateOrderPageAdminValidatorTest.java
@@ -6,12 +6,17 @@ import jakarta.validation.ConstraintValidatorContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,7 +26,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class UpdateOrderPageAdminValidatorTest {
+class UpdateOrderPageAdminValidatorTest {
     @Mock
     private ConstraintValidatorContext context;
     @InjectMocks
@@ -66,39 +71,6 @@ public class UpdateOrderPageAdminValidatorTest {
     }
 
     @Test
-    void updateOrderPageAdminValidationForBlankCustomerNameTest() {
-        UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
-            .userInfoDto(UbsCustomersDtoUpdate.builder()
-                .customerId(1L)
-                .customerName("")
-                .customerSurname("Tester")
-                .build())
-            .build();
-
-        boolean result = validator.isValid(invalidDto, context);
-
-        assertFalse(result);
-        verify(context).buildConstraintViolationWithTemplate("Customer Name cannot be blank");
-    }
-
-    @Test
-    void updateOrderPageAdminValidationForInvalidCharactersInCustomerNameTest() {
-        UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
-            .userInfoDto(UbsCustomersDtoUpdate.builder()
-                .customerId(1L)
-                .customerName("!@#$%^&*()`")
-                .customerSurname("ValidSurname")
-                .build())
-            .build();
-
-        boolean result = validator.isValid(invalidDto, context);
-
-        assertFalse(result);
-        verify(context).buildConstraintViolationWithTemplate(
-            "Only alphabetic characters and '-', ' ', and apostrophe are allowed");
-    }
-
-    @Test
     void updateOrderPageAdminValidationForNullCustomerSurnameTest() {
         UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
             .userInfoDto(UbsCustomersDtoUpdate.builder()
@@ -112,37 +84,32 @@ public class UpdateOrderPageAdminValidatorTest {
         assertTrue(result);
     }
 
-    @Test
-    void updateOrderPageAdminValidationForBlankCustomerSurnameTest() {
-        UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
-            .userInfoDto(UbsCustomersDtoUpdate.builder()
-                .customerId(1L)
-                .customerName("Tester")
-                .customerSurname("")
-                .build())
-            .build();
-
-        boolean result = validator.isValid(invalidDto, context);
-
-        assertFalse(result);
-        verify(context).buildConstraintViolationWithTemplate("Customer Surname cannot be blank");
+    private static Stream<Arguments> provideInvalidUserInfoData() {
+        return Stream.of(
+            Arguments.of("", "Tester", "Customer Name cannot be blank"),
+            Arguments.of("!@#$%^&*()`", "Tester",
+                "Only alphabetic characters and '-', ' ', and apostrophe are allowed"),
+            Arguments.of("Tester", "", "Customer Surname cannot be blank"),
+            Arguments.of("Tester", "!@#$%^&*()",
+                "Only alphabetic characters and '-', ' ', and apostrophe are allowed")
+        );
     }
 
-    @Test
-    void updateOrderPageAdminValidationForInvalidCharactersInCustomerSurnameTest() {
+    @ParameterizedTest
+    @MethodSource("provideInvalidUserInfoData")
+    void sagsagsagTest(String name, String surname, String expectedMessage) {
         UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
             .userInfoDto(UbsCustomersDtoUpdate.builder()
                 .customerId(1L)
-                .customerName("Tester")
-                .customerSurname("!@#$%^&*()")
+                .customerName(name)
+                .customerSurname(surname)
                 .build())
             .build();
 
         boolean result = validator.isValid(invalidDto, context);
 
         assertFalse(result);
-        verify(context).buildConstraintViolationWithTemplate(
-            "Only alphabetic characters and '-', ' ', and apostrophe are allowed");
+        verify(context).buildConstraintViolationWithTemplate(expectedMessage);
     }
 
     @Test

--- a/service-api/src/test/java/greencity/validator/UpdateOrderPageAdminValidatorTest.java
+++ b/service-api/src/test/java/greencity/validator/UpdateOrderPageAdminValidatorTest.java
@@ -52,6 +52,20 @@ public class UpdateOrderPageAdminValidatorTest {
     }
 
     @Test
+    void updateOrderPageAdminValidationForNullCustomerNameTest() {
+        UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
+            .userInfoDto(UbsCustomersDtoUpdate.builder()
+                .customerId(1L)
+                .customerSurname("T es'- te r")
+                .build())
+            .build();
+
+        boolean result = validator.isValid(invalidDto, context);
+
+        assertTrue(result);
+    }
+
+    @Test
     void updateOrderPageAdminValidationForBlankCustomerNameTest() {
         UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
             .userInfoDto(UbsCustomersDtoUpdate.builder()
@@ -72,7 +86,7 @@ public class UpdateOrderPageAdminValidatorTest {
         UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
             .userInfoDto(UbsCustomersDtoUpdate.builder()
                 .customerId(1L)
-                .customerName("!@#$%^&*()")
+                .customerName("!@#$%^&*()`")
                 .customerSurname("ValidSurname")
                 .build())
             .build();
@@ -82,6 +96,20 @@ public class UpdateOrderPageAdminValidatorTest {
         assertFalse(result);
         verify(context).buildConstraintViolationWithTemplate(
             "Only alphabetic characters and '-', ' ', and apostrophe are allowed");
+    }
+
+    @Test
+    void updateOrderPageAdminValidationForNullCustomerSurnameTest() {
+        UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
+            .userInfoDto(UbsCustomersDtoUpdate.builder()
+                .customerId(1L)
+                .customerName("Tester")
+                .build())
+            .build();
+
+        boolean result = validator.isValid(invalidDto, context);
+
+        assertTrue(result);
     }
 
     @Test
@@ -115,5 +143,12 @@ public class UpdateOrderPageAdminValidatorTest {
         assertFalse(result);
         verify(context).buildConstraintViolationWithTemplate(
             "Only alphabetic characters and '-', ' ', and apostrophe are allowed");
+    }
+
+    @Test
+    void updateOrderPageAdminValidationForNullDtoTest() {
+        boolean result = validator.isValid(new UpdateOrderPageAdminDto(), context);
+
+        assertTrue(result);
     }
 }

--- a/service-api/src/test/java/greencity/validator/UpdateOrderPageAdminValidatorTest.java
+++ b/service-api/src/test/java/greencity/validator/UpdateOrderPageAdminValidatorTest.java
@@ -96,7 +96,8 @@ class UpdateOrderPageAdminValidatorTest {
 
     @ParameterizedTest
     @MethodSource("provideInvalidUserInfoData")
-    void sagsagsagTest(String name, String surname, String expectedMessage) {
+    void updateOrderPageAdminValidationWithInvalidCustomerNameOrSurnameTest(String name, String surname,
+        String expectedMessage) {
         UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
             .userInfoDto(UbsCustomersDtoUpdate.builder()
                 .customerId(1L)

--- a/service-api/src/test/java/greencity/validator/UpdateOrderPageAdminValidatorTest.java
+++ b/service-api/src/test/java/greencity/validator/UpdateOrderPageAdminValidatorTest.java
@@ -91,8 +91,7 @@ class UpdateOrderPageAdminValidatorTest {
                 "Only alphabetic characters and '-', ' ', and apostrophe are allowed"),
             Arguments.of("Tester", "", "Customer Surname cannot be blank"),
             Arguments.of("Tester", "!@#$%^&*()",
-                "Only alphabetic characters and '-', ' ', and apostrophe are allowed")
-        );
+                "Only alphabetic characters and '-', ' ', and apostrophe are allowed"));
     }
 
     @ParameterizedTest

--- a/service-api/src/test/java/greencity/validator/UpdateOrderPageAdminValidatorTest.java
+++ b/service-api/src/test/java/greencity/validator/UpdateOrderPageAdminValidatorTest.java
@@ -1,0 +1,119 @@
+package greencity.validator;
+
+import greencity.dto.customer.UbsCustomersDtoUpdate;
+import greencity.dto.order.UpdateOrderPageAdminDto;
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class UpdateOrderPageAdminValidatorTest {
+    @Mock
+    private ConstraintValidatorContext context;
+    @InjectMocks
+    private UpdateOrderPageAdminValidator validator;
+
+    @BeforeEach
+    void setup() {
+        ConstraintValidatorContext.ConstraintViolationBuilder builder =
+            Mockito.mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+        when(context.buildConstraintViolationWithTemplate(anyString())).thenReturn(builder);
+        when(builder.addPropertyNode(anyString())).thenReturn(
+            Mockito.mock(ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext.class));
+    }
+
+    @Test
+    void updateOrderPageAdminValidationForValidNameAndSurnameTest() {
+        UpdateOrderPageAdminDto validDto = UpdateOrderPageAdminDto.builder()
+            .userInfoDto(UbsCustomersDtoUpdate.builder()
+                .customerId(1L)
+                .customerName("Tester")
+                .customerSurname("Tester")
+                .build())
+            .build();
+
+        boolean result = validator.isValid(validDto, context);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void updateOrderPageAdminValidationForBlankCustomerNameTest() {
+        UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
+            .userInfoDto(UbsCustomersDtoUpdate.builder()
+                .customerId(1L)
+                .customerName("")
+                .customerSurname("Tester")
+                .build())
+            .build();
+
+        boolean result = validator.isValid(invalidDto, context);
+
+        assertFalse(result);
+        verify(context).buildConstraintViolationWithTemplate("Customer Name cannot be blank");
+    }
+
+    @Test
+    void updateOrderPageAdminValidationForInvalidCharactersInCustomerNameTest() {
+        UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
+            .userInfoDto(UbsCustomersDtoUpdate.builder()
+                .customerId(1L)
+                .customerName("!@#$%^&*()")
+                .customerSurname("ValidSurname")
+                .build())
+            .build();
+
+        boolean result = validator.isValid(invalidDto, context);
+
+        assertFalse(result);
+        verify(context).buildConstraintViolationWithTemplate(
+            "Only alphabetic characters and '-', ' ', and apostrophe are allowed");
+    }
+
+    @Test
+    void updateOrderPageAdminValidationForBlankCustomerSurnameTest() {
+        UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
+            .userInfoDto(UbsCustomersDtoUpdate.builder()
+                .customerId(1L)
+                .customerName("Tester")
+                .customerSurname("")
+                .build())
+            .build();
+
+        boolean result = validator.isValid(invalidDto, context);
+
+        assertFalse(result);
+        verify(context).buildConstraintViolationWithTemplate("Customer Surname cannot be blank");
+    }
+
+    @Test
+    void updateOrderPageAdminValidationForInvalidCharactersInCustomerSurnameTest() {
+        UpdateOrderPageAdminDto invalidDto = UpdateOrderPageAdminDto.builder()
+            .userInfoDto(UbsCustomersDtoUpdate.builder()
+                .customerId(1L)
+                .customerName("Tester")
+                .customerSurname("!@#$%^&*()")
+                .build())
+            .build();
+
+        boolean result = validator.isValid(invalidDto, context);
+
+        assertFalse(result);
+        verify(context).buildConstraintViolationWithTemplate(
+            "Only alphabetic characters and '-', ' ', and apostrophe are allowed");
+    }
+}


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/8390">#8390</a>
<a href="https://github.com/ita-social-projects/GreenCity/issues/8391">#8391</a>

## Changed

- Added validation for fields _CustomerName_ and _CustomerSurname_ in `UpdateOrderPageAdminDto`;
- Added tests for the created validator;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added enhanced validation for updating order pages in the admin panel, ensuring customer name and surname fields meet specific character and formatting requirements.
- **Bug Fixes**
  - Improved error messaging for invalid customer name or surname entries during admin order updates.
- **Tests**
  - Introduced comprehensive tests to verify the new validation logic for admin order updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->