### PR TITLE
8869 Employee first and second names fields allow multiple special symbols instead of one allowed

### DIFF
--- a/service-api/src/main/java/greencity/constant/ValidationConstant.java
+++ b/service-api/src/main/java/greencity/constant/ValidationConstant.java
@@ -28,6 +28,7 @@ public class ValidationConstant {
             + "(?!.*\\.\\.)"
             + "(?!.*--)"
             + "(?!.*'')"
+            + "(?!.*(?:[-'ʼ’\\.]\\s+[-'ʼ’\\.]))"
             + "[-'ʼ’ ґҐіІєЄїЇА-Яа-я\\w\\.]{0,29}$";
     public static final String NAME_VALIDATION_MESSAGE =
         "Name must start with an English or Ukrainian letter, "

--- a/service-api/src/test/java/greencity/dto/employee/EmployeeWithTariffsIdDtoTest.java
+++ b/service-api/src/test/java/greencity/dto/employee/EmployeeWithTariffsIdDtoTest.java
@@ -125,7 +125,11 @@ class EmployeeWithTariffsIdDtoTest {
             Arguments.of("Лук' ян", "Є гор"),
             Arguments.of("Лук'ян.н", "Єгор.р"),
             Arguments.of("Петро", "Ґгор"),
-            Arguments.of("лук'ян", "їєґгор"));
+            Arguments.of("лук'ян", "їєґгор"),
+            Arguments.of("Іван-Петро", "Кирило-Миколайович"),
+            Arguments.of("Dr.Ігор", "П.Іванович"),
+            Arguments.of("Тест-Test", "Прізвище-Family"),
+            Arguments.of("Євген’О’Браєн", "Ґудзик"));
     }
 
     private static Stream<Arguments> provideInvalidNamePairs() {
@@ -145,7 +149,11 @@ class EmployeeWithTariffsIdDtoTest {
             Arguments.of("T--", "T--"),
             Arguments.of("T---", "T---"),
             Arguments.of("''", "''"),
-            Arguments.of("Ttttttttttttttttttttttttttttttt", "Ttttttttttttttttttttttttttttttt"));
+            Arguments.of("Ttttttttttttttttttttttttttttttt", "Ttttttttttttttttttttttttttttttt"),
+            Arguments.of("A - - B", "C - - D"),
+            Arguments.of("І. .ван", "Є. .гор"),
+            Arguments.of("Є ’     ’ ван", "Ґ ’ ’"),
+            Arguments.of("Test '' Name", "Last '' Name"));
     }
 
     private static Stream<Arguments> provideValidEmails() {


### PR DESCRIPTION
### 🔗 **Issue:** [#8869](https://github.com/ita-social-projects/GreenCity/issues/8869), [#8871](https://github.com/ita-social-projects/GreenCity/issues/8871)

This pull request refines the validation logic for name formatting and updates corresponding test cases to ensure compliance with new rules. The changes primarily focus on improving the regex pattern for name validation and enhancing test coverage by adding new valid and invalid name examples.

### Validation Logic Enhancements:
* Updated the regex pattern in `ValidationConstant.java` to disallow names with sequences like `"- ' "`, `"ʼ . "`, or `"’ . "`. This ensures stricter validation for name formatting.

### Test Case Updates:
#### Valid Name Tests:
* Added new valid name examples such as `"Іван-Петро"`, `"Dr.Ігор"`, `"Тест-Test"`, and `"Євген’О’Браєн"` to the `provideValidNamePairs()` method in `EmployeeWithTariffsIdDtoTest.java`. These examples reflect edge cases that comply with the updated validation rules.

#### Invalid Name Tests:
* Added new invalid name examples such as `"A - - B"`, `"І. .ван"`, `"Є ’     ’ ван"`, and `"Test '' Name"` to the `provideInvalidNamePairs()` method in `EmployeeWithTariffsIdDtoTest.java`. These examples test scenarios that violate the stricter validation logic.

✅ **This pull request closes** [#8869](https://github.com/ita-social-projects/GreenCity/issues/8869), [#8871](https://github.com/ita-social-projects/GreenCity/issues/8871) **once merged.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved name validation to prevent special characters (such as hyphens, apostrophes, and dots) from being separated by spaces in names.

* **Tests**
  * Expanded test coverage for name validation, adding more examples of valid and invalid name formats to ensure robust validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->