### PR TITLE
Bugfix #8534 - Fixed functionality for retrieving distincts for Kyiv city.

### DIFF
--- a/core/src/main/java/greencity/controller/AddressController.java
+++ b/core/src/main/java/greencity/controller/AddressController.java
@@ -193,6 +193,7 @@ public class AddressController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
             content = @Content(array = @ArraySchema(schema = @Schema(implementation = DistrictDto.class)))),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })
     @GetMapping("/districts-for-kyiv")
     public ResponseEntity<List<DistrictDto>> getAllDistrictsForKyiv() {

--- a/dao/src/main/java/greencity/repository/CityRepository.java
+++ b/dao/src/main/java/greencity/repository/CityRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CityRepository extends JpaRepository<City, Long> {
     /**
@@ -61,5 +62,5 @@ public interface CityRepository extends JpaRepository<City, Long> {
      *         not found
      */
     @Query("SELECT c.id FROM City c WHERE LOWER(c.nameEn) = LOWER(:cityName)")
-    Optional<Long> findIdByCityNameEnIgnoreCase(String cityName);
+    Optional<Long> findIdByCityNameEnIgnoreCase(@Param("cityName") String cityName);
 }

--- a/dao/src/main/java/greencity/repository/CityRepository.java
+++ b/dao/src/main/java/greencity/repository/CityRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CityRepository extends JpaRepository<City, Long> {
     /**
@@ -52,4 +53,14 @@ public interface CityRepository extends JpaRepository<City, Long> {
             + " AND (c.name_uk = :nameUk OR c.name_en = :nameEn) LIMIT 1",
         nativeQuery = true)
     Optional<City> findCityByRegionIdAndNameUkAndNameEn(Long regionId, String nameUk, String nameEn);
+
+    /**
+     * Retrieves the ID of a city by its eng name, ignoring case.
+     *
+     * @param cityName the eng name of the city to search for (case-insensitive)
+     * @return an {@link Optional} containing the city's ID if found, or empty if
+     *         not found
+     */
+    @Query("SELECT c.id FROM City c WHERE LOWER(c.nameEn) = LOWER(:cityName)")
+    Optional<Long> findIdByCityNameEnIgnoreCase(String cityName);
 }

--- a/dao/src/main/java/greencity/repository/CityRepository.java
+++ b/dao/src/main/java/greencity/repository/CityRepository.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface CityRepository extends JpaRepository<City, Long> {
     /**

--- a/service/src/main/java/greencity/constant/AppConstant.java
+++ b/service/src/main/java/greencity/constant/AppConstant.java
@@ -38,4 +38,5 @@ public class AppConstant {
     public static final String UNKNOWN_UK = "Невідомо";
     public static final String LOCALE_UK_NAME = "ua";
     public static final String LOCALE_EN_NAME = "en";
+    public static final String KYIV = "Kyiv";
 }

--- a/service/src/main/java/greencity/service/ubs/AddressServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/AddressServiceImpl.java
@@ -1,5 +1,6 @@
 package greencity.service.ubs;
 
+import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
 import greencity.constant.OrderHistory;
 import greencity.dto.CreateAddressRequestDto;
@@ -47,7 +48,6 @@ import static java.util.stream.Collectors.toMap;
 @Service
 @RequiredArgsConstructor
 public class AddressServiceImpl implements AddressService {
-    private static final Long CITY_ID_KIEV = 3L;
     private static final String KYIV_CITY = "Kyiv City";
     private final OrderAddressRepository orderAddressRepository;
     private final DistrictRepository districtRepository;
@@ -198,7 +198,9 @@ public class AddressServiceImpl implements AddressService {
      */
     @Override
     public List<DistrictDto> getAllDistrictsForKyiv() {
-        return districtRepository.findAllByCityId(CITY_ID_KIEV).stream()
+        Long cityId = cityRepository.findIdByCityNameEnIgnoreCase(AppConstant.KYIV)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.CITY_NOT_FOUND));
+        return districtRepository.findAllByCityId(cityId).stream()
             .filter(district -> !KYIV_CITY.equalsIgnoreCase(district.getNameEn()))
             .collect(toMap(
                 District::getNameUk,

--- a/service/src/test/java/greencity/service/ubs/AddressServiceTest.java
+++ b/service/src/test/java/greencity/service/ubs/AddressServiceTest.java
@@ -958,7 +958,7 @@ class AddressServiceTest {
 
     @Test
     void getAllDistrictsForKyivAndCityKyivNotFoundThenExceptionThrownTest() {
-        when(cityRepository.findIdByCityNameEnIgnoreCase(AppConstant.KYIV)).thenThrow(new NotFoundException(CITY_NOT_FOUND));
+        when(cityRepository.findIdByCityNameEnIgnoreCase(AppConstant.KYIV)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class, () -> addressService.getAllDistrictsForKyiv());
 

--- a/service/src/test/java/greencity/service/ubs/AddressServiceTest.java
+++ b/service/src/test/java/greencity/service/ubs/AddressServiceTest.java
@@ -1,6 +1,7 @@
 package greencity.service.ubs;
 
 import greencity.ModelUtils;
+import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
 import greencity.dto.CreateAddressRequestDto;
 import greencity.dto.address.AddressDto;
@@ -947,8 +948,22 @@ class AddressServiceTest {
     void getAllDistrictsForKyivTest() {
         List<District> district = List.of(ModelUtils.getDistrict());
         when(districtRepository.findAllByCityId(1L)).thenReturn(district);
+        when(cityRepository.findIdByCityNameEnIgnoreCase(AppConstant.KYIV)).thenReturn(Optional.of(1L));
+
         addressService.getAllDistrictsForKyiv();
+
+        verify(cityRepository, times(1)).findIdByCityNameEnIgnoreCase(AppConstant.KYIV);
         verify(districtRepository, times(1)).findAllByCityId(anyLong());
+    }
+
+    @Test
+    void getAllDistrictsForKyivAndCityKyivNotFoundThenExceptionThrownTest() {
+        when(cityRepository.findIdByCityNameEnIgnoreCase(AppConstant.KYIV)).thenThrow(new NotFoundException(CITY_NOT_FOUND));
+
+        assertThrows(NotFoundException.class, () -> addressService.getAllDistrictsForKyiv());
+
+        verify(cityRepository, times(1)).findIdByCityNameEnIgnoreCase(AppConstant.KYIV);
+        verify(districtRepository, times(0)).findAllByCityId(anyLong());
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/8534">#8534</a>

## Added

- Added _findIdByCityNameEnIgnoreCase_ method into the `CityRepository`;

## Changed

- Replaced hardcoded value for city Kyiv with retrieving id from DB in the `AddressServiceImpl` in the method _getAllDistrictsForKyiv_;
-  Added in the Swagger doc response 404 for the method _getAllDistrictsForKyiv_ in the `AddressController`; 
- Added unit tests for the refactored method _getAllDistrictsForKyiv_ in the `AddressServiceTest`;

## Summary Of Changes 🔥
Fixed functionality for retrieving distincts for Kyiv city.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to indicate that retrieving Kyiv districts may return a 404 Not Found response.

- **Bug Fixes**
  - Improved the method for retrieving Kyiv districts to dynamically find Kyiv by name instead of using a hardcoded city ID. Now throws an error if Kyiv is not found.

- **Tests**
  - Enhanced and added tests to verify correct behavior when Kyiv is not found and to ensure proper handling of errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->