### PR TITLE
fix: make chat search case-insensitive by applying LOWER() in criteria

### DIFF
--- a/dao/src/main/java/greencity/specification/ChatSpecifications.java
+++ b/dao/src/main/java/greencity/specification/ChatSpecifications.java
@@ -12,10 +12,13 @@ public class ChatSpecifications {
                 return criteriaBuilder.conjunction();
             }
 
+            String pattern = "%" + searchTerm.toLowerCase() + "%";
+
             return criteriaBuilder.or(
-                criteriaBuilder.like(root.get("firstName"), "%" + searchTerm + "%"),
-                criteriaBuilder.like(root.get("lastName"), "%" + searchTerm + "%"),
-                criteriaBuilder.like(root.get("username"), "%" + searchTerm + "%"));
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("firstName")), pattern),
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("lastName")), pattern),
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("username")), pattern)
+            );
         };
     }
 }

--- a/dao/src/main/java/greencity/specification/ChatSpecifications.java
+++ b/dao/src/main/java/greencity/specification/ChatSpecifications.java
@@ -15,10 +15,9 @@ public class ChatSpecifications {
             String pattern = "%" + searchTerm.toLowerCase() + "%";
 
             return criteriaBuilder.or(
-                    criteriaBuilder.like(criteriaBuilder.lower(root.get("firstName")), pattern),
-                    criteriaBuilder.like(criteriaBuilder.lower(root.get("lastName")), pattern),
-                    criteriaBuilder.like(criteriaBuilder.lower(root.get("username")), pattern)
-            );
+                criteriaBuilder.like(criteriaBuilder.lower(root.get("firstName")), pattern),
+                criteriaBuilder.like(criteriaBuilder.lower(root.get("lastName")), pattern),
+                criteriaBuilder.like(criteriaBuilder.lower(root.get("username")), pattern));
         };
     }
 }


### PR DESCRIPTION
**GreenCityUBS**

**Summary** 
This pull request fixes an issue where the chat search (by first name, last name, or username) was case-sensitive. For example, searching "вОва" wouldn't return "Вова". The logic now performs case-insensitive comparisons using LOWER() to normalize both sides of the comparison.

Змінено метод Specification<TelegramChat> hasNameLike(String searchTerm), щоб використовувати CriteriaBuilder.lower(...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat search to be case-insensitive when matching names and usernames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->