### PR TITLE
Fix/1751 manager login hang on invalid password

### DIFF
--- a/service/src/main/java/greencity/constant/TelegramBotConstants.java
+++ b/service/src/main/java/greencity/constant/TelegramBotConstants.java
@@ -179,5 +179,6 @@ public class TelegramBotConstants {
     public static final String PHOTO_CONTENT =
         "Фото контент";
 
-    public static final String LOGIN_FAILED = "Неправильний пароль. Спробуйте ще раз";
+    public static final String LOGIN_FAILED =
+        "Неправильний логін або пароль. Перевірте введені дані та спробуйте ще раз.";
 }

--- a/service/src/main/java/greencity/constant/TelegramBotConstants.java
+++ b/service/src/main/java/greencity/constant/TelegramBotConstants.java
@@ -178,4 +178,6 @@ public class TelegramBotConstants {
 
     public static final String PHOTO_CONTENT =
         "Фото контент";
+
+    public static final String INCORRECT_PASSWORD = "Неправильний пароль. Спробуйте ще раз";
 }

--- a/service/src/main/java/greencity/constant/TelegramBotConstants.java
+++ b/service/src/main/java/greencity/constant/TelegramBotConstants.java
@@ -179,5 +179,5 @@ public class TelegramBotConstants {
     public static final String PHOTO_CONTENT =
         "Фото контент";
 
-    public static final String INCORRECT_PASSWORD = "Неправильний пароль. Спробуйте ще раз";
+    public static final String LOGIN_FAILED = "Неправильний пароль. Спробуйте ще раз";
 }

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
@@ -83,7 +83,7 @@ public class TelegramLoginServiceImpl implements TelegramLoginService {
         } catch (BadRequestException e) {
             if (e.getMessage().contains("\"name\":\"password\"")) {
                 return MessageFactory.createFailLoginMessage(message.getChatId().toString(),
-                    TelegramBotConstants.INCORRECT_PASSWORD);
+                    TelegramBotConstants.LOGIN_FAILED);
             }
             return MessageFactory.createFailLoginMessage(message.getChatId().toString(),
                 TelegramBotConstants.SOMETHING_WENT_WRONG_PLEASE_TRY_AGAIN);

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
@@ -81,12 +81,8 @@ public class TelegramLoginServiceImpl implements TelegramLoginService {
 
             return MessageFactory.createSuccessLoginMessage(message.getChatId().toString(), name);
         } catch (BadRequestException e) {
-            if (e.getMessage().contains("\"name\":\"password\"")) {
-                return MessageFactory.createFailLoginMessage(message.getChatId().toString(),
-                    TelegramBotConstants.LOGIN_FAILED);
-            }
             return MessageFactory.createFailLoginMessage(message.getChatId().toString(),
-                TelegramBotConstants.SOMETHING_WENT_WRONG_PLEASE_TRY_AGAIN);
+                TelegramBotConstants.LOGIN_FAILED);
         } catch (Exception e) {
             return MessageFactory.createFailLoginMessage(message.getChatId().toString(),
                 TelegramBotConstants.SOMETHING_WENT_WRONG_PLEASE_TRY_AGAIN);

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
@@ -80,13 +80,11 @@ public class TelegramLoginServiceImpl implements TelegramLoginService {
                     .build());
 
             return MessageFactory.createSuccessLoginMessage(message.getChatId().toString(), name);
-
         } catch (BadRequestException e) {
             if (e.getMessage().contains("\"name\":\"password\"")) {
                 return MessageFactory.createFailLoginMessage(message.getChatId().toString(),
                     TelegramBotConstants.INCORRECT_PASSWORD);
             }
-
             return MessageFactory.createFailLoginMessage(message.getChatId().toString(),
                 TelegramBotConstants.SOMETHING_WENT_WRONG_PLEASE_TRY_AGAIN);
         } catch (Exception e) {

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
@@ -5,6 +5,7 @@ import greencity.constant.TelegramBotConstants;
 import greencity.dto.TestersSignInRequest;
 import greencity.entity.telegram.TelegramManager;
 import greencity.entity.user.employee.Employee;
+import greencity.exceptions.BadRequestException;
 import greencity.repository.EmployeeRepository;
 import greencity.repository.TelegramManagerRepository;
 import greencity.service.ubs.TelegramLoginService;
@@ -65,25 +66,32 @@ public class TelegramLoginServiceImpl implements TelegramLoginService {
                 TelegramBotConstants.EMPLOYEE_IS_NOT_MANAGER);
         }
 
