### PR TITLE
Bugfix #8901 - Fixed notifications not being returned

### DIFF
--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -965,9 +965,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     private NotificationShortDto createNotificationShortDto(UserNotification notification, String language,
         Long monthsOfAccountInactivity) {
-        NotificationTemplate template = templateRepository.findNotificationTemplateByIdAndNotificationReceiverType(
-            notification.getTemplateId(), SITE)
-            .orElseThrow(() -> new NotFoundException("Template not found"));
+        NotificationTemplate template = getNotificationTemplate(notification, SITE, templateRepository);
 
         String templateBody = resolveTemplateBody(language, SITE, template);
         if (notification.getParameters() == null) {

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -965,9 +965,8 @@ public class NotificationServiceImpl implements NotificationService {
 
     private NotificationShortDto createNotificationShortDto(UserNotification notification, String language,
         Long monthsOfAccountInactivity) {
-        NotificationTemplate template = templateRepository
-            .findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
-                notification.getNotificationType(), SITE)
+        NotificationTemplate template = templateRepository.findNotificationTemplateByIdAndNotificationReceiverType(
+            notification.getTemplateId(), SITE)
             .orElseThrow(() -> new NotFoundException("Template not found"));
 
         String templateBody = resolveTemplateBody(language, SITE, template);

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2772,6 +2772,7 @@ public class ModelUtils {
             .id(1L)
             .build());
         notification.setNotificationType(UNPAID_ORDER);
+        notification.setTemplateId(1L);
         return List.of(
             notification);
     }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -2772,7 +2772,6 @@ public class ModelUtils {
             .id(1L)
             .build());
         notification.setNotificationType(UNPAID_ORDER);
-        notification.setTemplateId(1L);
         return List.of(
             notification);
     }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -249,6 +249,7 @@ public class ModelUtils {
     public static final UserNotification TEST_USER_NOTIFICATION_7 = createUserNotificationForViolation7();
     public static final Violation TEST_VIOLATION = createTestViolation();
     public static final NotificationTemplate TEST_NOTIFICATION_TEMPLATE = createNotificationTemplate();
+    public static final NotificationTemplate TEST_NOTIFICATION_TEMPLATE_2 = createCustomNotificationTemplate();
     public static final NotificationTemplateDto TEST_NOTIFICATION_TEMPLATE_DTO = createNotificationTemplateDto();
 
     public static final NotificationTemplateWithPlatformsUpdateDto TEST_NOTIFICATION_TEMPLATE_UPDATE_DTO =
@@ -279,8 +280,11 @@ public class ModelUtils {
         Collections.singletonList(TEST_MAP_ADDITIONAL_BAG);
     public static final NotificationDto TEST_NOTIFICATION_DTO = createNotificationDto();
     public static final List<NotificationFullDto> TEST_NOTIFICATION_DTO_LIST = List.of(createNotificationFullDto());
+    public static final List<NotificationFullDto> TEST_NOTIFICATION_DTO_LIST_2 = createCustomNotificationsFullDtoList();
     public static final PageableAdvancedDto<NotificationFullDto> TEST_NOTIFICATION_FULL_DTO_PAGEABLE =
         createPageableAdvancedDtoForNotificationFullDto();
+    public static final PageableAdvancedDto<NotificationFullDto> TEST_NOTIFICATION_FULL_DTO_PAGEABLE_2 =
+        createPageableAdvancedDtoForCustomNotificationsFullDto();
     public static final UpdateOrderPageAdminDto UPDATE_ORDER_PAGE_ADMIN_DTO = updateOrderPageAdminDto();
     public static final CourierUpdateDto UPDATE_COURIER_DTO = getUpdateCourierDto();
     public static final List<Bag> TEST_BAG_LIST2 = Arrays.asList(createBag(1), createBag(2), createBag(3));
@@ -5945,5 +5949,46 @@ public class ModelUtils {
             .authorName("Автор 3")
             .id(1L)
             .build();
+    }
+
+    private static NotificationTemplate createCustomNotificationTemplate() {
+        NotificationTemplate notificationTemplate = getCustomNotificationTemplate();
+        notificationTemplate.getNotificationPlatforms().add(createNotificationPlatform(SITE));
+        notificationTemplate.setTitleEn("Title");
+        notificationTemplate.setTitleUk("TitleUk");
+
+        return notificationTemplate;
+    }
+
+    private static List<NotificationFullDto> createCustomNotificationsFullDtoList() {
+        return List.of(
+            NotificationFullDto.builder()
+                .id(1L)
+                .read(false)
+                .title("Title")
+                .body("BodyEng")
+                .images(List.of())
+
+                .build(),
+            NotificationFullDto.builder()
+                .id(2L)
+                .read(false)
+                .title("Title")
+                .body("BodyEng")
+                .images(List.of())
+                .build());
+    }
+
+    private static PageableAdvancedDto<NotificationFullDto> createPageableAdvancedDtoForCustomNotificationsFullDto() {
+        return new PageableAdvancedDto<>(
+            TEST_NOTIFICATION_DTO_LIST_2,
+            2L,
+            0,
+            1,
+            0,
+            false,
+            false,
+            true,
+            true);
     }
 }

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -73,12 +73,14 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import static greencity.ModelUtils.TEST_NOTIFICATION_FULL_DTO_PAGEABLE;
+import static greencity.ModelUtils.TEST_NOTIFICATION_FULL_DTO_PAGEABLE_2;
 import static greencity.ModelUtils.TEST_UUID;
 import static greencity.ModelUtils.TEST_PAGEABLE_ADVANCED_DTO;
 import static greencity.ModelUtils.TEST_NOTIFICATION_DTO;
 import static greencity.ModelUtils.TEST_NOTIFICATION_PARAMETER_SET;
 import static greencity.ModelUtils.TEST_NOTIFICATION_PARAMETER_SET2;
 import static greencity.ModelUtils.TEST_NOTIFICATION_TEMPLATE;
+import static greencity.ModelUtils.TEST_NOTIFICATION_TEMPLATE_2;
 import static greencity.ModelUtils.TEST_ORDER_2;
 import static greencity.ModelUtils.TEST_ORDER_3;
 import static greencity.ModelUtils.TEST_ORDER_4;
@@ -1630,5 +1632,42 @@ class NotificationServiceImplTest {
         notificationService.notifyManagerWithNewGreenOfficeRequestFromTelegramBot(USER_EMAIL, USERNAME);
 
         verify(userRemoteClient, times(1)).sendGreenOfficeRequestNotification(notification);
+    }
+
+    @Test
+    void testGetAllNotificationsForUserForCustomNotifications() {
+        User user = TEST_USER;
+        String language = "en";
+        UserNotification customNotification1 = UserNotification.builder()
+            .id(1L)
+            .user(user)
+            .notificationType(NotificationType.CUSTOM)
+            .templateId(1L)
+            .build();
+        UserNotification customNotification2 = UserNotification.builder()
+            .id(2L)
+            .user(user)
+            .notificationType(NotificationType.CUSTOM)
+            .templateId(1L)
+            .build();
+
+        Page<UserNotification> page = new PageImpl<>(List.of(customNotification1, customNotification2),
+            Mockito.mock(Pageable.class),
+            2L);
+
+        when(userRepository.findByUuid(user.getUuid())).thenReturn(user);
+
+        when(templateRepository.findNotificationTemplateByIdAndNotificationReceiverType(1L, SITE))
+            .thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE_2));
+
+        when(userNotificationRepository.findAllByUserAndIsDeletedFalse(user, TEST_PAGEABLE)).thenReturn(page);
+
+        when(userNotificationRepository.findById(1L)).thenReturn(Optional.of(customNotification1));
+        when(userNotificationRepository.findById(2L)).thenReturn(Optional.of(customNotification2));
+
+        PageableAdvancedDto<NotificationFullDto> actual =
+            notificationService.getAllNotificationsForUser(user.getUuid(), language, TEST_PAGEABLE);
+
+        assertEquals(TEST_NOTIFICATION_FULL_DTO_PAGEABLE_2, actual);
     }
 }

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -988,8 +988,8 @@ class NotificationServiceImplTest {
         when(userRepository.findByUuid(uuid)).thenReturn(TEST_USER);
         when(userNotificationRepository.findAllByUserAndIsDeletedFalse(TEST_USER, TEST_PAGEABLE))
             .thenReturn(TEST_PAGE);
-        when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
-            NotificationType.UNPAID_ORDER,
+        when(templateRepository.findNotificationTemplateByIdAndNotificationReceiverType(
+            1L,
             SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
 
         PageableAdvancedDto<NotificationShortDto> actual = notificationService
@@ -1035,6 +1035,9 @@ class NotificationServiceImplTest {
         when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
             notificationType,
             SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
+        when(templateRepository.findNotificationTemplateByIdAndNotificationReceiverType(
+            0L,
+            SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
         when(userNotification.getParameters())
             .thenReturn(notificationParameters);
         when(userNotification.getOrder())
@@ -1073,10 +1076,8 @@ class NotificationServiceImplTest {
             .thenReturn(page);
         when(userNotificationRepository.findById(notificationId))
             .thenReturn(Optional.of(userNotification));
-        when(userNotification.getNotificationType())
-            .thenReturn(notificationType);
-        when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
-            notificationType,
+        when(templateRepository.findNotificationTemplateByIdAndNotificationReceiverType(
+            0L,
             SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
         when(userNotification.getUser())
             .thenReturn(anotherUser);
@@ -1109,15 +1110,6 @@ class NotificationServiceImplTest {
             .thenReturn(user);
         when(userNotificationRepository.findAllByUserAndIsDeletedFalse(user, TEST_PAGEABLE))
             .thenReturn(page);
-        when(userNotification.getNotificationType())
-            .thenReturn(notificationType);
-        when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
-            notificationType,
-            SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
-        when(userNotification.getId())
-            .thenReturn(notificationId);
-        when(userNotificationRepository.findById(notificationId))
-            .thenReturn(notFoundNotification);
 
         assertThrows(
             NotFoundException.class,

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -988,8 +988,8 @@ class NotificationServiceImplTest {
         when(userRepository.findByUuid(uuid)).thenReturn(TEST_USER);
         when(userNotificationRepository.findAllByUserAndIsDeletedFalse(TEST_USER, TEST_PAGEABLE))
             .thenReturn(TEST_PAGE);
-        when(templateRepository.findNotificationTemplateByIdAndNotificationReceiverType(
-            1L,
+        when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
+            NotificationType.UNPAID_ORDER,
             SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
 
         PageableAdvancedDto<NotificationShortDto> actual = notificationService
@@ -1035,9 +1035,6 @@ class NotificationServiceImplTest {
         when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
             notificationType,
             SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
-        when(templateRepository.findNotificationTemplateByIdAndNotificationReceiverType(
-            0L,
-            SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
         when(userNotification.getParameters())
             .thenReturn(notificationParameters);
         when(userNotification.getOrder())
@@ -1076,8 +1073,10 @@ class NotificationServiceImplTest {
             .thenReturn(page);
         when(userNotificationRepository.findById(notificationId))
             .thenReturn(Optional.of(userNotification));
-        when(templateRepository.findNotificationTemplateByIdAndNotificationReceiverType(
-            0L,
+        when(userNotification.getNotificationType())
+            .thenReturn(notificationType);
+        when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
+            notificationType,
             SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
         when(userNotification.getUser())
             .thenReturn(anotherUser);
@@ -1110,6 +1109,15 @@ class NotificationServiceImplTest {
             .thenReturn(user);
         when(userNotificationRepository.findAllByUserAndIsDeletedFalse(user, TEST_PAGEABLE))
             .thenReturn(page);
+        when(userNotification.getNotificationType())
+            .thenReturn(notificationType);
+        when(templateRepository.findNotificationTemplateByNotificationTypeAndNotificationReceiverType(
+            notificationType,
+            SITE)).thenReturn(Optional.of(TEST_NOTIFICATION_TEMPLATE));
+        when(userNotification.getId())
+            .thenReturn(notificationId);
+        when(userNotificationRepository.findById(notificationId))
+            .thenReturn(notFoundNotification);
 
         assertThrows(
             NotFoundException.class,


### PR DESCRIPTION
# GreenCityUBS PR
:clipboard:[#8901](https://github.com/ita-social-projects/GreenCity/issues/8901)

## Summary Of Changes :fire:
Fixed notifications not being returned by correcting logic of `NotificationTemplate` retrieval, which would fail for `CUSTOM` notification template.
## Changed
* `NotificationServiceImpl` : Fixed `NotificationTemplate` retrieval logic by switching to existing logic provided by `getNotificationTemplate` method. 
* `NotificationServiceImplTest` : Added test that checks the correctness of `NotificationTemplate` retrieval for `CUSTOM` notification template.
* `ModelUtils` : Extended test utility.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification template retrieval by matching templates using template ID and receiver type for custom notifications.

* **Tests**
  * Added new test data and test cases to verify handling of custom notifications with specific templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->