### PR TITLE
Properly adjust RetrieveMessageErrorDecoder to parse response error m…

### DIFF
--- a/core/src/main/java/greencity/exception/handler/RetrieveMessageErrorDecoder.java
+++ b/core/src/main/java/greencity/exception/handler/RetrieveMessageErrorDecoder.java
@@ -1,5 +1,6 @@
 package greencity.exception.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Response;
 import feign.codec.ErrorDecoder;
 import greencity.exceptions.BadRequestException;
@@ -14,22 +15,32 @@ import java.nio.charset.StandardCharsets;
 
 @Component
 public class RetrieveMessageErrorDecoder implements ErrorDecoder {
+    private final ObjectMapper objectMapper;
+
+    public RetrieveMessageErrorDecoder() {
+        this.objectMapper = new ObjectMapper();
+    }
+
     @Override
     public Exception decode(String methodKey, Response response) {
-        ExceptionResponse exception;
         try (InputStream body = response.body().asInputStream()) {
-            exception = ExceptionResponse
-                .builder()
-                .message(IOUtils.toString(body, StandardCharsets.UTF_8)).build();
+            ExceptionResponse exception;
+            String bodyString = IOUtils.toString(body, StandardCharsets.UTF_8);
+
+            try {
+                exception = objectMapper.readValue(bodyString, ExceptionResponse.class);
+            } catch (Exception e) {
+                exception = ExceptionResponse.builder().message(bodyString).build();
+            }
+
+            return switch (response.status()) {
+                case 400 -> new BadRequestException(exception.getMessage());
+                case 403 -> new AccessDeniedException(exception.getMessage());
+                case 404 -> new NotFoundException(exception.getMessage());
+                default -> new RemoteServerUnavailableException(exception.getMessage());
+            };
         } catch (IOException e) {
             return new Exception(e.getMessage());
         }
-
-        return switch (response.status()) {
-            case 400 -> new BadRequestException(exception.getMessage());
-            case 403 -> new AccessDeniedException(exception.getMessage());
-            case 404 -> new NotFoundException(exception.getMessage());
-            default -> new RemoteServerUnavailableException(exception.getMessage());
-        };
     }
 }

