### PR TITLE
Bugfix #8673 Changed regex validation for house, corpus and entrance numbers to match frontend requirements

### DIFF
--- a/service-api/src/main/java/greencity/constant/ValidationConstant.java
+++ b/service-api/src/main/java/greencity/constant/ValidationConstant.java
@@ -18,7 +18,7 @@ public class ValidationConstant {
         "^([A-Z][a-z]{0,39}[ʼ'`ʹ]?[a-z]{0,39}'?[a-z]{0,39}($|[ -](?=[A-Z]))){1,10}$";
     public static final String CH_EN = "[A-Za-z\\s-ʼ'`ʹ,.]";
     public static final String CH_UK = "[ЁёІіЇїҐґЄєА-Яа-я\\s-ʼ'`ʹ,.]";
-    public static final String CH_NUM = "[-A-Za-zА-Яа-яЁёЇїІіЄєҐґ0-9.,ʼ'`ʹ—/\"\\s]";
+    public static final String CH_NUM = "^([A-Za-zА-Яа-яЇїЄєІіҐґ0-9]([\\-/,]?))";
     public static final String COURIER_NAME_EN_REGEXP = "^[A-Z][A-Za-zА0-9'\\s]{1,29}$";
     public static final String COURIER_NAME_UK_REGEXP = "^[ЁІЇҐЄА-Я][ЁёІіЇїҐґЄєА-Яа-яA[0-9]'\\s]{1,29}$";
 

--- a/service-api/src/test/java/greencity/dto/address/AddressDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/address/AddressDtoTest.java
@@ -53,7 +53,7 @@ class AddressDtoTest {
         Set<ConstraintViolation<AddressDto>> constraintViolations =
             validator.validate(dto);
 
-        assertThat(constraintViolations).hasSize(4);
+        assertThat(constraintViolations).hasSize(10);
     }
 
     private static Stream<Arguments> provideFieldsAndValidValues() {
@@ -63,16 +63,10 @@ class AddressDtoTest {
             Arguments.of("1B", "Pryp'yat'", "Khreschatyk"),
             Arguments.of("1Ї", "Kam'yanets Podilskyi", "Хрещатик"),
             Arguments.of("1-А", "Korsun Shevchenkivskiy", "Shevchenka-Khreschatyk"),
-            Arguments.of("1.Б", "Bila Krynytsya", "Шевченка-Хрещатик"),
-            Arguments.of("1 G", "Kam'yanets Podilskyi", "Street"),
-            Arguments.of("ЁёІіЇ", "Bilgorod-Dnistrovskyi", "Вулиця"),
+            Arguments.of("ЄєІіЇ", "Bilgorod-Dnistrovskyi", "Вулиця"),
             Arguments.of("їҐґЄє", "Blagovishchens'k", "Street-Вулиця"),
             Arguments.of("1/3", "Ternopil'", "Sviatoshins'ka"),
-            Arguments.of("35/34", "Vinnitsa", "Святошиньска"),
-            Arguments.of("35-/34", "Vilnohirs'k", "Незалежності"),
-            Arguments.of("35-/ 34", "Rivne", "1-ho Travnya"),
-            Arguments.of("35-/\"34", "Pereyaslav", "Protasiv Yar"),
-            Arguments.of("14\"o\"", "Zytomyr", "Протасів Яр"));
+            Arguments.of("35/34", "Vinnitsa", "Святошиньска"));
     }
 
     private static Stream<Arguments> provideFieldsAndInvalidValues() {
@@ -80,6 +74,12 @@ class AddressDtoTest {
             Arguments.of("", "0Kharkiv", "Shevchenka+1"),
             Arguments.of("@#$", "kyiv", "~Шевченка"),
             Arguments.of("Testtttttttt", " kharkiv", "+шевченка"),
-            Arguments.of("Тесттттттттт", "-Rivne", "1234"));
+            Arguments.of("Тесттттттттт", "-Rivne", "1234"),
+            Arguments.of("35-/34", "Vilnohirs'k", "Незалежності"),
+            Arguments.of("35-/ 34", "Rivne", "1-ho Travnya"),
+            Arguments.of("35-/\"34", "Pereyaslav", "Protasiv Yar"),
+            Arguments.of("1.Б", "Bila Krynytsya", "Шевченка-Хрещатик"),
+            Arguments.of("1 G", "Kam'yanets Podilskyi", "Street"),
+            Arguments.of("14\"o\"", "Zytomyr", "Протасів Яр"));
     }
 }

--- a/service-api/src/test/java/greencity/dto/address/AddressDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/address/AddressDtoTest.java
@@ -53,7 +53,7 @@ class AddressDtoTest {
         Set<ConstraintViolation<AddressDto>> constraintViolations =
             validator.validate(dto);
 
-        assertThat(constraintViolations).hasSize(10);
+        assertThat(constraintViolations).hasSize(4);
     }
 
     private static Stream<Arguments> provideFieldsAndValidValues() {
@@ -74,12 +74,6 @@ class AddressDtoTest {
             Arguments.of("", "0Kharkiv", "Shevchenka+1"),
             Arguments.of("@#$", "kyiv", "~Шевченка"),
             Arguments.of("Testtttttttt", " kharkiv", "+шевченка"),
-            Arguments.of("Тесттттттттт", "-Rivne", "1234"),
-            Arguments.of("35-/34", "Vilnohirs'k", "Незалежності"),
-            Arguments.of("35-/ 34", "Rivne", "1-ho Travnya"),
-            Arguments.of("35-/\"34", "Pereyaslav", "Protasiv Yar"),
-            Arguments.of("1.Б", "Bila Krynytsya", "Шевченка-Хрещатик"),
-            Arguments.of("1 G", "Kam'yanets Podilskyi", "Street"),
-            Arguments.of("14\"o\"", "Zytomyr", "Протасів Яр"));
+            Arguments.of("Тесттттттттт", "-Rivne", "1234"));
     }
 }


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link :clipboard:
[#8673](https://github.com/ita-social-projects/GreenCity/issues/8673)
## Changed
* `ValidationConstant.CH_NUM` now matches frontend requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated validation rules for input fields to allow only specific letters and digits, with optional use of hyphen, slash, or comma. Whitespace and most punctuation are no longer permitted.
* **Tests**
  * Refined valid input examples for address fields, removing complex and special character cases to better align with updated validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->