### PR TITLE
8929 violation the edited violation in the order cannot be saved

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -140,7 +140,7 @@ public class ManagementOrderController {
     @ResponseStatus(value = HttpStatus.CREATED)
     @PreAuthorize("@preAuthorizer.hasAuthority('CREATE_NEW_CERTIFICATE', authentication)")
     @PostMapping("/addCertificate")
-    public ResponseEntity<HttpStatus> addCertificate(
+    public ResponseEntity<Void> addCertificate(
         @Valid @RequestBody CertificateDtoForAdding certificateDtoForAdding) {
         certificateService.addCertificate(certificateDtoForAdding);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -163,7 +163,7 @@ public class ManagementOrderController {
     })
     @PreAuthorize("@preAuthorizer.hasAuthority('EDIT_CERTIFICATE', authentication)")
     @DeleteMapping("/deleteCertificate/{responseCode}")
-    public ResponseEntity<HttpStatus> deleteCertificate(
+    public ResponseEntity<Void> deleteCertificate(
         @PathVariable String responseCode) {
         certificateService.deleteCertificate(responseCode);
         return ResponseEntity.status(HttpStatus.OK).build();
@@ -245,7 +245,7 @@ public class ManagementOrderController {
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content)
     })
     @PatchMapping(value = "/addPointsToUser")
-    public ResponseEntity<HttpStatus> addPointsToUser(
+    public ResponseEntity<Void> addPointsToUser(
         @Valid @RequestBody AddingPointsToUserDto addingPointsToUserDto) {
         ubsManagementService.addPointsToUser(addingPointsToUserDto);
         return ResponseEntity.status(HttpStatus.OK).build();
@@ -301,7 +301,7 @@ public class ManagementOrderController {
     })
     @PostMapping(value = "/addViolationToUser",
         consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
-    public ResponseEntity<HttpStatus> addUsersViolation(@Valid @RequestPart AddingViolationsToUserDto add,
+    public ResponseEntity<Void> addUsersViolation(@Valid @RequestPart AddingViolationsToUserDto add,
         @RequestPart(required = false) @Nullable @ValidImage MultipartFile[] files,
         Principal principal) {
         violationService.addUserViolation(add, files, principal.getName());
@@ -700,7 +700,7 @@ public class ManagementOrderController {
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })
     @DeleteMapping("/delete-violation-from-order/{orderId}")
-    public ResponseEntity<HttpStatus> deleteViolationFromOrder(@Positive @PathVariable Long orderId,
+    public ResponseEntity<Void> deleteViolationFromOrder(@Positive @PathVariable Long orderId,
         @Parameter(hidden = true) @CurrentUserUuid String uuid) {
         violationService.deleteViolation(orderId, uuid);
         return ResponseEntity.status(HttpStatus.OK).build();
@@ -750,7 +750,7 @@ public class ManagementOrderController {
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })
     @DeleteMapping("/delete-manual-payment/{id}")
-    public ResponseEntity<ResponseStatus> deleteManualPayment(@Positive @PathVariable(name = "id") Long paymentId,
+    public ResponseEntity<Void> deleteManualPayment(@Positive @PathVariable(name = "id") Long paymentId,
         @Parameter(hidden = true) @CurrentUserUuid String uuid) {
         paymentService.deleteManualPayment(paymentId, uuid);
         return ResponseEntity.status(HttpStatus.OK).build();
@@ -824,7 +824,7 @@ public class ManagementOrderController {
     })
     @ApiLocale
     @PutMapping(value = "/updateViolationToUser", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<HttpStatus> updateUsersViolation(@Valid @RequestPart UpdateViolationToUserDto add,
+    public ResponseEntity<Void> updateUsersViolation(@Valid @RequestPart UpdateViolationToUserDto add,
         @Nullable @RequestPart(required = false) @ValidImage MultipartFile[] multipartFiles,
         @Parameter(hidden = true) @CurrentUserUuid String uuid) {
         violationService.updateUserViolation(add, multipartFiles, uuid);
@@ -847,7 +847,7 @@ public class ManagementOrderController {
         @ApiResponse(responseCode = "422", description = HttpStatuses.UNPROCESSABLE_ENTITY, content = @Content)
     })
     @PutMapping("/update-eco-store/{id}")
-    public ResponseEntity<HttpStatus> updateEcoStoreIdToOrder(
+    public ResponseEntity<Void> updateEcoStoreIdToOrder(
         @RequestBody @Valid EcoNumberDto ecoNumberDto, @Positive @PathVariable(name = "id") Long orderId,
         Principal principal) {
         ubsManagementService.updateEcoNumberForOrderById(ecoNumberDto, orderId, principal.getName());
@@ -908,7 +908,7 @@ public class ManagementOrderController {
         @ApiResponse(responseCode = "422", description = HttpStatuses.UNPROCESSABLE_ENTITY, content = @Content)
     })
     @PutMapping("/all-order-page-admin-info")
-    public ResponseEntity<HttpStatus> updateAllOrderPageAdminInfo(
+    public ResponseEntity<Void> updateAllOrderPageAdminInfo(
         @RequestBody @Valid UpdateAllOrderPageDto updateAllOrderPageDto, Principal principal,
         @RequestParam String lang) {
         ubsManagementService.updateAllOrderAdminPageInfo(updateAllOrderPageDto, principal.getName(), lang);

--- a/core/src/main/java/greencity/controller/ManagementOrderController.java
+++ b/core/src/main/java/greencity/controller/ManagementOrderController.java
@@ -143,7 +143,7 @@ public class ManagementOrderController {
     public ResponseEntity<HttpStatus> addCertificate(
         @Valid @RequestBody CertificateDtoForAdding certificateDtoForAdding) {
         certificateService.addCertificate(certificateDtoForAdding);
-        return new ResponseEntity<>(HttpStatus.CREATED);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     /**
@@ -166,7 +166,7 @@ public class ManagementOrderController {
     public ResponseEntity<HttpStatus> deleteCertificate(
         @PathVariable String responseCode) {
         certificateService.deleteCertificate(responseCode);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     /**
@@ -248,7 +248,7 @@ public class ManagementOrderController {
     public ResponseEntity<HttpStatus> addPointsToUser(
         @Valid @RequestBody AddingPointsToUserDto addingPointsToUserDto) {
         ubsManagementService.addPointsToUser(addingPointsToUserDto);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     /**
@@ -703,7 +703,7 @@ public class ManagementOrderController {
     public ResponseEntity<HttpStatus> deleteViolationFromOrder(@Positive @PathVariable Long orderId,
         @Parameter(hidden = true) @CurrentUserUuid String uuid) {
         violationService.deleteViolation(orderId, uuid);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     /**
@@ -753,7 +753,7 @@ public class ManagementOrderController {
     public ResponseEntity<ResponseStatus> deleteManualPayment(@Positive @PathVariable(name = "id") Long paymentId,
         @Parameter(hidden = true) @CurrentUserUuid String uuid) {
         paymentService.deleteManualPayment(paymentId, uuid);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     /**
@@ -816,20 +816,19 @@ public class ManagementOrderController {
      */
     @Operation(summary = "Update Violation to User")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED, content = @Content),
+        @ApiResponse(responseCode = "204", description = HttpStatuses.NO_CONTENT, content = @Content),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })
     @ApiLocale
-    @ResponseStatus(value = HttpStatus.CREATED)
     @PutMapping(value = "/updateViolationToUser", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<HttpStatus> updateUsersViolation(@Valid @RequestPart UpdateViolationToUserDto add,
         @Nullable @RequestPart(required = false) @ValidImage MultipartFile[] multipartFiles,
         @Parameter(hidden = true) @CurrentUserUuid String uuid) {
         violationService.updateUserViolation(add, multipartFiles, uuid);
-        return new ResponseEntity<>(HttpStatus.CREATED);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     /**
@@ -840,19 +839,19 @@ public class ManagementOrderController {
      */
     @Operation(summary = "update eco-store id for order")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED, content = @Content),
+        @ApiResponse(responseCode = "204", description = HttpStatuses.NO_CONTENT, content = @Content),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content),
         @ApiResponse(responseCode = "422", description = HttpStatuses.UNPROCESSABLE_ENTITY, content = @Content)
     })
-    @PutMapping("/update-eco-store{id}")
+    @PutMapping("/update-eco-store/{id}")
     public ResponseEntity<HttpStatus> updateEcoStoreIdToOrder(
         @RequestBody @Valid EcoNumberDto ecoNumberDto, @Positive @PathVariable(name = "id") Long orderId,
         Principal principal) {
         ubsManagementService.updateEcoNumberForOrderById(ecoNumberDto, orderId, principal.getName());
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     /**
@@ -870,7 +869,7 @@ public class ManagementOrderController {
 
     @Operation(summary = "update order admin page info and save reason if needed")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED, content = @Content),
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK, content = @Content),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content),
@@ -889,7 +888,7 @@ public class ManagementOrderController {
             ubsManagementService.updateOrderAdminPageInfoAndSaveReason(orderId, updateOrderPageAdminDto, language,
                 principal.getName(), images);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(bigOrderTableDTO);
+        return ResponseEntity.status(HttpStatus.OK).body(bigOrderTableDTO);
     }
 
     /**
@@ -901,7 +900,7 @@ public class ManagementOrderController {
      */
     @Operation(summary = "update all order admin page info")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED, content = @Content),
+        @ApiResponse(responseCode = "204", description = HttpStatuses.NO_CONTENT, content = @Content),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content),
@@ -913,7 +912,7 @@ public class ManagementOrderController {
         @RequestBody @Valid UpdateAllOrderPageDto updateAllOrderPageDto, Principal principal,
         @RequestParam String lang) {
         ubsManagementService.updateAllOrderAdminPageInfo(updateAllOrderPageDto, principal.getName(), lang);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     /**

--- a/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementOrderControllerTest.java
@@ -302,11 +302,11 @@ class ManagementOrderControllerTest {
 
         String writeValueAsString = objectMapper.writeValueAsString(ecoNumberDto);
 
-        mockMvc.perform(MockMvcRequestBuilders.put(ubsManagementLink + "/update-eco-store{id}", 1L)
+        mockMvc.perform(MockMvcRequestBuilders.put(ubsManagementLink + "/update-eco-store/{id}", 1L)
             .content(writeValueAsString)
             .principal(principal)
             .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated());
+            .andExpect(status().isNoContent());
     }
 
     @Test
@@ -406,7 +406,7 @@ class ManagementOrderControllerTest {
             .principal(principal)
             .param("lang", "ua")
             .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated());
+            .andExpect(status().isNoContent());
     }
 
     @Test
@@ -447,7 +447,7 @@ class ManagementOrderControllerTest {
                 .param("language", "en")
                 .principal(principal)
                 .contentType(MediaType.MULTIPART_FORM_DATA))
-            .andExpect(status().isCreated());
+            .andExpect(status().isOk());
     }
 
     @Test

--- a/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
@@ -242,7 +242,7 @@ public class ViolationServiceImpl implements ViolationService {
                 violationImages.remove(image);
             }
         }
-        if (multipartFiles.length > 0) {
+        if (multipartFiles != null && multipartFiles.length > 0) {
             List<String> images = new LinkedList<>();
             setImages(multipartFiles, images);
             if (violation.getImages().isEmpty()) {


### PR DESCRIPTION
### 🔗 **Issue:** [#8929](https://github.com/ita-social-projects/GreenCity/issues/#8929)

This pull request refactors the `ManagementOrderController` and related services to improve consistency in HTTP response handling and enhance code robustness. The key changes include standardizing the use of `ResponseEntity` for HTTP responses, updating API documentation to align with HTTP status code conventions, and adding null checks for better error handling.

### Improvements to HTTP Response Handling:
* Standardized the use of `ResponseEntity.status(...).build()` for returning HTTP status codes in methods such as `addCertificate`, `deleteCertificate`, `addPointsToUser`, and others, replacing the older `new ResponseEntity<>(...)` syntax. (`[[1]](diffhunk://#diff-7075784c8d1e8b9182d7df6f9b3af9c8d5b935b40010a2cefc4489aaa54c9aaaL146-R146)`, `[[2]](diffhunk://#diff-7075784c8d1e8b9182d7df6f9b3af9c8d5b935b40010a2cefc4489aaa54c9aaaL169-R169)`, `[[3]](diffhunk://#diff-7075784c8d1e8b9182d7df6f9b3af9c8d5b935b40010a2cefc4489aaa54c9aaaL251-R251)`, `[[4]](diffhunk://#diff-7075784c8d1e8b9182d7df6f9b3af9c8d5b935b40010a2cefc4489aaa54c9aaaL706-R706)`, `[[5]](diffhunk://#diff-7075784c8d1e8b9182d7df6f9b3af9c8d5b935b40010a2cefc4489aaa54c9aaaL756-R756)`)

### Updates to API Documentation and Status Codes:
* Updated API response codes in annotations to reflect appropriate HTTP status codes, such as changing `201 CREATED` to `204 NO_CONTENT` or `200 OK` where applicable. This includes endpoints like `updateUsersViolation`, `updateEcoStoreIdToOrder`, and `updatePageAdminInfo`. (`[[1]](diffhunk://#diff-7075784c8d1e8b9182d7df6f9b3af9c8d5b935b40010a2cefc4489aaa54c9aaaL819-R831)`, `[[2]](diffhunk://#diff-7075784c8d1e8b9182d7df6f9b3af9c8d5b935b40010a2cefc4489aaa54c9aaaL843-R854)`, `[[3]](diffhunk://#diff-7075784c8d1e8b9182d7df6f9b3af9c8d5b935b40010a2cefc4489aaa54c9aaaL873-R872)`, `[[4]](diffhunk://#diff-7075784c8d1e8b9182d7df6f9b3af9c8d5b935b40010a2cefc4489aaa54c9aaaL904-R903)`)

### Code Robustness Enhancements:
* Added a null check for `multipartFiles` in the `updateViolation` method of `ViolationServiceImpl` to prevent potential `NullPointerException`. (`[service/src/main/java/greencity/service/ubs/ViolationServiceImpl.javaL245-R245](diffhunk://#diff-4d58256aef8a7aa7a96e8675bd3aea4999671be51f52e0ebc3638af658f2563cL245-R245)`)

✅ **This pull request closes** [#8929](https://github.com/ita-social-projects/GreenCity/issues/8929) **once merged.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when updating violations with image files, preventing errors if no files are provided.
  * Corrected endpoint path mapping for updating eco-store IDs.

* **Refactor**
  * Standardized API response types and status codes for order management actions to better align with RESTful conventions. Update operations now return more appropriate status codes and response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->