-        var response = userRemoteClient.signIn(new TestersSignInRequest(login, password, secretToken));
+        try {
+            var response = userRemoteClient.signIn(new TestersSignInRequest(login, password, secretToken));
 
-        if (!response.getStatusCode().is2xxSuccessful()) {
+            var responseBody = response.getBody();
+            String name = (responseBody != null && responseBody.name() != null) ? responseBody.name() : USERNAME;
+
+            telegramManagerRepository.save(
+                TelegramManager
+                    .builder()
+                    .chatId(message.getChatId().toString())
+                    .employee(employee.get())
+                    .build());
+
+            return MessageFactory.createSuccessLoginMessage(message.getChatId().toString(), name);
+
+        } catch (BadRequestException e) {
+            if (e.getMessage().contains("\"name\":\"password\"")) {
+                return MessageFactory.createFailLoginMessage(message.getChatId().toString(),
+                    TelegramBotConstants.INCORRECT_PASSWORD);
+            }
+
+            return MessageFactory.createFailLoginMessage(message.getChatId().toString(),
+                TelegramBotConstants.SOMETHING_WENT_WRONG_PLEASE_TRY_AGAIN);
+        } catch (Exception e) {
             return MessageFactory.createFailLoginMessage(message.getChatId().toString(),
                 TelegramBotConstants.SOMETHING_WENT_WRONG_PLEASE_TRY_AGAIN);
         }
-
-        var responseBody = response.getBody();
-        String name = (responseBody != null && responseBody.name() != null) ? responseBody.name() : USERNAME;
-
-        telegramManagerRepository.save(
-            TelegramManager
-                .builder()
-                .chatId(message.getChatId().toString())
-                .employee(employee.get())
-                .build());
-
-        return MessageFactory.createSuccessLoginMessage(
-            message.getChatId().toString(),
-            name);
     }
 }

--- a/service/src/test/java/greencity/ubstelegrambot/service/TelegramLoginServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/service/TelegramLoginServiceTest.java
@@ -6,6 +6,8 @@ import greencity.dto.SuccessSignInDto;
 import greencity.dto.TestersSignInRequest;
 import greencity.entity.telegram.TelegramManager;
 import greencity.entity.user.employee.Employee;
+import greencity.exceptions.BadRequestException;
+import greencity.exceptions.http.RemoteServerUnavailableException;
 import greencity.repository.EmployeeRepository;
 import greencity.repository.TelegramManagerRepository;
 import org.junit.jupiter.api.Test;
@@ -137,7 +139,7 @@ class TelegramLoginServiceTest {
     }
 
     @Test
