### PR TITLE
Modified security configuration for PATCH ubs/update-address endpoint

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -201,12 +201,12 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.PATCH,
                     SUPER_ADMIN_LINK + "/deactivateCourier/{id}",
                     SUPER_ADMIN_LINK + "/switchTariffStatus/{tariffId}",
-                    UBS_MANAG_LINK + "/addChatLink",
-                    UBS_LINK + "/update-address")
+                    UBS_MANAG_LINK + "/addChatLink")
                 .hasAnyRole(ADMIN, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.PATCH,
                     UBS_MANAG_LINK + "/update-order-page-admin-info/{id}",
-                    SUPER_ADMIN_LINK + "/activeLocations/{id}")
+                    SUPER_ADMIN_LINK + "/activeLocations/{id}",
+                    UBS_LINK + "/update-address")
                 .hasAnyRole(UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.POST,
                     ADMIN_LINK + "/notification/add-template")

--- a/core/src/main/java/greencity/controller/AddressController.java
+++ b/core/src/main/java/greencity/controller/AddressController.java
@@ -9,6 +9,7 @@ import greencity.dto.address.AddressDto;
 import greencity.dto.address.UpdateAddressDto;
 import greencity.dto.location.api.DistrictDto;
 import greencity.dto.order.OrderAddressDtoRequest;
+import greencity.dto.order.OrderAddressDtoResponse;
 import greencity.dto.order.OrderWithAddressesResponseDto;
 import greencity.dto.order.ReadAddressByOrderDto;
 import greencity.dto.user.UserVO;
@@ -21,6 +22,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.security.Principal;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -206,22 +208,22 @@ public class AddressController {
      *
      * @param addressDto The updated address information.
      * @param principal  The user principal.
-     * @return HTTP status of 200 if the update was successful.
+     * @return {@link HttpStatus}
      */
     @Operation(summary = "Update address for current order",
         description = "Update address for current order on big order table")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK, content = @Content),
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
+            content = @Content(schema = @Schema(implementation = OrderAddressDtoResponse.class))),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })
     @PatchMapping("/update-address")
