### PR TITLE
Bugfix #8570, #8600 Fixed orders not being deleted

### DIFF
--- a/dao/src/main/java/greencity/entity/order/Order.java
+++ b/dao/src/main/java/greencity/entity/order/Order.java
@@ -186,7 +186,7 @@ public class Order {
 
     @OneToMany(
         mappedBy = "order",
-        cascade = CascadeType.ALL)
+        cascade = CascadeType.ALL, orphanRemoval = true)
     @Setter(AccessLevel.PRIVATE)
     @Builder.Default
     private List<OrderBag> orderBags = new ArrayList<>();

--- a/dao/src/main/java/greencity/entity/order/Order.java
+++ b/dao/src/main/java/greencity/entity/order/Order.java
@@ -186,7 +186,7 @@ public class Order {
 
     @OneToMany(
         mappedBy = "order",
-        cascade = CascadeType.ALL, orphanRemoval = true)
+        cascade = CascadeType.ALL)
     @Setter(AccessLevel.PRIVATE)
     @Builder.Default
     private List<OrderBag> orderBags = new ArrayList<>();

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -1513,7 +1513,7 @@ public class UBSClientServiceImpl implements UBSClientService {
             throw new NotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST);
         }
         order.getOrderBags().clear();
-        orderRepository.save(order);
+        orderRepository.saveAndFlush(order);
         orderRepository.delete(order);
     }
 

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -2156,7 +2156,7 @@ class UBSClientServiceImplTest {
 
         ubsService.deleteOrder(order.getUser().getUuid(), 1L);
 
-        verify(orderRepository).save(order);
+        verify(orderRepository).saveAndFlush(order);
         verify(ordersForUserRepository).getAllByUserUuidAndId(order.getUser().getUuid(), order.getId());
     }
 


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link :clipboard:
[#8570](https://github.com/ita-social-projects/GreenCity/issues/8570), [#8600](https://github.com/ita-social-projects/GreenCity/issues/8600)
## Changed
* Modified `deleteOrder` method to prevent `OptimisticLockingFailureException` by flushing order before deletion.
## Summary Of Changes :fire:
Fixed functionality of deleting orders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when deleting orders to ensure changes are immediately saved and reflected in the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->