### PR TITLE
Add proper swagger documentation for 200 status code for ubs/processO…

### DIFF
--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -180,6 +180,8 @@ public class OrderController {
      */
     @Operation(summary = "Process user order.")
     @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
+            content = @Content(schema = @Schema(implementation = PaymentSystemResponse.class))),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)


### PR DESCRIPTION
### 🔗 **Issue:** [#8668](https://github.com/ita-social-projects/GreenCity/issues/8668)

This pull request includes a minor update to the `OrderController.java` file. The change adds a new `ApiResponse` annotation to document the `200 OK` response for the `getUBSUsers` method, specifying that it returns a `PaymentSystemResponse` schema.

- [`core/src/main/java/greencity/controller/OrderController.java`](diffhunk://#diff-5435e6df200d6d69ba57234af15692b7109803e136cf9ede29131abba11891e1R183-R184): Added `ApiResponse` annotation for the `200 OK` response in the `getUBSUsers` method, with `PaymentSystemResponse` as the schema.

✅ **This pull request closes** [#8668](https://github.com/ita-social-projects/GreenCity/issues/8668) **once merged.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved API documentation for order processing by specifying the response schema for successful requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->