### PR TITLE
8895 endpoint admin ubs employee get employees by tariff id works incorrectly

### DIFF
--- a/core/src/test/java/greencity/controller/ManagementEmployeeControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementEmployeeControllerTest.java
@@ -4,12 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import greencity.ModelUtils;
 import greencity.client.UserRemoteClient;
 import greencity.configuration.SecurityConfig;
+import greencity.constant.ErrorMessage;
 import greencity.converters.UserArgumentResolver;
 import greencity.dto.employee.EmployeeDto;
 import greencity.dto.employee.EmployeeWithTariffsDto;
 import greencity.dto.employee.EmployeeWithTariffsIdDto;
 import greencity.dto.employee.UserEmployeeAuthorityDto;
 import greencity.dto.tariff.TariffWithChatAccess;
+import greencity.exception.handler.CustomExceptionHandler;
+import greencity.exceptions.NotFoundException;
 import greencity.filters.EmployeeFilterCriteria;
 import greencity.filters.EmployeePage;
 import greencity.service.ubs.UBSClientService;
@@ -20,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
@@ -28,16 +32,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.Validator;
-
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import static greencity.ModelUtils.getUuid;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -52,6 +53,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -73,18 +75,19 @@ class ManagementEmployeeControllerTest {
     @Mock
     private UBSClientService ubsClientService;
     @Mock
-    UserRemoteClient userRemoteClient;
+    private UserRemoteClient userRemoteClient;
     @Mock
     private Validator mockValidator;
 
     @InjectMocks
-    ManagementEmployeeController controller;
+    private ManagementEmployeeController controller;
 
     private final Principal principal = getUuid();
 
     @BeforeEach
     void setup() {
         this.mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(new CustomExceptionHandler(new DefaultErrorAttributes()))
             .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
                 new UserArgumentResolver(userRemoteClient))
             .setValidator(mockValidator)
@@ -256,12 +259,25 @@ class ManagementEmployeeControllerTest {
 
         MvcResult result = mockMvc.perform(get(UBS_LINK + "/get-employees/{tariffId}", tariffId))
             .andExpect(status().isOk())
-            .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andReturn();
 
         String jsonResponse = result.getResponse().getContentAsString();
 
         assertTrue(jsonResponse.contains("\"firstName\":\"John\""));
+
+        verify(service, times(1)).getEmployeesByTariffId(tariffId);
+    }
+
+    @Test
+    void getEmployeesByTariffIdShouldReturn404WhenNotFound() throws Exception {
+        Long tariffId = 1L;
+        when(service.getEmployeesByTariffId(tariffId))
+            .thenThrow(new NotFoundException(
+                ErrorMessage.EMPLOYEE_WITH_ENABLED_CHAT_NOT_FOUND_BY_TARIFF_ID + tariffId));
+
+        mockMvc.perform(get(UBS_LINK + "/get-employees/{tariffId}", tariffId))
+            .andExpect(status().isNotFound());
 
         verify(service, times(1)).getEmployeesByTariffId(tariffId);
     }
@@ -276,7 +292,7 @@ class ManagementEmployeeControllerTest {
 
         mockMvc.perform(get(UBS_LINK + "/" + email))
             .andExpect(status().isOk())
-            .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_XML_VALUE + ";charset=UTF-8"))
+            .andExpect(content().contentType(MediaType.APPLICATION_XML_VALUE + ";charset=UTF-8"))
             .andReturn();
 
         verify(service, times(1)).getEmployeeByEmail(email);

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -41,6 +41,8 @@ public class ErrorMessage {
     public static final String FILE_NOT_SAVED = "File hasn't been saved";
     public static final String EMPLOYEE_NOT_FOUND = "Employee with current id doesn't exist: ";
     public static final String EMPLOYEE_WITH_UUID_NOT_FOUND = "Employee with current uuid doesn't exist: ";
+    public static final String EMPLOYEE_WITH_ENABLED_CHAT_NOT_FOUND_BY_TARIFF_ID =
+        "No employees with enabled chat found for tariff id: ";
     public static final String ACTIVE_EMPLOYEE_WITH_CURRENT_EMAIL_ALREADY_EXISTS =
         "Active employee with this email already exists: ";
     public static final String PHONE_NUMBER_PARSING_FAIL = "Phone number parsing fail: ";

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -164,8 +164,8 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
     private List<GetEmployeeDto> mapEmployeeFilterViewsToGetEmployeeDtos(List<EmployeeFilterView> employeeFilterViews) {
         List<Employee> employees = employeeRepository.findAll();
         Map<Long, GetEmployeeDto> getEmployeeDtoMap = new LinkedHashMap<>();
-        for (var employeeFilterView : employeeFilterViews) {
-            var getEmployeeDto = getEmployeeDtoMap.computeIfAbsent(employeeFilterView.getEmployeeId(),
+        for (EmployeeFilterView employeeFilterView : employeeFilterViews) {
+            GetEmployeeDto getEmployeeDto = getEmployeeDtoMap.computeIfAbsent(employeeFilterView.getEmployeeId(),
                 id -> modelMapper.map(employeeFilterView, GetEmployeeDto.class));
             getEmployeeDto.setTariffs(employees.stream()
                 .filter(employee -> employee.getId().equals(employeeFilterView.getEmployeeId()))
@@ -296,7 +296,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
     }
 
     private void updateEmployeeAuthoritiesToRelatedPositions(EmployeeWithTariffsIdDto dto) {
-        var positions = EmployeePositionsDto.builder()
+        EmployeePositionsDto positions = EmployeePositionsDto.builder()
             .email(dto.getEmployeeDto().getEmail())
             .positions(dto.getEmployeeDto().getEmployeePositions())
             .build();

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -446,6 +446,10 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
         List<Employee> employeeWithEnabledChat =
             employeeRepository.selectAllEmployeesByTariffIdAndChatEqualsTrue(tariffId);
 
+        if (employeeWithEnabledChat.isEmpty()) {
+            throw new NotFoundException("No employees found with enabled chat for tariff id: " + tariffId);
+        }
+
         return employeeWithEnabledChat
             .stream()
             .map(employee -> modelMapper.map(employee, EmployeeWithTariffsDto.class))

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -447,7 +447,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
             employeeRepository.selectAllEmployeesByTariffIdAndChatEqualsTrue(tariffId);
 
         if (employeeWithEnabledChat.isEmpty()) {
-            throw new NotFoundException("No employees found with enabled chat for tariff id: " + tariffId);
+            throw new NotFoundException(ErrorMessage.EMPLOYEE_WITH_ENABLED_CHAT_NOT_FOUND_BY_TARIFF_ID + tariffId);
         }
 
         return employeeWithEnabledChat

--- a/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
@@ -33,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import org.springframework.mock.web.MockMultipartFile;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -55,6 +56,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.anyLong;
@@ -329,7 +331,7 @@ class UBSManagementEmployeeServiceImplTest {
         assertEquals(EmployeeStatus.INACTIVE, employee.getEmployeeStatus());
         Exception thrown = assertThrows(NotFoundException.class,
             () -> employeeService.deactivateEmployee(2L));
-        assertEquals(thrown.getMessage(), ErrorMessage.EMPLOYEE_NOT_FOUND + 2L);
+        assertEquals(ErrorMessage.EMPLOYEE_NOT_FOUND + 2L, thrown.getMessage());
     }
 
     @Test
@@ -343,7 +345,7 @@ class UBSManagementEmployeeServiceImplTest {
         assertEquals(EmployeeStatus.ACTIVE, employee.getEmployeeStatus());
         Exception thrown = assertThrows(NotFoundException.class,
             () -> employeeService.deactivateEmployee(2L));
-        assertEquals(thrown.getMessage(), ErrorMessage.EMPLOYEE_NOT_FOUND + 2L);
+        assertEquals(ErrorMessage.EMPLOYEE_NOT_FOUND + 2L, thrown.getMessage());
     }
 
     @Test
@@ -498,7 +500,7 @@ class UBSManagementEmployeeServiceImplTest {
 
         Exception thrown1 = assertThrows(NotFoundException.class,
             () -> employeeService.deleteEmployeeImage(2L));
-        assertEquals(thrown1.getMessage(), ErrorMessage.EMPLOYEE_NOT_FOUND + 2L);
+        assertEquals(ErrorMessage.EMPLOYEE_NOT_FOUND + 2L, thrown1.getMessage());
 
         when(repository.findById(1L)).thenReturn(Optional.of(employee));
 
@@ -538,6 +540,20 @@ class UBSManagementEmployeeServiceImplTest {
 
         verify(repository, times(1)).selectAllEmployeesByTariffIdAndChatEqualsTrue(tariffId);
         verify(modelMapper, times(1)).map(employee, EmployeeWithTariffsDto.class);
+    }
+
+    @Test
+    void getEmployeesByTariffIdShouldThrowNotFoundExceptionTest() {
+        Long tariffId = 1L;
+        when(repository.selectAllEmployeesByTariffIdAndChatEqualsTrue(tariffId)).thenReturn(Collections.emptyList());
+
+        NotFoundException thrown =
+            assertThrows(NotFoundException.class, () -> employeeService.getEmployeesByTariffId(tariffId));
+
+        assertEquals(ErrorMessage.EMPLOYEE_WITH_ENABLED_CHAT_NOT_FOUND_BY_TARIFF_ID + tariffId, thrown.getMessage());
+
+        verify(repository, times(1)).selectAllEmployeesByTariffIdAndChatEqualsTrue(tariffId);
+        verify(modelMapper, never()).map(any(Employee.class), eq(EmployeeWithTariffsDto.class));
     }
 
     @Test


### PR DESCRIPTION
### 🔗 **Issue:** [#8895](https://github.com/ita-social-projects/GreenCity/issues/8895)

This pull request introduces enhancements to error handling, code readability, and test coverage in the `ManagementEmployeeControllerTest` and `UBSManagementEmployeeServiceImpl` classes, along with updates to error messages. The key changes include adding a new error message for missing employees with enabled chat by tariff ID, refactoring code for clarity, and improving test cases to cover edge scenarios.

### Enhancements to error handling:
* Added a new error message constant `EMPLOYEE_WITH_ENABLED_CHAT_NOT_FOUND_BY_TARIFF_ID` in `ErrorMessage` to handle cases where no employees with enabled chat are found for a given tariff ID. (`service-api/src/main/java/greencity/constant/ErrorMessage.java`, [service-api/src/main/java/greencity/constant/ErrorMessage.javaR44-R45](diffhunk://#diff-17ce78c012168463131f18e2bc5c39bacda9d4878bec3bcc3ebdac9858635d17R44-R45))
* Updated the `getEmployeesByTariffId` method in `UBSManagementEmployeeServiceImpl` to throw a `NotFoundException` with the new error message when no employees are found. (`service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java`, [service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.javaR449-R452](diffhunk://#diff-ba45b437214cdd04d4f6b436df24fd7a681db99a3faaade2bd661f7d4e338d30R449-R452))

### Improvements to test coverage:
* Added a new test case `getEmployeesByTariffIdShouldReturn404WhenNotFound` in `ManagementEmployeeControllerTest` to verify that a 404 status is returned when no employees are found for a tariff ID. (`core/src/test/java/greencity/controller/ManagementEmployeeControllerTest.java`, [core/src/test/java/greencity/controller/ManagementEmployeeControllerTest.javaR272-R284](diffhunk://#diff-43db3d85581377e59965e0ca8547c24909074ea1acd42a846315729bcdb03369R272-R284))
* Added a new test case `getEmployeesByTariffIdShouldThrowNotFoundExceptionTest` in `UBSManagementEmployeeServiceImplTest` to ensure the `NotFoundException` is thrown correctly when no employees are found. (`service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java`, [service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.javaR545-R558](diffhunk://#diff-2646a244f1af9b82021fd2d39e6c8504cf8684b2f9515a779bf92d33c6766019R545-R558))

### Code readability improvements:
* Refactored variable declarations in `UBSManagementEmployeeServiceImpl` to use explicit types for better clarity. (`service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java`, [[1]](diffhunk://#diff-ba45b437214cdd04d4f6b436df24fd7a681db99a3faaade2bd661f7d4e338d30L167-R168) [[2]](diffhunk://#diff-ba45b437214cdd04d4f6b436df24fd7a681db99a3faaade2bd661f7d4e338d30L299-R299)
* Simplified assertions in multiple test cases by reordering parameters for better readability. (`service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java`, [[1]](diffhunk://#diff-2646a244f1af9b82021fd2d39e6c8504cf8684b2f9515a779bf92d33c6766019L332-R334) [[2]](diffhunk://#diff-2646a244f1af9b82021fd2d39e6c8504cf8684b2f9515a779bf92d33c6766019L346-R348) [[3]](diffhunk://#diff-2646a244f1af9b82021fd2d39e6c8504cf8684b2f9515a779bf92d33c6766019L501-R503)

### Controller test updates:
* Added `CustomExceptionHandler` and `DefaultErrorAttributes` to the `ManagementEmployeeControllerTest` setup for consistent error handling in tests. (`core/src/test/java/greencity/controller/ManagementEmployeeControllerTest.java`, [core/src/test/java/greencity/controller/ManagementEmployeeControllerTest.javaL76-R90](diffhunk://#diff-43db3d85581377e59965e0ca8547c24909074ea1acd42a846315729bcdb03369L76-R90))
* Replaced `MockMvcResultMatchers.content()` with `content()` for consistency across test cases. (`core/src/test/java/greencity/controller/ManagementEmployeeControllerTest.java`, [[1]](diffhunk://#diff-43db3d85581377e59965e0ca8547c24909074ea1acd42a846315729bcdb03369L259-R262) [[2]](diffhunk://#diff-43db3d85581377e59965e0ca8547c24909074ea1acd42a846315729bcdb03369L279-R295)

✅ **This pull request closes** [#8895](https://github.com/ita-social-projects/GreenCity/issues/8895) **once merged.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer error messaging when no employees with enabled chat are found for a given tariff ID.
  * The system now returns a 404 Not Found status if no employees with enabled chat exist for the specified tariff ID.

* **Bug Fixes**
  * Improved error handling and response consistency for employee search by tariff ID.

* **Tests**
  * Added tests to verify correct 404 responses and error messages when no employees are found.
  * Enhanced test coverage for service and controller error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->