### PR TITLE
Bugfix #8866 - Added counter to order formation in process[New/Existing]Order flow to sync with processOrder method

### DIFF
--- a/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSClientServiceImpl.java
@@ -534,6 +534,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         Order order = modelMapper.map(dto, Order.class);
         order.setOrderDate(LocalDateTime.now());
         order.setOrderStatus(OrderStatus.FORMED);
+        order.setCounterOrderPaymentId(0L);
 
         User currentUser = userRepository.findByUuid(uuid);
 
@@ -1098,6 +1099,7 @@ public class UBSClientServiceImpl implements UBSClientService {
         order.setUbsUser(userData);
         order.setUser(currentUser);
         order.setSumTotalAmountWithoutDiscounts(calculateOrderSumWithoutDiscounts(bagsOrdered));
+        order.setCounterOrderPaymentId(order.getCounterOrderPaymentId() + 1);
         setOrderPaymentStatus(order, sumToPayInCoins);
 
         Payment payment = Payment.builder()

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -573,6 +573,7 @@ public class ModelUtils {
     public static Order getOrder() {
         return Order.builder()
             .id(1L)
+            .counterOrderPaymentId(1L)
             .orderDate(LocalDateTime.of(2023, 10, 20, 14, 58))
             .payment(Lists.newArrayList(Payment.builder()
                 .id(1L)


### PR DESCRIPTION
### 🔗 **Issue:** [#8866](https://github.com/ita-social-projects/GreenCity/issues/8866)

This pull request correctly initializes counterOrderPaymentId for new orders and synchronizes counter updates for all methods responsible for order processing.

✅ **This pull request closes** [#8866](https://github.com/ita-social-projects/GreenCity/issues/8866) **once merged.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of order payment tracking to ensure the payment attempt counter is properly initialized and incremented for new and saved orders.

* **Tests**
  * Updated test utilities to reflect the changes in order payment tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->