-    public ResponseEntity<Void> updateAddress(@RequestBody @Valid UpdateAddressDto addressDto,
-        @Parameter(hidden = true) Principal principal) {
-        addressService.addressUpdate(addressDto, principal.getName());
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Optional<OrderAddressDtoResponse>> updateAddress(
+        @RequestBody @Valid UpdateAddressDto addressDto, @Parameter(hidden = true) Principal principal) {
+        return ResponseEntity.ok(addressService.addressUpdate(addressDto, principal.getName()));
     }
 
     /**

--- a/core/src/main/java/greencity/controller/AddressController.java
+++ b/core/src/main/java/greencity/controller/AddressController.java
@@ -22,7 +22,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.security.Principal;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -221,7 +220,7 @@ public class AddressController {
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })
     @PatchMapping("/update-address")
-    public ResponseEntity<Optional<OrderAddressDtoResponse>> updateAddress(
+    public ResponseEntity<OrderAddressDtoResponse> updateAddress(
         @RequestBody @Valid UpdateAddressDto addressDto, @Parameter(hidden = true) Principal principal) {
         return ResponseEntity.ok(addressService.addressUpdate(addressDto, principal.getName()));
     }

--- a/service-api/src/main/java/greencity/service/ubs/AddressService.java
+++ b/service-api/src/main/java/greencity/service/ubs/AddressService.java
@@ -13,7 +13,6 @@ import greencity.entity.order.Order;
 import greencity.entity.user.User;
 import greencity.entity.user.ubs.OrderAddress;
 import java.util.List;
-import java.util.Optional;
 
 public interface AddressService {
     /**
@@ -45,7 +44,7 @@ public interface AddressService {
      * @return {@link OrderAddressDtoResponse} that contains address.
      * @author Kizerov Dmytro
      */
-    Optional<OrderAddressDtoResponse> addressUpdate(UpdateAddressDto addressDto, String email);
+    OrderAddressDtoResponse addressUpdate(UpdateAddressDto addressDto, String email);
 
     /**
      * Method that save address for current user.
@@ -67,7 +66,7 @@ public interface AddressService {
      * @return {@link OrderAddressDtoResponse} that contains address.
      * @author Mahdziak Orest
      */
-    Optional<OrderAddressDtoResponse> updateAddress(OrderAddressExportDetailsDtoUpdate dtoUpdate, Order order,
+    OrderAddressDtoResponse updateAddress(OrderAddressExportDetailsDtoUpdate dtoUpdate, Order order,
         String email);
 
     /**

--- a/service-api/src/main/java/greencity/service/ubs/AddressService.java
+++ b/service-api/src/main/java/greencity/service/ubs/AddressService.java
@@ -42,9 +42,10 @@ public interface AddressService {
      *
      * @param addressDto {@link UpdateAddressDto}
      * @param email      {@link String} the user's email
+     * @return {@link OrderAddressDtoResponse} that contains address.
      * @author Kizerov Dmytro
      */
-    void addressUpdate(UpdateAddressDto addressDto, String email);
+    Optional<OrderAddressDtoResponse> addressUpdate(UpdateAddressDto addressDto, String email);
 
     /**
      * Method that save address for current user.

--- a/service/src/main/java/greencity/service/ubs/AddressServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/AddressServiceImpl.java
@@ -89,10 +89,10 @@ public class AddressServiceImpl implements AddressService {
 
     @Override
     @Transactional
-    public void addressUpdate(UpdateAddressDto addressDto, String email) {
+    public Optional<OrderAddressDtoResponse> addressUpdate(UpdateAddressDto addressDto, String email) {
         Order order = orderRepository.findById(addressDto.getOrderId())
             .orElseThrow(() -> new NotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST + addressDto.getOrderId()));
-        updateAddress(addressDto.getOrderAddressExportDetails(), order, email);
+        return updateAddress(addressDto.getOrderAddressExportDetails(), order, email);
     }
 
     /**

--- a/service/src/main/java/greencity/service/ubs/AddressServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/AddressServiceImpl.java
@@ -89,7 +89,7 @@ public class AddressServiceImpl implements AddressService {
 
     @Override
     @Transactional
-    public Optional<OrderAddressDtoResponse> addressUpdate(UpdateAddressDto addressDto, String email) {
+    public OrderAddressDtoResponse addressUpdate(UpdateAddressDto addressDto, String email) {
         Order order = orderRepository.findById(addressDto.getOrderId())
             .orElseThrow(() -> new NotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST + addressDto.getOrderId()));
         return updateAddress(addressDto.getOrderAddressExportDetails(), order, email);
@@ -144,7 +144,7 @@ public class AddressServiceImpl implements AddressService {
      */
     @Override
     @Transactional
-    public Optional<OrderAddressDtoResponse> updateAddress(OrderAddressExportDetailsDtoUpdate dtoUpdate, Order order,
+    public OrderAddressDtoResponse updateAddress(OrderAddressExportDetailsDtoUpdate dtoUpdate, Order order,
         String email) {
         OrderAddress orderAddress = orderAddressRepository.findById(dtoUpdate.getId())
             .orElseThrow(() -> new NotFoundException(String.format(NOT_FOUND_ADDRESS_BY_ID, dtoUpdate.getId())));
@@ -152,7 +152,7 @@ public class AddressServiceImpl implements AddressService {
         mapUpdatedOrderAddressFields(orderAddress, updatedOrderAddress, dtoUpdate.getAddressComment());
         orderAddressRepository.save(updatedOrderAddress);
         eventService.saveEvent(OrderHistory.WASTE_REMOVAL_ADDRESS_CHANGE_UK, email, order);
-        return Optional.of(modelMapper.map(updatedOrderAddress, OrderAddressDtoResponse.class));
+        return modelMapper.map(updatedOrderAddress, OrderAddressDtoResponse.class);
     }
 
     /**


### PR DESCRIPTION
# GreenCityUBS PR
[#8670](https://github.com/ita-social-projects/GreenCity/issues/8670)

## Summary Of Changes :fire:
Modified SecurityConfig for /ubs/update-address, refactored the endpoint

## Changed
* Modified SecurityConfig so that PATCH `/ubs/update-address` endpoint is only accessible to role `UBS_EMPLOYEE` to match existing event logging logic of `AddressService` and prevent ambiguous behavior.
* Refactored /ubs/update-address endpoint, which now returns `OrderAddressDtoResponse` with 200 status code, provided relevant documentation for Swagger.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The update address endpoint now returns updated address information in the response, allowing users to receive confirmation and details of their updated address.

* **Bug Fixes**
  * Improved API documentation to accurately reflect the response content for the update address endpoint.

* **Refactor**
  * Adjusted access control for the update address endpoint to allow only specific user roles to perform updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->