### PR TITLE
Fix permit all to endpoint which creates user profile, make only auth…

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -106,9 +106,6 @@ public class SecurityConfig {
                     UBS_LINK + "/districts-for-kyiv",
                     COMMIT_INFO)
                 .permitAll()
-                .requestMatchers(HttpMethod.POST,
-                    UBS_LINK + "/userProfile/user/create")
-                .permitAll()
                 .requestMatchers("/v2/api-docs/**",
                     "/v3/api-docs/**",
                     "/swagger.json",
@@ -297,6 +294,9 @@ public class SecurityConfig {
                     "/notifications/{notificationId}/viewNotification",
                     "/notifications/{notificationId}/unreadNotification")
                 .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE)
+                .requestMatchers(HttpMethod.POST,
+                    UBS_LINK + "/userProfile/user/create")
+                .hasAnyRole(USER, ADMIN)
                 .requestMatchers(HttpMethod.PUT,
                     UBS_LINK + "/userProfile/**",
                     UBS_LINK + "/update-order-address")

--- a/core/src/main/java/greencity/controller/UserProfileController.java
+++ b/core/src/main/java/greencity/controller/UserProfileController.java
@@ -81,6 +81,7 @@ public class UserProfileController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED,
             content = @Content(schema = @Schema(implementation = Long.class))),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })


### PR DESCRIPTION
### 🔗 **Issue:** [#7273](https://github.com/ita-social-projects/GreenCity/issues/7273)

This pull request includes updates to the security configuration and API documentation in the `core` module. The most important changes involve modifying access control rules in the `SecurityConfig` class and adding a new response code to the API documentation in the `UserProfileController` class.

### Security Configuration Updates:
* `core/src/main/java/greencity/configuration/SecurityConfig.java`:
  - Removed the `permitAll` access for the `POST` endpoint `UBS_LINK + "/userProfile/user/create"` and restricted it to roles `USER` and `ADMIN`. This ensures that only authenticated users with the specified roles can access this endpoint. [[1]](diffhunk://#diff-05eb7be5959ff2ad17a6652cc076f4be0fb0dbdf640f016db9f572ded4297ee0L109-L111) [[2]](diffhunk://#diff-05eb7be5959ff2ad17a6652cc076f4be0fb0dbdf640f016db9f572ded4297ee0R297-R299)

### API Documentation Enhancements:
* `core/src/main/java/greencity/controller/UserProfileController.java`:
  - Added a `401 Unauthorized` response description to the `getUserData` method's API documentation, improving clarity on possible error scenarios.

✅ **This pull request closes** [#7273](https://github.com/ita-social-projects/GreenCity/issues/7273) **once merged.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The create user profile endpoint now requires users to be authenticated with USER or ADMIN roles.
* **Documentation**
  * Updated API documentation to indicate that a 401 Unauthorized response is possible when creating a user profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->