### PR TITLE
Bugfix #8559 fixed inserting an empty value into the reason field of the change_of_points table when paying for an order

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -1768,6 +1768,7 @@ public class UBSClientServiceImpl implements UBSClientService {
                 .amount(-pointsToUse)
                 .date(LocalDateTime.now())
                 .order(order)
+                .reason(BonusReason.DEBIT_PAYMENT)
                 .build());
 
         orderRepository.save(order);


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/8559">#8559</a>

## Changed

- Fixed inserting an empty value into the reason field of the change_of_points table when paying for an order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy in recording the reason for user point deductions during order payments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->