--- a/core/src/main/java/greencity/exception/handler/RetrieveMessageErrorDecoder.java
+++ b/core/src/main/java/greencity/exception/handler/RetrieveMessageErrorDecoder.java
@@ -24,14 +24,8 @@ public class RetrieveMessageErrorDecoder implements ErrorDecoder {
     @Override
     public Exception decode(String methodKey, Response response) {
         try (InputStream body = response.body().asInputStream()) {
-            ExceptionResponse exception;
             String bodyString = IOUtils.toString(body, StandardCharsets.UTF_8);
-
-            try {
-                exception = objectMapper.readValue(bodyString, ExceptionResponse.class);
-            } catch (Exception e) {
-                exception = ExceptionResponse.builder().message(bodyString).build();
-            }
+            ExceptionResponse exception = getExceptionResponse(bodyString);
 
             return switch (response.status()) {
                 case 400 -> new BadRequestException(exception.getMessage());
@@ -42,5 +36,15 @@ public class RetrieveMessageErrorDecoder implements ErrorDecoder {
         } catch (IOException e) {
             return new Exception(e.getMessage());
         }
+    }
+
+    private ExceptionResponse getExceptionResponse(String bodyString) {
+        ExceptionResponse exception;
+        try {
+            exception = objectMapper.readValue(bodyString, ExceptionResponse.class);
+        } catch (Exception e) {
+            exception = ExceptionResponse.builder().message(bodyString).build();
+        }
+        return exception;
     }
 }

--- a/core/src/test/java/greencity/exception/handler/RetrieveMessageErrorDecoderTest.java
+++ b/core/src/test/java/greencity/exception/handler/RetrieveMessageErrorDecoderTest.java
@@ -13,18 +13,26 @@ import feign.Response;
 import greencity.exceptions.BadRequestException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 class RetrieveMessageErrorDecoderTest {
     private final RetrieveMessageErrorDecoder decoder = new RetrieveMessageErrorDecoder();
     private final Response mockResponse = mock(Response.class);
     private final Response.Body mockBody = mock(Response.Body.class);
 
+    private String wrapJsonMessage(String message) throws IOException {
+        return new ObjectMapper().writeValueAsString(new ExceptionResponse(message, null, null, null));
+    }
+
     @Test
     void decodeThrowsBadRequestExceptionTest() throws IOException {
         String errorMessage = "This is a bad request";
+        String jsonBody = wrapJsonMessage(errorMessage);
+
         when(mockResponse.status()).thenReturn(400);
         when(mockResponse.body()).thenReturn(mockBody);
-        when(mockBody.asInputStream()).thenReturn(IOUtils.toInputStream(errorMessage, StandardCharsets.UTF_8));
+        when(mockBody.asInputStream()).thenReturn(IOUtils.toInputStream(jsonBody, StandardCharsets.UTF_8));
+
         Exception exception = decoder.decode("methodKey", mockResponse);
         assertEquals(BadRequestException.class, exception.getClass());
         assertEquals(errorMessage, exception.getMessage());
@@ -36,10 +44,13 @@ class RetrieveMessageErrorDecoderTest {
 
     @Test
     void decodeThrowsAccessDeniedExceptionTest() throws IOException {
-        String errorMessage = "This is an access denied";
+        String errorMessage = "Access denied";
+        String jsonBody = wrapJsonMessage(errorMessage);
+
         when(mockResponse.status()).thenReturn(403);
         when(mockResponse.body()).thenReturn(mockBody);
-        when(mockBody.asInputStream()).thenReturn(IOUtils.toInputStream(errorMessage, StandardCharsets.UTF_8));
+        when(mockBody.asInputStream()).thenReturn(IOUtils.toInputStream(jsonBody, StandardCharsets.UTF_8));
+
         Exception exception = decoder.decode("methodKey", mockResponse);
         assertEquals(AccessDeniedException.class, exception.getClass());
         assertEquals(errorMessage, exception.getMessage());
@@ -51,10 +62,13 @@ class RetrieveMessageErrorDecoderTest {
 
     @Test
     void decodeThrowsNotFoundExceptionTest() throws IOException {
-        String errorMessage = "This is a not found";
+        String errorMessage = "Not found";
+        String jsonBody = wrapJsonMessage(errorMessage);
+
         when(mockResponse.status()).thenReturn(404);
         when(mockResponse.body()).thenReturn(mockBody);
-        when(mockBody.asInputStream()).thenReturn(IOUtils.toInputStream(errorMessage, StandardCharsets.UTF_8));
+        when(mockBody.asInputStream()).thenReturn(IOUtils.toInputStream(jsonBody, StandardCharsets.UTF_8));
+
         Exception exception = decoder.decode("methodKey", mockResponse);
         assertEquals(NotFoundException.class, exception.getClass());
         assertEquals(errorMessage, exception.getMessage());
@@ -77,13 +91,54 @@ class RetrieveMessageErrorDecoderTest {
 
     @Test
     void decodeThrowsRemoteServerUnavailableExceptionTest() throws IOException {
-        String errorMessage = "An error occurred";
+        String errorMessage = "Remote error";
+        String jsonBody = wrapJsonMessage(errorMessage);
+
+        when(mockResponse.status()).thenReturn(500);
         when(mockResponse.body()).thenReturn(mockBody);
-        when(mockBody.asInputStream()).thenReturn(IOUtils.toInputStream(errorMessage, StandardCharsets.UTF_8));
+        when(mockBody.asInputStream()).thenReturn(IOUtils.toInputStream(jsonBody, StandardCharsets.UTF_8));
+
         Exception exception = decoder.decode("methodKey", mockResponse);
         assertEquals(RemoteServerUnavailableException.class, exception.getClass());
         assertEquals(errorMessage, exception.getMessage());
 
+        verify(mockResponse).status();
+        verify(mockResponse).body();
+        verify(mockBody).asInputStream();
+    }
+
+    @Test
+    void decodeWithPlainExceptionFallsBackToRawMessage() throws IOException {
+        String rawMessage = "Plain raw exception";
+
+        when(mockResponse.status()).thenReturn(400);
+        when(mockResponse.body()).thenReturn(mockBody);
+        when(mockBody.asInputStream()).thenReturn(IOUtils.toInputStream(rawMessage, StandardCharsets.UTF_8));
+
+        Exception exception = decoder.decode("methodKey", mockResponse);
+        assertEquals(BadRequestException.class, exception.getClass());
+        assertEquals(rawMessage, exception.getMessage());
+
+        verify(mockResponse).status();
+        verify(mockResponse).body();
+        verify(mockBody).asInputStream();
+    }
+
+    @Test
+    void decodeWithUnknownStatusReturnsRemoteServerUnavailableException() throws IOException {
+        String errorMessage = "I'm a teapot";
+        String jsonBody = wrapJsonMessage(errorMessage);
+
+        when(mockResponse.status()).thenReturn(418);
+        when(mockResponse.body()).thenReturn(mockBody);
+        when(mockBody.asInputStream()).thenReturn(IOUtils.toInputStream(jsonBody, StandardCharsets.UTF_8));
+
+        Exception exception = decoder.decode("methodKey", mockResponse);
+
+        assertEquals(RemoteServerUnavailableException.class, exception.getClass());
+        assertEquals(errorMessage, exception.getMessage());
+
+        verify(mockResponse).status();
         verify(mockResponse).body();
         verify(mockBody).asInputStream();
     }


### PR DESCRIPTION
### 🔗 **Issue:** [#8880](https://github.com/ita-social-projects/GreenCity/issues/8880)

This pull request improves error decoding in the `RetrieveMessageErrorDecoder` class by introducing JSON parsing for structured error messages and enhances test coverage to validate the new functionality. The most important changes include the addition of an `ObjectMapper` for JSON deserialization, updates to the decoding logic, and expanded test cases for various scenarios.

### Updates to `RetrieveMessageErrorDecoder`:

* Added `ObjectMapper` to deserialize JSON error messages into `ExceptionResponse` objects, falling back to raw message strings if deserialization fails. (`core/src/main/java/greencity/exception/handler/RetrieveMessageErrorDecoder.java`, [[1]](diffhunk://#diff-e722c42b39e521e06003fe4490933d64f82b373e7302ea5e431e585fc2c0ea65R3) [[2]](diffhunk://#diff-e722c42b39e521e06003fe4490933d64f82b373e7302ea5e431e585fc2c0ea65R18-R33)
* Updated `decode` method to handle `IOException` separately and ensure proper exception handling for different HTTP statuses. (`core/src/main/java/greencity/exception/handler/RetrieveMessageErrorDecoder.java`, [core/src/main/java/greencity/exception/handler/RetrieveMessageErrorDecoder.javaR42-R44](diffhunk://#diff-e722c42b39e521e06003fe4490933d64f82b373e7302ea5e431e585fc2c0ea65R42-R44))

### Enhancements to test coverage:

* Introduced a helper method, `wrapJsonMessage`, in the test class to generate JSON-formatted error messages for testing. (`core/src/test/java/greencity/exception/handler/RetrieveMessageErrorDecoderTest.java`, [core/src/test/java/greencity/exception/handler/RetrieveMessageErrorDecoderTest.javaR16-R35](diffhunk://#diff-e037f42554cc3758d01daa498eccec96cbcf5948627093692c389a3c325796e9R16-R35))
* Refactored existing tests to use JSON bodies instead of plain text, ensuring compatibility with the new decoding logic. (`core/src/test/java/greencity/exception/handler/RetrieveMessageErrorDecoderTest.java`, [[1]](diffhunk://#diff-e037f42554cc3758d01daa498eccec96cbcf5948627093692c389a3c325796e9L39-R53) [[2]](diffhunk://#diff-e037f42554cc3758d01daa498eccec96cbcf5948627093692c389a3c325796e9L54-R71)
* Added new test cases to validate fallback behavior for plain text error messages, handling of unknown HTTP statuses, and proper exception type mapping for different scenarios. (`core/src/test/java/greencity/exception/handler/RetrieveMessageErrorDecoderTest.java`, [core/src/test/java/greencity/exception/handler/RetrieveMessageErrorDecoderTest.javaL80-R141](diffhunk://#diff-e037f42554cc3758d01daa498eccec96cbcf5948627093692c389a3c325796e9L80-R141))

✅ **This pull request closes** [#8880](https://github.com/ita-social-projects/GreenCity/issues/8880) **once merged.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for server responses, ensuring error messages are correctly displayed even if the response is not in the expected format.

* **Tests**
  * Enhanced error decoding tests to cover both JSON and plain text error responses, ensuring more reliable handling of various server error formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->