### PR TITLE
Bug/8656/fix wayforpay 500 error on invalid request

### DIFF
--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -212,7 +212,7 @@ public class OrderController {
      *                 format.
      * @param servlet  The HttpServletResponse object to handle the redirection.
      * @return A PaymentResponseWayForPay object representing the validated payment
-     * response.
+     *         response.
      * @throws IOException If an input or output exception occurred during the
      *                     redirection.
      */

--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -212,7 +212,7 @@ public class OrderController {
      *                 format.
      * @param servlet  The HttpServletResponse object to handle the redirection.
      * @return A PaymentResponseWayForPay object representing the validated payment
-     *         response.
+     * response.
      * @throws IOException If an input or output exception occurred during the
      *                     redirection.
      */
@@ -238,11 +238,11 @@ public class OrderController {
             objectMapper.readValue(decodedResponse, PaymentResponseDto.class);
         log.info("PaymentResponseDto: {}", paymentResponseDto);
 
-        if (HttpStatus.OK.is2xxSuccessful()) {
-            servlet.sendRedirect(redirectionConfigProp.getGreenCityClient());
-        }
+        PaymentResponseWayForPay result = ubsClientService.validatePayment(paymentResponseDto);
 
-        return ubsClientService.validatePayment(paymentResponseDto);
+        servlet.sendRedirect(redirectionConfigProp.getGreenCityClient());
+
+        return result;
     }
 
     /**

--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -1,5 +1,6 @@
 package greencity.exception.handler;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.ResourceNotFoundException;
@@ -280,5 +281,20 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
         ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(webRequest));
         log.trace(ex.getMessage(), ex);
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(exceptionResponse);
+    }
+
+    /**
+     * Method intercepts exception {@link JsonProcessingException}.
+     *
+     * @param ex      Exception that should be intercepted.
+     * @param request Contains details about the occurred exception.
+     * @return {@code ResponseEntity} which contains the HTTP status and body with
+     *         the exception message.
+     */
+    @ExceptionHandler(JsonProcessingException.class)
+    public final ResponseEntity<Object> handleJsonProcessingException(JsonProcessingException ex, WebRequest request) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
+        log.error("Invalid JSON format: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
     }
 }

--- a/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
+++ b/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package greencity.exception.handler;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.ResourceNotFoundException;
 import greencity.exceptions.UnprocessableEntityException;
@@ -72,6 +73,9 @@ class CustomExceptionHandlerTest {
 
     @Mock
     NotFoundException notFoundException;
+
+    @Mock
+    JsonProcessingException jsonProcessingException;
 
     @Mock
     HttpStatus status;
@@ -245,6 +249,16 @@ class CustomExceptionHandlerTest {
             .thenReturn(objectMap);
         assertEquals(customExceptionHandler.handleWrongSignatureException(wrongSignatureException, webRequest),
             ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(exceptionResponse));
+        verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
+    }
+
+    @Test
+    void handleJsonProcessingExceptionTest() {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(objectMap);
+        when(errorAttributes.getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class)))
+            .thenReturn(objectMap);
+        assertEquals(customExceptionHandler.handleJsonProcessingException(jsonProcessingException, webRequest),
+            ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse));
         verify(errorAttributes).getErrorAttributes(any(WebRequest.class), any(ErrorAttributeOptions.class));
     }
 }

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -302,6 +302,9 @@ public class UBSClientServiceImpl implements UBSClientService {
     @Transactional
     public PaymentResponseWayForPay validatePayment(PaymentResponseDto response) {
         String decodedOrderReference = OrderUtils.decodeOrderReference(response.getOrderReference());
+        if (!decodedOrderReference.matches("\\d+_\\d+_\\d+")) {
+            throw new BadRequestException(PAYMENT_VALIDATION_ERROR);
+        }
         Payment orderPayment = mapPayment(response, decodedOrderReference);
         String[] ids = decodedOrderReference.split("_");
         Order order = orderRepository.findById(Long.valueOf(ids[0]))
@@ -320,11 +323,19 @@ public class UBSClientServiceImpl implements UBSClientService {
         if (response.getFee() == null) {
             response.setFee("0");
         }
+
+        long amount;
+        try {
+            amount = Long.parseLong(response.getAmount()) * 100;
+        } catch (NumberFormatException e) {
+            throw new BadRequestException(PAYMENT_VALIDATION_ERROR);
+        }
+
         return Payment.builder()
             .id(Long.valueOf(decodedOrderReference
                 .substring(decodedOrderReference.lastIndexOf("_") + 1)))
             .currency(response.getCurrency())
-            .amount(Long.parseLong(response.getAmount()) * 100)
+            .amount(amount)
             .orderStatus(OrderStatus.FORMED)
             .senderCellPhone(response.getPhone())
             .maskedCard(response.getCardPan())

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -302,7 +302,7 @@ public class UBSClientServiceImpl implements UBSClientService {
     @Transactional
     public PaymentResponseWayForPay validatePayment(PaymentResponseDto response) {
         String decodedOrderReference;
-        try{
+        try {
             decodedOrderReference = OrderUtils.decodeOrderReference(response.getOrderReference());
         } catch (IllegalArgumentException e) {
             throw new BadRequestException(PAYMENT_VALIDATION_ERROR);

--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -301,7 +301,12 @@ public class UBSClientServiceImpl implements UBSClientService {
     @Override
     @Transactional
     public PaymentResponseWayForPay validatePayment(PaymentResponseDto response) {
-        String decodedOrderReference = OrderUtils.decodeOrderReference(response.getOrderReference());
+        String decodedOrderReference;
+        try{
+            decodedOrderReference = OrderUtils.decodeOrderReference(response.getOrderReference());
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException(PAYMENT_VALIDATION_ERROR);
+        }
         if (!decodedOrderReference.matches("\\d+_\\d+_\\d+")) {
             throw new BadRequestException(PAYMENT_VALIDATION_ERROR);
         }

--- a/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSClientServiceImplTest.java
@@ -3131,6 +3131,68 @@ class UBSClientServiceImplTest {
     }
 
     @Test
+    void testValidatePaymentInvalidOrderReference() {
+        PaymentResponseDto response = getPaymentResponseDto();
+
+        try (MockedStatic<OrderUtils> orderUtilsMock = mockStatic(OrderUtils.class)) {
+            orderUtilsMock.when(() -> OrderUtils.decodeOrderReference(anyString()))
+                .thenThrow(new IllegalArgumentException());
+
+            BadRequestException exception = assertThrows(
+                BadRequestException.class,
+                () -> ubsClientService.validatePayment(response));
+
+            assertEquals(PAYMENT_VALIDATION_ERROR, exception.getMessage());
+            orderUtilsMock.verify(() -> OrderUtils.decodeOrderReference(anyString()));
+        }
+    }
+
+    @Test
+    void testValidatePaymentInvalidOrderReferenceFormat() {
+        PaymentResponseDto response = getPaymentResponseDto();
+
+        try (MockedStatic<OrderUtils> orderUtilsMock = mockStatic(OrderUtils.class)) {
+            orderUtilsMock.when(() -> OrderUtils.decodeOrderReference(anyString()))
+                .thenReturn("invalid_format");
+
+            BadRequestException exception = assertThrows(
+                BadRequestException.class,
+                () -> ubsClientService.validatePayment(response));
+
+            assertEquals(PAYMENT_VALIDATION_ERROR, exception.getMessage());
+            orderUtilsMock.verify(() -> OrderUtils.decodeOrderReference(anyString()));
+        }
+    }
+
+    @Test
+    void testValidatePaymentInvalidAmount() {
+        PaymentResponseDto response = PaymentResponseDto.builder()
+            .orderReference(getPaymentResponseDto().getOrderReference())
+            .currency(getPaymentResponseDto().getCurrency())
+            .amount("invalid_amount")
+            .transactionStatus(getPaymentResponseDto().getTransactionStatus())
+            .phone(getPaymentResponseDto().getPhone())
+            .cardPan(getPaymentResponseDto().getCardPan())
+            .cardType(getPaymentResponseDto().getCardType())
+            .createdDate(getPaymentResponseDto().getCreatedDate())
+            .paymentSystem(getPaymentResponseDto().getPaymentSystem())
+            .email(getPaymentResponseDto().getEmail())
+            .build();
+
+        try (MockedStatic<OrderUtils> orderUtilsMock = mockStatic(OrderUtils.class)) {
+            orderUtilsMock.when(() -> OrderUtils.decodeOrderReference(anyString()))
+                .thenReturn("1_2_3");
+
+            BadRequestException exception = assertThrows(
+                BadRequestException.class,
+                () -> ubsClientService.validatePayment(response));
+
+            assertEquals(PAYMENT_VALIDATION_ERROR, exception.getMessage());
+            orderUtilsMock.verify(() -> OrderUtils.decodeOrderReference(anyString()));
+        }
+    }
+
+    @Test
     void testMapPayment() {
         PaymentResponseDto response = PaymentResponseDto.builder()
             .orderReference("MV8xXzE=")


### PR DESCRIPTION
This pull request fixes a bug that caused 500 errors when receiving invalid responses from the WayForPay payment system by adding proper error handling to the JSON parsing process and handling cases where field values were invalid in payment responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added handling for invalid JSON input, providing clear error responses when JSON parsing fails.

* **Bug Fixes**
  * Improved error handling for payment validation, ensuring invalid order references and payment amounts are properly managed with user-friendly error messages.

* **Refactor**
  * Simplified the payment processing flow for better reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->