### PR TITLE
Feature: replace localDateTime with utc Instant in telegram entities

### DIFF
--- a/dao/src/main/java/greencity/entity/telegram/MessageAsset.java
+++ b/dao/src/main/java/greencity/entity/telegram/MessageAsset.java
@@ -19,7 +19,6 @@ import org.hibernate.validator.constraints.URL;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import java.time.Instant;
 
 @Data

--- a/dao/src/main/java/greencity/entity/telegram/MessageAsset.java
+++ b/dao/src/main/java/greencity/entity/telegram/MessageAsset.java
@@ -1,7 +1,16 @@
 package greencity.entity.telegram;
 
 import greencity.enums.AssetType;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,7 +19,8 @@ import org.hibernate.validator.constraints.URL;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import java.time.LocalDateTime;
+
+import java.time.Instant;
 
 @Data
 @Entity
@@ -39,10 +49,10 @@ public class MessageAsset {
 
     @CreatedDate
     @Column(updatable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     @ManyToOne
     @JoinColumn(name = "message_id", nullable = false)

--- a/dao/src/main/java/greencity/entity/telegram/TelegramChat.java
+++ b/dao/src/main/java/greencity/entity/telegram/TelegramChat.java
@@ -2,9 +2,26 @@ package greencity.entity.telegram;
 
 import greencity.entity.user.User;
 import greencity.enums.ChatState;
-import jakarta.persistence.*;
-import lombok.*;
-import java.time.LocalDateTime;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +46,7 @@ public class TelegramChat {
     private ChatState chatState = ChatState.NORMAL;
 
     @Column(name = "chat_state_updated_at", nullable = false)
-    private LocalDateTime chatStateUpdatedAt;
+    private Instant chatStateUpdatedAt;
 
     @Column(nullable = false, name = "notify")
     private Boolean isNotify;

--- a/dao/src/main/java/greencity/entity/telegram/TelegramChat.java
+++ b/dao/src/main/java/greencity/entity/telegram/TelegramChat.java
@@ -20,7 +20,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;

--- a/dao/src/main/java/greencity/entity/telegram/TelegramMessage.java
+++ b/dao/src/main/java/greencity/entity/telegram/TelegramMessage.java
@@ -22,7 +22,6 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import java.time.Instant;
 import java.util.List;
 

--- a/dao/src/main/java/greencity/entity/telegram/TelegramMessage.java
+++ b/dao/src/main/java/greencity/entity/telegram/TelegramMessage.java
@@ -2,7 +2,19 @@ package greencity.entity.telegram;
 
 import greencity.enums.MessageDeliveryStatus;
 import greencity.enums.MessageViewingStatus;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,7 +22,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import java.time.LocalDateTime;
+
+import java.time.Instant;
 import java.util.List;
 
 @Data
@@ -26,10 +39,10 @@ public class TelegramMessage {
 
     @CreatedDate
     @Column(updatable = false, nullable = false)
-    private LocalDateTime sendAt;
+    private Instant sendAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     @OneToMany(mappedBy = "message", cascade = CascadeType.ALL)
     private List<MessageAsset> assets;

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -293,5 +293,5 @@
     <include file="db/changelog/logs/2025-08-05-ch-add-unread-count-and-viewing-status-to-chat-and-message.xml"/>
     <include file="db/changelog/logs/2025-08-05-ch-add-last-message-in-telegram-chat.xml"/>
     <include file="db/changelog/logs/2025-08-07-ch-update-localdatetime-to-instant-in-telegram-entities.xml"/>
-
+    <include file="db/changelog/logs/2025-08-08-ch-update-chat-state-updated-at-field-in-telegram-chat.xml"/>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -292,5 +292,6 @@
     <include file="db/changelog/logs/ch-change-email-column-types-Popovych.xml"/>
     <include file="db/changelog/logs/2025-08-05-ch-add-unread-count-and-viewing-status-to-chat-and-message.xml"/>
     <include file="db/changelog/logs/2025-08-05-ch-add-last-message-in-telegram-chat.xml"/>
+    <include file="db/changelog/logs/2025-08-07-ch-update-localdatetime-to-instant-in-telegram-entities.xml"/>
 
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/2025-08-07-ch-update-localdatetime-to-instant-in-telegram-entities.xml
+++ b/dao/src/main/resources/db/changelog/logs/2025-08-07-ch-update-localdatetime-to-instant-in-telegram-entities.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <changeSet id="2025-08-07-update-localdatetime-to-instant-in-telegram-entities" author="Anton Pampukha">
+        <comment>Convert LocalDateTime to Instant (timestamp to timestamptz)</comment>
+
+        <sql>
+            ALTER TABLE telegram_message
+                ALTER COLUMN send_at TYPE TIMESTAMP WITH TIME ZONE USING send_at AT TIME ZONE 'UTC',
+                ALTER COLUMN updated_at TYPE TIMESTAMP WITH TIME ZONE USING updated_at AT TIME ZONE 'UTC';
+        </sql>
+
+        <sql>
+            ALTER TABLE message_asset
+                ALTER COLUMN created_at TYPE TIMESTAMP WITH TIME ZONE USING created_at AT TIME ZONE 'UTC',
+                ALTER COLUMN updated_at TYPE TIMESTAMP WITH TIME ZONE USING updated_at AT TIME ZONE 'UTC';
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/2025-08-07-ch-update-localdatetime-to-instant-in-telegram-entities.xml
+++ b/dao/src/main/resources/db/changelog/logs/2025-08-07-ch-update-localdatetime-to-instant-in-telegram-entities.xml
@@ -3,7 +3,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
     <changeSet id="2025-08-07-update-localdatetime-to-instant-in-telegram-entities" author="Anton Pampukha">
         <preConditions onFail="HALT" onError="HALT">

--- a/dao/src/main/resources/db/changelog/logs/2025-08-07-ch-update-localdatetime-to-instant-in-telegram-entities.xml
+++ b/dao/src/main/resources/db/changelog/logs/2025-08-07-ch-update-localdatetime-to-instant-in-telegram-entities.xml
@@ -6,18 +6,38 @@
                             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
 
     <changeSet id="2025-08-07-update-localdatetime-to-instant-in-telegram-entities" author="Anton Pampukha">
-        <comment>Convert LocalDateTime to Instant (timestamp to timestamptz)</comment>
+        <preConditions onFail="HALT" onError="HALT">
+            <dbms type="postgresql"/>
+            <tableExists tableName="telegram_message"/>
+            <columnExists tableName="telegram_message" columnName="send_at"/>
+            <columnExists tableName="telegram_message" columnName="updated_at"/>
+            <tableExists tableName="message_asset"/>
+            <columnExists tableName="message_asset" columnName="created_at"/>
+            <columnExists tableName="message_asset" columnName="updated_at"/>
+        </preConditions>
+
+        <comment>Convert LocalDateTime to Instant (timestamp → timestamptz)</comment>
 
         <sql>
             ALTER TABLE telegram_message
-                ALTER COLUMN send_at TYPE TIMESTAMP WITH TIME ZONE USING send_at AT TIME ZONE 'UTC',
-                ALTER COLUMN updated_at TYPE TIMESTAMP WITH TIME ZONE USING updated_at AT TIME ZONE 'UTC';
+            ALTER COLUMN send_at TYPE TIMESTAMP WITH TIME ZONE USING send_at AT TIME ZONE 'UTC',
+            ALTER COLUMN updated_at TYPE TIMESTAMP WITH TIME ZONE USING updated_at AT TIME ZONE 'UTC';
         </sql>
 
         <sql>
             ALTER TABLE message_asset
-                ALTER COLUMN created_at TYPE TIMESTAMP WITH TIME ZONE USING created_at AT TIME ZONE 'UTC',
-                ALTER COLUMN updated_at TYPE TIMESTAMP WITH TIME ZONE USING updated_at AT TIME ZONE 'UTC';
+            ALTER COLUMN created_at TYPE TIMESTAMP WITH TIME ZONE USING created_at AT TIME ZONE 'UTC',
+            ALTER COLUMN updated_at TYPE TIMESTAMP WITH TIME ZONE USING updated_at AT TIME ZONE 'UTC';
         </sql>
+
+        <rollback>
+            ALTER TABLE telegram_message
+            ALTER COLUMN send_at TYPE TIMESTAMP WITHOUT TIME ZONE,
+            ALTER COLUMN updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+            ALTER TABLE message_asset
+            ALTER COLUMN created_at TYPE TIMESTAMP WITHOUT TIME ZONE,
+            ALTER COLUMN updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+        </rollback>
     </changeSet>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/2025-08-07-ch-update-localdatetime-to-instant-in-telegram-entities.xml
+++ b/dao/src/main/resources/db/changelog/logs/2025-08-07-ch-update-localdatetime-to-instant-in-telegram-entities.xml
@@ -31,13 +31,15 @@
         </sql>
 
         <rollback>
-            ALTER TABLE telegram_message
-            ALTER COLUMN send_at TYPE TIMESTAMP WITHOUT TIME ZONE,
-            ALTER COLUMN updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+            <sql>
+                ALTER TABLE telegram_message
+                ALTER COLUMN send_at TYPE TIMESTAMP WITHOUT TIME ZONE,
+                ALTER COLUMN updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
-            ALTER TABLE message_asset
-            ALTER COLUMN created_at TYPE TIMESTAMP WITHOUT TIME ZONE,
-            ALTER COLUMN updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+                ALTER TABLE message_asset
+                ALTER COLUMN created_at TYPE TIMESTAMP WITHOUT TIME ZONE,
+                ALTER COLUMN updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+            </sql>
         </rollback>
     </changeSet>
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/2025-08-08-ch-update-chat-state-updated-at-field-in-telegram-chat.xml
+++ b/dao/src/main/resources/db/changelog/logs/2025-08-08-ch-update-chat-state-updated-at-field-in-telegram-chat.xml
@@ -3,7 +3,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
     <changeSet id="replace-chat-state-updated-at-in-telegram-chat" author="Anton Pampukha">
         <preConditions onFail="MARK_RAN">
@@ -12,10 +12,17 @@
 
         <comment>Change chat_state_updated_at from timestamp without time zone to with time zone</comment>
 
-        <modifyDataType
-                tableName="telegram_chat"
-                columnName="chat_state_updated_at"
-                newDataType="timestamp with time zone"/>
+        <sql>
+            ALTER TABLE telegram_chat
+            ALTER COLUMN chat_state_updated_at TYPE TIMESTAMP WITH TIME ZONE USING chat_state_updated_at AT TIME ZONE 'UTC';
+        </sql>
+
+        <rollback>
+            <sql>
+                ALTER TABLE telegram_chat
+                ALTER COLUMN chat_state_updated_at TYPE TIMESTAMP WITHOUT TIME ZONE USING chat_state_updated_at AT TIME ZONE 'UTC';
+            </sql>
+        </rollback>
     </changeSet>
 
 </databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/2025-08-08-ch-update-chat-state-updated-at-field-in-telegram-chat.xml
+++ b/dao/src/main/resources/db/changelog/logs/2025-08-08-ch-update-chat-state-updated-at-field-in-telegram-chat.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <changeSet id="replace-chat-state-updated-at-in-telegram-chat" author="Anton Pampukha">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="telegram_chat" columnName="chat_state_updated_at"/>
+        </preConditions>
+
+        <comment>Change chat_state_updated_at from timestamp without time zone to with time zone</comment>
+
+        <modifyDataType
+                tableName="telegram_chat"
+                columnName="chat_state_updated_at"
+                newDataType="timestamp with time zone"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service-api/src/main/java/greencity/dto/telegram/TelegramMessageDto.java
+++ b/service-api/src/main/java/greencity/dto/telegram/TelegramMessageDto.java
@@ -6,7 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import java.time.LocalDateTime;
+
+import java.time.Instant;
 import java.util.List;
 
 @Data
@@ -16,7 +17,7 @@ import java.util.List;
 public class TelegramMessageDto {
     private Long id;
 
-    private LocalDateTime sendAt;
+    private Instant sendAt;
 
     private String text;
 

--- a/service-api/src/main/java/greencity/dto/telegram/TelegramMessageDto.java
+++ b/service-api/src/main/java/greencity/dto/telegram/TelegramMessageDto.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
 import java.time.Instant;
 import java.util.List;
 

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramFeedbackServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramFeedbackServiceImpl.java
@@ -16,7 +16,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Message;
-
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramFeedbackServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramFeedbackServiceImpl.java
@@ -16,7 +16,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Message;
-import java.time.LocalDateTime;
+
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -50,7 +51,7 @@ public class TelegramFeedbackServiceImpl implements TelegramFeedbackService {
         chatFeedback.get().setFeedbackState(FeedbackState.CLOSED);
         chatFeedbackRepository.save(chatFeedback.get());
         telegramChat.get().setChatState(ChatState.NORMAL);
-        telegramChat.get().setChatStateUpdatedAt(LocalDateTime.now());
+        telegramChat.get().setChatStateUpdatedAt(Instant.now());
         telegramChatRepository.save(telegramChat.get());
         return MessageFactory.createFeedbackThanksMessage(message.getChatId().toString());
     }
@@ -67,7 +68,7 @@ public class TelegramFeedbackServiceImpl implements TelegramFeedbackService {
         }
 
         chat.get().setChatState(ChatState.MAKING_FEEDBACK);
-        chat.get().setChatStateUpdatedAt(LocalDateTime.now());
+        chat.get().setChatStateUpdatedAt(Instant.now());
         telegramChatRepository.save(chat.get());
 
         Optional<ChatFeedback> inProgressFeedback = chatFeedbackRepository

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramGreenOfficeServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramGreenOfficeServiceImpl.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Message;
-import java.time.LocalDateTime;
+
+import java.time.Instant;
 import java.util.Optional;
 
 @Service
@@ -43,7 +44,7 @@ public class TelegramGreenOfficeServiceImpl implements TelegramGreenOfficeServic
 
         notificationService.notifyManagerWithNewGreenOfficeRequestFromTelegramBot(email, username);
         chat.setChatState(ChatState.NORMAL);
-        chat.setChatStateUpdatedAt(LocalDateTime.now());
+        chat.setChatStateUpdatedAt(Instant.now());
         telegramChatRepository.save(chat);
         return MessageFactory.createGreenOfficeThanksMessage(message.getChatId().toString());
     }

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramGreenOfficeServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramGreenOfficeServiceImpl.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Message;
-
 import java.time.Instant;
 import java.util.Optional;
 

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
@@ -81,7 +81,7 @@ public class TelegramServiceImpl implements TelegramService {
             .text(request.getText())
             .fromManager(true)
             .status(MessageDeliveryStatus.SENT)
-            .sendAt(LocalDateTime.now())
+            .sendAt(Instant.now())
             .messageViewingStatus(MessageViewingStatus.READ)
             .build();
 

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
@@ -45,7 +45,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.Update;
-
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
@@ -3,7 +3,12 @@ package greencity.ubstelegrambot.service;
 import greencity.constant.TelegramBotConstants;
 import greencity.dto.order.OrdersDataForUserDto;
 import greencity.dto.pageble.PageableDto;
-import greencity.dto.telegram.*;
+import greencity.dto.telegram.ChatDto;
+import greencity.dto.telegram.ChatUserDto;
+import greencity.dto.telegram.CreateTelegramMessageRequest;
+import greencity.dto.telegram.MarkMessagesAsReadRequest;
+import greencity.dto.telegram.MessageAssetDto;
+import greencity.dto.telegram.TelegramMessageDto;
 import greencity.entity.order.Order;
 import greencity.entity.telegram.MessageAsset;
 import greencity.entity.telegram.TelegramChat;
@@ -40,12 +45,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.Update;
+
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -408,7 +413,7 @@ public class TelegramServiceImpl implements TelegramService {
             .lastName(message.getFrom().getLastName())
             .isNotify(true)
             .chatState(ChatState.NORMAL)
-            .chatStateUpdatedAt(LocalDateTime.now());
+            .chatStateUpdatedAt(Instant.now());
 
         if (!uuid.isEmpty()) {
             userRepository.findUserByUuid(uuid).ifPresent(newChatBuilder::user);

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
@@ -50,7 +50,6 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -471,7 +470,7 @@ public class TelegramServiceImpl implements TelegramService {
             : update.getMessage().getChatId().toString();
 
         telegramChatRepository.findByChatId(chatId).ifPresent(chat -> {
-            Instant updatedAt = chat.getChatStateUpdatedAt().atZone(ZoneId.systemDefault()).toInstant();
+            Instant updatedAt = chat.getChatStateUpdatedAt();
             if (Duration.between(updatedAt, Instant.now()).toMinutes() > 10) {
                 chat.setChatState(ChatState.NORMAL);
                 telegramChatRepository.save(chat);

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -32,7 +32,6 @@ import org.telegram.telegrambots.meta.api.objects.Document;
 import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.PhotoSize;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -32,6 +32,8 @@ import org.telegram.telegrambots.meta.api.objects.Document;
 import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.PhotoSize;
+
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -98,7 +100,7 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
                 .fromManager(false)
                 .mediaGroupId(mediaGroupId)
                 .status(MessageDeliveryStatus.SENT)
-                .sendAt(LocalDateTime.now())
+                .sendAt(Instant.now())
                 .text(messageText)
                 .messageViewingStatus(MessageViewingStatus.UNREAD)
                 .build();

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -32,7 +32,6 @@ import org.telegram.telegrambots.meta.api.objects.Document;
 import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.PhotoSize;
-
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -32,8 +32,8 @@ import org.telegram.telegrambots.meta.api.objects.Document;
 import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.PhotoSize;
+
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -72,7 +72,7 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
 
         if (message.hasText() && message.getText().contains(TelegramBotConstants.CLIENT_END_SUPPORT_MODE)) {
             chat.setChatState(ChatState.NORMAL);
-            chat.setChatStateUpdatedAt(LocalDateTime.now());
+            chat.setChatStateUpdatedAt(Instant.now());
             telegramChatRepository.save(chat);
             telegramNotificationService.notifyManagerAboutEndSupportModeFromUser(message.getFrom().getUserName());
             return MessageFactory.createEndSupportMessage(chat.getChatId());

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramUtils.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramUtils.java
@@ -16,13 +16,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.File;
+
 import java.io.IOException;
 import java.net.URI;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import static greencity.constant.ErrorMessage.POSITION_NOT_FOUND;
 import static greencity.constant.ValidationConstant.EMAIL_REGEXP;
 
@@ -112,7 +114,7 @@ public class TelegramUtils {
             return MessageFactory.createUnknownErrorOccurredMessage(chatId);
         }
         chat.get().setChatState(newState);
-        chat.get().setChatStateUpdatedAt(LocalDateTime.now());
+        chat.get().setChatStateUpdatedAt(Instant.now());
         telegramChatRepository.save(chat.get());
         return messageSupplier.apply(chatId);
     }

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramUtils.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramUtils.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.File;
-
 import java.io.IOException;
 import java.net.URI;
 import java.time.Instant;
@@ -24,7 +23,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import static greencity.constant.ErrorMessage.POSITION_NOT_FOUND;
 import static greencity.constant.ValidationConstant.EMAIL_REGEXP;
 

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -196,6 +196,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -1605,13 +1606,13 @@ public class ModelUtils {
     }
 
     public static TelegramChat getTelegramBotNotifyTrue() {
-        return new TelegramChat(1L, "12345", ChatState.NORMAL, LocalDateTime.now(), true, "username", "first_name",
+        return new TelegramChat(1L, "12345", ChatState.NORMAL, Instant.now(), true, "username", "first_name",
             "last_name", 0, null, null,
             new ArrayList<>(), new ArrayList<>());
     }
 
     public static TelegramChat getTelegramBotNotifyFalse() {
-        return new TelegramChat(1L, "12345", ChatState.NORMAL, LocalDateTime.now(), false, "username", "first_name",
+        return new TelegramChat(1L, "12345", ChatState.NORMAL, Instant.now(), false, "username", "first_name",
             "last_name", 0, null, null,
             new ArrayList<>(), new ArrayList<>());
     }

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
@@ -61,6 +61,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashMap;
@@ -274,7 +275,7 @@ class TelegramServiceTest {
         TelegramMessage message = TelegramMessage.builder()
             .id(100L)
             .text("Hello")
-            .sendAt(LocalDateTime.now())
+            .sendAt(Instant.now())
             .fromManager(false)
             .status(MessageDeliveryStatus.SENT)
             .assets(List.of(MessageAsset.builder()
@@ -348,7 +349,7 @@ class TelegramServiceTest {
         TelegramMessage message = TelegramMessage.builder()
             .id(100L)
             .text("Hello")
-            .sendAt(LocalDateTime.now())
+            .sendAt(Instant.now())
             .fromManager(true)
             .status(MessageDeliveryStatus.SENT)
             .assets(List.of(asset))
@@ -468,7 +469,7 @@ class TelegramServiceTest {
         TelegramMessage message = TelegramMessage.builder()
             .id(100L)
             .text("Message with null assets")
-            .sendAt(LocalDateTime.now())
+            .sendAt(Instant.now())
             .fromManager(true)
             .status(MessageDeliveryStatus.SENT)
             .assets(null)

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
@@ -63,6 +63,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -677,7 +678,7 @@ class TelegramServiceTest {
 
         TelegramChat telegramChat = TelegramChat.builder()
             .chatId(chatId.toString())
-            .chatStateUpdatedAt(LocalDateTime.now().minusMinutes(15))
+            .chatStateUpdatedAt(Instant.now().minus(15, ChronoUnit.MINUTES))
             .build();
 
         when(telegramChatRepository.findByChatId(chatId.toString())).thenReturn(Optional.of(telegramChat));
@@ -840,7 +841,7 @@ class TelegramServiceTest {
 
         TelegramChat telegramChat = TelegramChat.builder()
             .chatId(chatId.toString())
-            .chatStateUpdatedAt(LocalDateTime.now().minusMinutes(15))
+            .chatStateUpdatedAt(Instant.now().minus(1, ChronoUnit.MINUTES))
             .build();
 
         when(telegramChatRepository.findByChatId(chatId.toString()))

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
@@ -841,7 +841,7 @@ class TelegramServiceTest {
 
         TelegramChat telegramChat = TelegramChat.builder()
             .chatId(chatId.toString())
-            .chatStateUpdatedAt(Instant.now().minus(1, ChronoUnit.MINUTES))
+            .chatStateUpdatedAt(Instant.now().minus(15, ChronoUnit.MINUTES))
             .build();
 
         when(telegramChatRepository.findByChatId(chatId.toString()))

--- a/service/src/test/java/greencity/ubstelegrambot/service/TelegramFeedbackServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/service/TelegramFeedbackServiceTest.java
@@ -23,13 +23,25 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Chat;
 import org.telegram.telegrambots.meta.api.objects.Message;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
-import static greencity.ubstelegrambot.constant.TelegramConstants.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static greencity.ubstelegrambot.constant.TelegramConstants.BAD_FEEDBACK_MESSAGE;
+import static greencity.ubstelegrambot.constant.TelegramConstants.FEEDBACK_THANK_YOU_MESSAGE;
+import static greencity.ubstelegrambot.constant.TelegramConstants.GREAT_FEEDBACK_MESSAGE;
+import static greencity.ubstelegrambot.constant.TelegramConstants.UNKNOWN_ERROR_OCCURRED_PLEASE_TRY_AGAIN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class TelegramFeedbackServiceTest {
@@ -57,7 +69,7 @@ class TelegramFeedbackServiceTest {
             .id(chatDbId)
             .chatId(chatId.toString())
             .chatState(ChatState.MAKING_FEEDBACK)
-            .chatStateUpdatedAt(LocalDateTime.now().minusDays(1))
+            .chatStateUpdatedAt(Instant.now().minus(1, ChronoUnit.DAYS))
             .isNotify(true)
             .build();
 
@@ -82,7 +94,7 @@ class TelegramFeedbackServiceTest {
         assertEquals(FeedbackState.CLOSED, chatFeedback.getFeedbackState());
         assertEquals(ChatState.NORMAL, telegramChat.getChatState());
         assertNotNull(telegramChat.getChatStateUpdatedAt());
-        assertTrue(telegramChat.getChatStateUpdatedAt().isAfter(LocalDateTime.now().minusMinutes(1)));
+        assertTrue(telegramChat.getChatStateUpdatedAt().isAfter(Instant.now().minus(1, ChronoUnit.MINUTES)));
 
         verify(chatFeedbackRepository).save(chatFeedback);
         verify(telegramChatRepository).save(telegramChat);
@@ -118,7 +130,7 @@ class TelegramFeedbackServiceTest {
             .id(chatDbId)
             .chatId(chatId.toString())
             .chatState(ChatState.NORMAL)
-            .chatStateUpdatedAt(LocalDateTime.now())
+            .chatStateUpdatedAt(Instant.now())
             .isNotify(true)
             .build();
 
@@ -148,7 +160,7 @@ class TelegramFeedbackServiceTest {
             .id(chatDbId)
             .chatId(chatId.toString())
             .chatState(ChatState.MAKING_FEEDBACK)
-            .chatStateUpdatedAt(LocalDateTime.now())
+            .chatStateUpdatedAt(Instant.now())
             .isNotify(true)
             .build();
 
@@ -183,7 +195,7 @@ class TelegramFeedbackServiceTest {
             .id(chatDbId)
             .chatId(chatId.toString())
             .chatState(ChatState.MAKING_FEEDBACK)
-            .chatStateUpdatedAt(LocalDateTime.now())
+            .chatStateUpdatedAt(Instant.now())
             .isNotify(true)
             .build();
 
@@ -229,7 +241,7 @@ class TelegramFeedbackServiceTest {
             .id(chatDbId)
             .chatId(chatId)
             .chatState(ChatState.NORMAL)
-            .chatStateUpdatedAt(LocalDateTime.now().minusDays(1))
+            .chatStateUpdatedAt(Instant.now().minus(1, ChronoUnit.DAYS))
             .isNotify(true)
             .build();
 
@@ -265,7 +277,7 @@ class TelegramFeedbackServiceTest {
             .id(chatDbId)
             .chatId(chatId)
             .chatState(ChatState.NORMAL)
-            .chatStateUpdatedAt(LocalDateTime.now())
+            .chatStateUpdatedAt(Instant.now())
             .isNotify(true)
             .build();
 
@@ -294,7 +306,7 @@ class TelegramFeedbackServiceTest {
             .id(chatDbId)
             .chatId(chatId)
             .chatState(ChatState.NORMAL)
-            .chatStateUpdatedAt(LocalDateTime.now().minusHours(1))
+            .chatStateUpdatedAt(Instant.now().minus(1, ChronoUnit.HOURS))
             .isNotify(true)
             .build();
 
@@ -307,7 +319,7 @@ class TelegramFeedbackServiceTest {
 
         // then
         assertEquals(ChatState.MAKING_FEEDBACK, chat.getChatState());
-        assertTrue(chat.getChatStateUpdatedAt().isAfter(LocalDateTime.now().minusMinutes(1)));
+        assertTrue(chat.getChatStateUpdatedAt().isAfter(Instant.now().minus(1, ChronoUnit.MINUTES)));
         verify(telegramChatRepository).save(chat);
     }
 

--- a/service/src/test/java/greencity/ubstelegrambot/service/TelegramNotificationServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/service/TelegramNotificationServiceTest.java
@@ -18,7 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -40,7 +40,7 @@ class TelegramNotificationServiceTest {
     private TelegramNotificationService telegramNotificationService;
     private final User user = User.builder().id(32L).recipientEmail("user@email.com")
         .telegramBot(
-            new TelegramChat(1L, "12345", ChatState.NORMAL, LocalDateTime.now(), true, "username", "first_name",
+            new TelegramChat(1L, "12345", ChatState.NORMAL, Instant.now(), true, "username", "first_name",
                 "last_name", 0, null, null,
                 new ArrayList<>(), new ArrayList<>()))
         .build();
@@ -94,7 +94,7 @@ class TelegramNotificationServiceTest {
         assertFalse(telegramNotificationService.isEnabled(userEntity));
 
         userEntity
-            .setTelegramBot(new TelegramChat(1L, "12345", ChatState.NORMAL, LocalDateTime.now(), true, "username",
+            .setTelegramBot(new TelegramChat(1L, "12345", ChatState.NORMAL, Instant.now(), true, "username",
                 "first_name", "last_name", 0,
                 userEntity, null, new ArrayList<>(), new ArrayList<>()));
 


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link :clipboard:
[#8954 ](https://github.com/ita-social-projects/GreenCity/issues/8954)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated timestamp fields in Telegram-related features to use a more precise and time zone-aware format across the application.
* **Chores**
  * Applied corresponding database schema changes to support the updated timestamp format.
* **Tests**
  * Adjusted tests to align with the new timestamp representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->