-    void testProcessInputManagerCredentialsRequest_WithUnsuccessfulRemoteSignIn_ShouldReturnTryAgainMessage() {
+    void testProcessInputManagerCredentialsRequest_WithInvalidPassword_ShouldReturnWrongPasswordMessage() {
         Message message = mock(Message.class);
         when(message.getText()).thenReturn("manager@test.com:password");
         when(message.getChatId()).thenReturn(123L);
@@ -146,8 +148,46 @@ class TelegramLoginServiceTest {
         when(employeeRepository.findByEmailWithPositions("manager@test.com")).thenReturn(Optional.of(employee));
         when(telegramUtils.checkIsEmployeeManager(employee)).thenReturn(true);
 
-        ResponseEntity<SuccessSignInDto> responseEntity = new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
-        when(userRemoteClient.signIn(any())).thenReturn(responseEntity);
+        when(userRemoteClient.signIn(any()))
+            .thenThrow(new BadRequestException("{\"name\":\"password\",\"message\":\"Bad password\"}"));
+
+        SendMessage result = telegramLoginService.processInputManagerCredentialsRequest(message);
+
+        assertEquals("123", result.getChatId());
+        assertTrue(result.getText().contains(TelegramBotConstants.INCORRECT_PASSWORD));
+    }
+
+    @Test
+    void testProcessInputManagerCredentialsRequest_WithBadRequestNonPassword_ShouldReturnTryAgainMessage() {
+        Message message = mock(Message.class);
+        when(message.getText()).thenReturn("manager@test.com:wrongpassword");
+        when(message.getChatId()).thenReturn(123L);
+
+        Employee employee = new Employee();
+        when(employeeRepository.findByEmailWithPositions("manager@test.com")).thenReturn(Optional.of(employee));
+        when(telegramUtils.checkIsEmployeeManager(employee)).thenReturn(true);
+
+        when(userRemoteClient.signIn(any()))
+            .thenThrow(new BadRequestException("Invalid login format"));
+
+        SendMessage result = telegramLoginService.processInputManagerCredentialsRequest(message);
+
+        assertEquals("123", result.getChatId());
+        assertTrue(result.getText().contains(TelegramBotConstants.SOMETHING_WENT_WRONG_PLEASE_TRY_AGAIN));
+    }
+
+    @Test
+    void testProcessInputManagerCredentialsRequest_WithGenericException_ShouldReturnTryAgainMessage() {
+        Message message = mock(Message.class);
+        when(message.getText()).thenReturn("manager@test.com:anypassword");
+        when(message.getChatId()).thenReturn(123L);
+
+        Employee employee = new Employee();
+        when(employeeRepository.findByEmailWithPositions("manager@test.com")).thenReturn(Optional.of(employee));
+        when(telegramUtils.checkIsEmployeeManager(employee)).thenReturn(true);
+
+        when(userRemoteClient.signIn(any()))
+            .thenThrow(new RemoteServerUnavailableException("Server is down"));
 
         SendMessage result = telegramLoginService.processInputManagerCredentialsRequest(message);
 

--- a/service/src/test/java/greencity/ubstelegrambot/service/TelegramLoginServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/service/TelegramLoginServiceTest.java
@@ -158,25 +158,6 @@ class TelegramLoginServiceTest {
     }
 
     @Test
-    void testProcessInputManagerCredentialsRequest_WithBadRequestNonPassword_ShouldReturnTryAgainMessage() {
-        Message message = mock(Message.class);
-        when(message.getText()).thenReturn("manager@test.com:wrongpassword");
-        when(message.getChatId()).thenReturn(123L);
-
-        Employee employee = new Employee();
-        when(employeeRepository.findByEmailWithPositions("manager@test.com")).thenReturn(Optional.of(employee));
-        when(telegramUtils.checkIsEmployeeManager(employee)).thenReturn(true);
-
-        when(userRemoteClient.signIn(any()))
-            .thenThrow(new BadRequestException("Invalid login format"));
-
-        SendMessage result = telegramLoginService.processInputManagerCredentialsRequest(message);
-
-        assertEquals("123", result.getChatId());
-        assertTrue(result.getText().contains(TelegramBotConstants.SOMETHING_WENT_WRONG_PLEASE_TRY_AGAIN));
-    }
-
-    @Test
     void testProcessInputManagerCredentialsRequest_WithGenericException_ShouldReturnTryAgainMessage() {
         Message message = mock(Message.class);
         when(message.getText()).thenReturn("manager@test.com:anypassword");

--- a/service/src/test/java/greencity/ubstelegrambot/service/TelegramLoginServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/service/TelegramLoginServiceTest.java
@@ -154,7 +154,7 @@ class TelegramLoginServiceTest {
         SendMessage result = telegramLoginService.processInputManagerCredentialsRequest(message);
 
         assertEquals("123", result.getChatId());
-        assertTrue(result.getText().contains(TelegramBotConstants.INCORRECT_PASSWORD));
+        assertTrue(result.getText().contains(TelegramBotConstants.LOGIN_FAILED));
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link :clipboard:
[#1751](https://github.com/ita-social-projects/GreenCityUBS/issues/1751)
## Changed

- Wrapped manager login flow in try-catch to handle BadRequestException and generic exceptions
- Returned user-friendly message for invalid password
- Added unit tests for new logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages during login to distinguish between incorrect password and other errors.
  * Users now receive a specific message if their password is incorrect, and a generic message for other login issues.

* **Tests**
  * Enhanced test coverage for login error handling, including scenarios for incorrect passwords and other exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->