### PR TITLE
Fix unauthorized access to order-details-for-tariff endpoint

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -97,7 +97,6 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET,
                     UBS_LINK + "/getAllActiveCouriers",
                     UBS_LINK + "/locations/{courierId}",
-                    UBS_LINK + "/order-details-for-tariff",
                     UBS_LINK + "/tariffinfo/**",
                     ADMIN_EMPL_LINK + "/get-employees/{tariffId}",
                     UBS_LINK + "/locationsByCourier/{courierId}",


### PR DESCRIPTION
This PR enhances security by removing the order-details-for-tariff endpoint from publicly accessible endpoints. The changes ensure that this endpoint now requires proper authentication, preventing unauthorized access to order details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated security settings to restrict unauthenticated access to a specific order details page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->