### PR TITLE
8961 api admin notifications notifications same field is different on different endpoints

### DIFF
--- a/service/src/main/java/greencity/mapping/notification/NotificationMappers.java
+++ b/service/src/main/java/greencity/mapping/notification/NotificationMappers.java
@@ -1,0 +1,45 @@
+package greencity.mapping.notification;
+
+import greencity.dto.notification.NotificationPlatformDto;
+import greencity.dto.notification.NotificationTemplateMainInfoDto;
+import greencity.entity.notifications.NotificationPlatform;
+import greencity.entity.notifications.NotificationTemplate;
+import java.util.Objects;
+import java.util.function.Function;
+
+public class NotificationMappers {
+    private NotificationMappers() {
+    }
+
+    public static final Function<NotificationTemplate, NotificationTemplateMainInfoDto> toNotificationTemplateMainInfoDto =
+        notificationTemplate -> NotificationTemplateMainInfoDto.builder()
+            .type(notificationTemplate.getNotificationType())
+            .trigger(notificationTemplate.getTrigger())
+            .triggerDescriptionUk(notificationTemplate.getTrigger().getDescriptionUk())
+            .triggerDescriptionEn(notificationTemplate.getTrigger().getDescriptionEn())
+            .time(notificationTemplate.getTime())
+            .timeDescriptionUk(notificationTemplate.getTime().getDescriptionUk())
+            .timeDescriptionEn(notificationTemplate.getTime().getDescriptionEn())
+            .schedule(notificationTemplate.getSchedule())
+            .titleUk(notificationTemplate.getTitleUk())
+            .titleEn(notificationTemplate.getTitleEn())
+            .notificationStatus(notificationTemplate.getNotificationStatus())
+            .scheduleUpdateForbidden(notificationTemplate.isScheduleUpdateForbidden())
+            .userCategoryDescriptionUk(
+                Objects.isNull(notificationTemplate.getUserCategory()) ? null
+                    : notificationTemplate.getUserCategory().getDescriptionUk())
+            .userCategoryDescriptionEn(
+                Objects.isNull(notificationTemplate.getUserCategory()) ? null
+                    : notificationTemplate.getUserCategory().getDescriptionEn())
+            .build();
+
+    public static final Function<NotificationPlatform, NotificationPlatformDto> toNotificationPlatformDto =
+        platform -> NotificationPlatformDto.builder()
+            .id(platform.getId())
+            .receiverType(platform.getNotificationReceiverType())
+            .nameEn(platform.getNotificationReceiverType().getName())
+            .bodyUk(platform.getBodyUk())
+            .bodyEn(platform.getBodyEn())
+            .status(platform.getNotificationStatus())
+            .build();
+}

--- a/service/src/main/java/greencity/mapping/notification/NotificationMappers.java
+++ b/service/src/main/java/greencity/mapping/notification/NotificationMappers.java
@@ -7,10 +7,43 @@ import greencity.entity.notifications.NotificationTemplate;
 import java.util.Objects;
 import java.util.function.Function;
 
+/**
+ * Utility class providing reusable mapping functions for converting
+ * notification-related entity objects into their corresponding DTO
+ * representations.
+ * <p>
+ * This class is not meant to be instantiated; all mappings are exposed as
+ * public static {@link Function} instances for direct usage in mappers,
+ * services, or stream pipelines.
+ * </p>
+ *
+ * <h2>Available Mappers</h2>
+ * <ul>
+ * <li>{@link #toNotificationTemplateMainInfoDto} – Maps a
+ * {@link NotificationTemplate} entity to a
+ * {@link NotificationTemplateMainInfoDto}.</li>
+ * <li>{@link #toNotificationPlatformDto} – Maps a {@link NotificationPlatform}
+ * entity to a {@link NotificationPlatformDto}.</li>
+ * </ul>
+ */
 public class NotificationMappers {
+    /**
+     * Private constructor to prevent instantiation.
+     */
     private NotificationMappers() {
     }
 
+    /**
+     * Maps a {@link NotificationTemplate} entity to a
+     * {@link NotificationTemplateMainInfoDto}.
+     * <p>
+     * Copies type, trigger details, time details, schedule, title, status, schedule
+     * update restriction flag, and user category descriptions.
+     * </p>
+     *
+     * @see NotificationTemplate
+     * @see NotificationTemplateMainInfoDto
+     */
     public static final Function<NotificationTemplate, NotificationTemplateMainInfoDto> toNotificationTemplateMainInfoDto =
         notificationTemplate -> NotificationTemplateMainInfoDto.builder()
             .type(notificationTemplate.getNotificationType())
@@ -33,6 +66,17 @@ public class NotificationMappers {
                     : notificationTemplate.getUserCategory().getDescriptionEn())
             .build();
 
+    /**
+     * Maps a {@link NotificationPlatform} entity to a
+     * {@link NotificationPlatformDto}.
+     * <p>
+     * Copies platform ID, receiver type, English name, body texts in both
+     * languages, and notification status.
+     * </p>
+     *
+     * @see NotificationPlatform
+     * @see NotificationPlatformDto
+     */
     public static final Function<NotificationPlatform, NotificationPlatformDto> toNotificationPlatformDto =
         platform -> NotificationPlatformDto.builder()
             .id(platform.getId())

--- a/service/src/main/java/greencity/mapping/notification/NotificationMappers.java
+++ b/service/src/main/java/greencity/mapping/notification/NotificationMappers.java
@@ -5,25 +5,24 @@ import greencity.dto.notification.NotificationTemplateMainInfoDto;
 import greencity.entity.notifications.NotificationPlatform;
 import greencity.entity.notifications.NotificationTemplate;
 import java.util.Objects;
-import java.util.function.Function;
 
 /**
- * Utility class providing reusable mapping functions for converting
- * notification-related entity objects into their corresponding DTO
- * representations.
+ * Utility class providing mapping methods for converting notification-related
+ * entities into their corresponding DTO representations.
  * <p>
- * This class is not meant to be instantiated; all mappings are exposed as
- * public static {@link Function} instances for direct usage in mappers,
- * services, or stream pipelines.
+ * This class is non-instantiable and exposes all mappers as public static
+ * methods, allowing them to be used directly in services, mappers, or stream
+ * operations.
  * </p>
  *
  * <h2>Available Mappers</h2>
  * <ul>
- * <li>{@link #toNotificationTemplateMainInfoDto} – Maps a
+ * <li>{@link #toNotificationTemplateMainInfoDto(NotificationTemplate)} – Maps a
  * {@link NotificationTemplate} entity to a
  * {@link NotificationTemplateMainInfoDto}.</li>
- * <li>{@link #toNotificationPlatformDto} – Maps a {@link NotificationPlatform}
- * entity to a {@link NotificationPlatformDto}.</li>
+ * <li>{@link #toNotificationPlatformDto(NotificationPlatform)} – Maps a
+ * {@link NotificationPlatform} entity to a
+ * {@link NotificationPlatformDto}.</li>
  * </ul>
  */
 public class NotificationMappers {
@@ -34,18 +33,20 @@ public class NotificationMappers {
     }
 
     /**
-     * Maps a {@link NotificationTemplate} entity to a
+     * Converts a {@link NotificationTemplate} entity to a
      * {@link NotificationTemplateMainInfoDto}.
      * <p>
-     * Copies type, trigger details, time details, schedule, title, status, schedule
-     * update restriction flag, and user category descriptions.
+     * Maps the notification type, trigger and its descriptions, time and its
+     * descriptions, schedule, titles, status, schedule update restriction flag, and
+     * user category descriptions (if available).
      * </p>
      *
-     * @see NotificationTemplate
-     * @see NotificationTemplateMainInfoDto
+     * @param notificationTemplate the entity to map
+     * @return a populated {@link NotificationTemplateMainInfoDto}
      */
-    public static final Function<NotificationTemplate, NotificationTemplateMainInfoDto> toNotificationTemplateMainInfoDto =
-        notificationTemplate -> NotificationTemplateMainInfoDto.builder()
+    public static NotificationTemplateMainInfoDto toNotificationTemplateMainInfoDto(
+        NotificationTemplate notificationTemplate) {
+        return NotificationTemplateMainInfoDto.builder()
             .type(notificationTemplate.getNotificationType())
             .trigger(notificationTemplate.getTrigger())
             .triggerDescriptionUk(notificationTemplate.getTrigger().getDescriptionUk())
@@ -65,25 +66,27 @@ public class NotificationMappers {
                 Objects.isNull(notificationTemplate.getUserCategory()) ? null
                     : notificationTemplate.getUserCategory().getDescriptionEn())
             .build();
+    }
 
     /**
-     * Maps a {@link NotificationPlatform} entity to a
+     * Converts a {@link NotificationPlatform} entity to a
      * {@link NotificationPlatformDto}.
      * <p>
-     * Copies platform ID, receiver type, English name, body texts in both
-     * languages, and notification status.
+     * Maps the platform ID, receiver type, receiver type name (English), message
+     * body in both languages, and notification status.
      * </p>
      *
-     * @see NotificationPlatform
-     * @see NotificationPlatformDto
+     * @param notificationPlatform the entity to map
+     * @return a populated {@link NotificationPlatformDto}
      */
-    public static final Function<NotificationPlatform, NotificationPlatformDto> toNotificationPlatformDto =
-        platform -> NotificationPlatformDto.builder()
-            .id(platform.getId())
-            .receiverType(platform.getNotificationReceiverType())
-            .nameEn(platform.getNotificationReceiverType().getName())
-            .bodyUk(platform.getBodyUk())
-            .bodyEn(platform.getBodyEn())
-            .status(platform.getNotificationStatus())
+    public static NotificationPlatformDto toNotificationPlatformDto(NotificationPlatform notificationPlatform) {
+        return NotificationPlatformDto.builder()
+            .id(notificationPlatform.getId())
+            .receiverType(notificationPlatform.getNotificationReceiverType())
+            .nameEn(notificationPlatform.getNotificationReceiverType().getName())
+            .bodyUk(notificationPlatform.getBodyUk())
+            .bodyEn(notificationPlatform.getBodyEn())
+            .status(notificationPlatform.getNotificationStatus())
             .build();
+    }
 }

--- a/service/src/main/java/greencity/mapping/notification/NotificationTemplateDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/notification/NotificationTemplateDtoMapper.java
@@ -13,7 +13,7 @@ public class NotificationTemplateDtoMapper
         return NotificationTemplateDto.builder()
             .id(notificationTemplate.getId())
             .notificationTemplateMainInfoDto(
-                NotificationMappers.toNotificationTemplateMainInfoDto.apply(notificationTemplate))
+                NotificationMappers.toNotificationTemplateMainInfoDto(notificationTemplate))
             .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/notification/NotificationTemplateDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/notification/NotificationTemplateDtoMapper.java
@@ -1,9 +1,7 @@
 package greencity.mapping.notification;
 
 import greencity.dto.notification.NotificationTemplateDto;
-import greencity.dto.notification.NotificationTemplateMainInfoDto;
 import greencity.entity.notifications.NotificationTemplate;
-import java.util.Objects;
 import org.modelmapper.AbstractConverter;
 import org.springframework.stereotype.Component;
 
@@ -15,23 +13,7 @@ public class NotificationTemplateDtoMapper
         return NotificationTemplateDto.builder()
             .id(notificationTemplate.getId())
             .notificationTemplateMainInfoDto(
-                NotificationTemplateMainInfoDto.builder()
-                    .type(notificationTemplate.getNotificationType())
-                    .trigger(notificationTemplate.getTrigger())
-                    .triggerDescriptionUk(notificationTemplate.getTrigger().getDescriptionUk())
-                    .triggerDescriptionEn(notificationTemplate.getTrigger().getDescriptionEn())
-                    .time(notificationTemplate.getTime())
-                    .timeDescriptionUk(notificationTemplate.getTime().getDescriptionUk())
-                    .timeDescriptionEn(notificationTemplate.getTime().getDescriptionEn())
-                    .schedule(notificationTemplate.getSchedule())
-                    .titleUk(notificationTemplate.getTitleUk())
-                    .titleEn(notificationTemplate.getTitleEn())
-                    .notificationStatus(notificationTemplate.getNotificationStatus())
-                    .userCategoryDescriptionUk(Objects.isNull(notificationTemplate.getUserCategory()) ? null
-                        : notificationTemplate.getUserCategory().getDescriptionUk())
-                    .userCategoryDescriptionEn(Objects.isNull(notificationTemplate.getUserCategory()) ? null
-                        : notificationTemplate.getUserCategory().getDescriptionEn())
-                    .build())
+                NotificationMappers.toNotificationTemplateMainInfoDto.apply(notificationTemplate))
             .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/notification/NotificationTemplateWithPlatformsDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/notification/NotificationTemplateWithPlatformsDtoMapper.java
@@ -12,9 +12,9 @@ class NotificationTemplateWithPlatformsDtoMapper
     protected NotificationTemplateWithPlatformsDto convert(NotificationTemplate notificationTemplate) {
         return NotificationTemplateWithPlatformsDto.builder()
             .notificationTemplateMainInfoDto(
-                NotificationMappers.toNotificationTemplateMainInfoDto.apply(notificationTemplate))
+                NotificationMappers.toNotificationTemplateMainInfoDto(notificationTemplate))
             .platforms(notificationTemplate.getNotificationPlatforms().stream()
-                .map(NotificationMappers.toNotificationPlatformDto)
+                .map(NotificationMappers::toNotificationPlatformDto)
                 .toList())
             .build();
     }

--- a/service/src/main/java/greencity/mapping/notification/NotificationTemplateWithPlatformsDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/notification/NotificationTemplateWithPlatformsDtoMapper.java
@@ -1,13 +1,9 @@
 package greencity.mapping.notification;
 
-import greencity.dto.notification.NotificationPlatformDto;
-import greencity.dto.notification.NotificationTemplateMainInfoDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsDto;
 import greencity.entity.notifications.NotificationTemplate;
-import java.util.Objects;
 import org.modelmapper.AbstractConverter;
 import org.springframework.stereotype.Component;
-import java.util.stream.Collectors;
 
 @Component
 class NotificationTemplateWithPlatformsDtoMapper
@@ -15,37 +11,11 @@ class NotificationTemplateWithPlatformsDtoMapper
     @Override
     protected NotificationTemplateWithPlatformsDto convert(NotificationTemplate notificationTemplate) {
         return NotificationTemplateWithPlatformsDto.builder()
-            .notificationTemplateMainInfoDto(NotificationTemplateMainInfoDto.builder()
-                .type(notificationTemplate.getNotificationType())
-                .trigger(notificationTemplate.getTrigger())
-                .triggerDescriptionUk(notificationTemplate.getTrigger().getDescriptionUk())
-                .triggerDescriptionEn(notificationTemplate.getTrigger().getDescriptionEn())
-                .time(notificationTemplate.getTime())
-                .timeDescriptionUk(notificationTemplate.getTime().getDescriptionUk())
-                .timeDescriptionEn(notificationTemplate.getTime().getDescriptionEn())
-                .schedule(notificationTemplate.getSchedule())
-                .titleUk(notificationTemplate.getTitleUk())
-                .titleEn(notificationTemplate.getTitleEn())
-                .notificationStatus(notificationTemplate.getNotificationStatus())
-                .scheduleUpdateForbidden(notificationTemplate.isScheduleUpdateForbidden())
-                .userCategoryDescriptionUk(
-                    Objects.isNull(notificationTemplate.getUserCategory()) ? null
-                        : notificationTemplate.getUserCategory().getDescriptionUk())
-                .userCategoryDescriptionEn(Objects.isNull(notificationTemplate.getUserCategory()) ? null
-                    : notificationTemplate.getUserCategory().getDescriptionEn())
-                .build())
+            .notificationTemplateMainInfoDto(
+                NotificationMappers.toNotificationTemplateMainInfoDto.apply(notificationTemplate))
             .platforms(notificationTemplate.getNotificationPlatforms().stream()
-                .map(platform -> NotificationPlatformDto.builder()
-                    .id(platform.getId())
-                    .receiverType(platform.getNotificationReceiverType())
-                    .nameEn(platform
-                        .getNotificationReceiverType()
-                        .getName())
-                    .bodyUk(platform.getBodyUk())
-                    .bodyEn(platform.getBodyEn())
-                    .status(platform.getNotificationStatus())
-                    .build())
-                .collect(Collectors.toList()))
+                .map(NotificationMappers.toNotificationPlatformDto)
+                .toList())
             .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/notification/NotificationTemplateWithPlatformsUpdateDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/notification/NotificationTemplateWithPlatformsUpdateDtoMapper.java
@@ -22,7 +22,7 @@ public class NotificationTemplateWithPlatformsUpdateDtoMapper
                 .userCategory(notificationTemplate.getUserCategory())
                 .build())
             .platforms(notificationTemplate.getNotificationPlatforms().stream()
-                .map(NotificationMappers.toNotificationPlatformDto)
+                .map(NotificationMappers::toNotificationPlatformDto)
                 .toList())
             .build();
     }

--- a/service/src/main/java/greencity/mapping/notification/NotificationTemplateWithPlatformsUpdateDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/notification/NotificationTemplateWithPlatformsUpdateDtoMapper.java
@@ -1,10 +1,8 @@
 package greencity.mapping.notification;
 
-import greencity.dto.notification.NotificationPlatformDto;
 import greencity.dto.notification.NotificationTemplateUpdateInfoDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsUpdateDto;
 import greencity.entity.notifications.NotificationTemplate;
-import java.util.stream.Collectors;
 import org.modelmapper.AbstractConverter;
 import org.springframework.stereotype.Component;
 
@@ -24,17 +22,8 @@ public class NotificationTemplateWithPlatformsUpdateDtoMapper
                 .userCategory(notificationTemplate.getUserCategory())
                 .build())
             .platforms(notificationTemplate.getNotificationPlatforms().stream()
-                .map(platform -> NotificationPlatformDto.builder()
-                    .id(platform.getId())
-                    .receiverType(platform.getNotificationReceiverType())
-                    .nameEn(platform
-                        .getNotificationReceiverType()
-                        .getName())
-                    .bodyUk(platform.getBodyUk())
-                    .bodyEn(platform.getBodyEn())
-                    .status(platform.getNotificationStatus())
-                    .build())
-                .collect(Collectors.toList()))
+                .map(NotificationMappers.toNotificationPlatformDto)
+                .toList())
             .build();
     }
 }

--- a/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
@@ -29,7 +29,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -84,9 +83,9 @@ public class NotificationTemplateServiceImpl implements NotificationTemplateServ
     }
 
     private void updateNotificationTemplatePlatforms(List<NotificationPlatform> platforms,
-        List<NotificationPlatformDto> platformDtos) {
+        List<NotificationPlatformDto> platformDTOs) {
         for (NotificationPlatform platform : platforms) {
-            NotificationPlatformDto platformDto = platformDtos.stream()
+            NotificationPlatformDto platformDto = platformDTOs.stream()
                 .filter(dto -> dto.getId().equals(platform.getId()))
                 .findAny()
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOTIFICATION_PLATFORM_NOT_FOUND));
@@ -110,7 +109,7 @@ public class NotificationTemplateServiceImpl implements NotificationTemplateServ
         Page<NotificationTemplate> notificationTemplates = notificationTemplateRepository.findAll(pageRequest);
         List<NotificationTemplateDto> templateDtoList = notificationTemplates.stream()
             .map(notificationTemplate -> modelMapper.map(notificationTemplate, NotificationTemplateDto.class))
-            .collect(Collectors.toList());
+            .toList();
         return new PageableDto<>(
             templateDtoList,
             notificationTemplates.getTotalElements(),

--- a/service/src/test/java/greencity/mapping/notification/NotificationMappersTest.java
+++ b/service/src/test/java/greencity/mapping/notification/NotificationMappersTest.java
@@ -14,7 +14,7 @@ class NotificationMappersTest {
         NotificationTemplate notification = ModelUtils.TEST_NOTIFICATION_TEMPLATE;
 
         NotificationTemplateMainInfoDto dto =
-            NotificationMappers.toNotificationTemplateMainInfoDto.apply(notification);
+            NotificationMappers.toNotificationTemplateMainInfoDto(notification);
 
         assertEquals(notification.getNotificationType(), dto.getType());
         assertEquals(notification.getTrigger(), dto.getTrigger());
@@ -37,7 +37,7 @@ class NotificationMappersTest {
             .getNotificationPlatforms().getFirst();
 
         NotificationPlatformDto dto =
-            NotificationMappers.toNotificationPlatformDto.apply(platform);
+            NotificationMappers.toNotificationPlatformDto(platform);
 
         assertEquals(platform.getId(), dto.getId());
         assertEquals(platform.getNotificationReceiverType(), dto.getReceiverType());

--- a/service/src/test/java/greencity/mapping/notification/NotificationMappersTest.java
+++ b/service/src/test/java/greencity/mapping/notification/NotificationMappersTest.java
@@ -1,0 +1,49 @@
+package greencity.mapping.notification;
+
+import greencity.ModelUtils;
+import greencity.dto.notification.NotificationPlatformDto;
+import greencity.dto.notification.NotificationTemplateMainInfoDto;
+import greencity.entity.notifications.NotificationPlatform;
+import greencity.entity.notifications.NotificationTemplate;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NotificationMappersTest {
+    @Test
+    void toNotificationTemplateMainInfoDto_AllFields() {
+        NotificationTemplate notification = ModelUtils.TEST_NOTIFICATION_TEMPLATE;
+
+        NotificationTemplateMainInfoDto dto =
+            NotificationMappers.toNotificationTemplateMainInfoDto.apply(notification);
+
+        assertEquals(notification.getNotificationType(), dto.getType());
+        assertEquals(notification.getTrigger(), dto.getTrigger());
+        assertEquals(notification.getTrigger().getDescriptionUk(), dto.getTriggerDescriptionUk());
+        assertEquals(notification.getTrigger().getDescriptionEn(), dto.getTriggerDescriptionEn());
+        assertEquals(notification.getTime(), dto.getTime());
+        assertEquals(notification.getTime().getDescriptionUk(), dto.getTimeDescriptionUk());
+        assertEquals(notification.getTime().getDescriptionEn(), dto.getTimeDescriptionEn());
+        assertEquals(notification.getSchedule(), dto.getSchedule());
+        assertEquals(notification.getTitleUk(), dto.getTitleUk());
+        assertEquals(notification.getTitleEn(), dto.getTitleEn());
+        assertEquals(notification.getNotificationStatus(), dto.getNotificationStatus());
+        assertEquals(notification.getUserCategory().getDescriptionUk(), dto.getUserCategoryDescriptionUk());
+        assertEquals(notification.getUserCategory().getDescriptionEn(), dto.getUserCategoryDescriptionEn());
+    }
+
+    @Test
+    void toNotificationPlatformDto_AllFields() {
+        NotificationPlatform platform = ModelUtils.TEST_NOTIFICATION_TEMPLATE
+            .getNotificationPlatforms().getFirst();
+
+        NotificationPlatformDto dto =
+            NotificationMappers.toNotificationPlatformDto.apply(platform);
+
+        assertEquals(platform.getId(), dto.getId());
+        assertEquals(platform.getNotificationReceiverType(), dto.getReceiverType());
+        assertEquals(platform.getNotificationReceiverType().getName(), dto.getNameEn());
+        assertEquals(platform.getBodyUk(), dto.getBodyUk());
+        assertEquals(platform.getBodyEn(), dto.getBodyEn());
+        assertEquals(platform.getNotificationStatus(), dto.getStatus());
+    }
+}


### PR DESCRIPTION
### 🔗 **Issue:** [#8961](https://github.com/ita-social-projects/GreenCity/issues/8961)

This pull request refactors notification entity-to-DTO mapping logic by introducing a new utility class, `NotificationMappers`, which centralizes reusable mapping functions. The change improves code maintainability and reduces duplication across multiple mappers. Existing mappers are updated to use these new static mapping functions, and redundant mapping code is removed. Additionally, a dedicated test class is added to verify the correctness of the new mappers.

**Mapping logic centralization:**

* Introduced `NotificationMappers` utility class with static mapping functions for converting `NotificationTemplate` and `NotificationPlatform` entities to their respective DTOs (`NotificationTemplateMainInfoDto` and `NotificationPlatformDto`).

**Refactoring of existing mappers:**

* Updated `NotificationTemplateDtoMapper`, `NotificationTemplateWithPlatformsDtoMapper`, and `NotificationTemplateWithPlatformsUpdateDtoMapper` to use the new mapping functions from `NotificationMappers` instead of inline mapping logic. This removes duplicated code and streamlines mapping operations. [[1]](diffhunk://#diff-db698a5d10faabd5c4425b3490b8281390a6cd921b44c2f0fc202e4f68118b96L18-R16) [[2]](diffhunk://#diff-b6acabf58a9ed705a95dc8a2108424f2880fa0bbe860aba0b2600039896c54a4L3-R18) [[3]](diffhunk://#diff-73c4a1a19f1441d852f75756a9eaa4a3e09f6958265377d5f8275fbc557fa6baL27-R26)

**Testing improvements:**

* Added `NotificationMappersTest` to provide unit tests for the new static mapping functions, ensuring correct mapping of all relevant fields.

**Minor code cleanup:**

* Removed unused imports and replaced `.collect(Collectors.toList())` with `.toList()` in several locations for conciseness and clarity. [[1]](diffhunk://#diff-fa64df8e534c35d361c1beda03fb58cacdcfe9fb3955f1a588bfc6500734fbbaL32) [[2]](diffhunk://#diff-fa64df8e534c35d361c1beda03fb58cacdcfe9fb3955f1a588bfc6500734fbbaL113-R112)

**Parameter naming consistency:**

* Renamed method parameters for clarity, such as changing `platformDtos` to `platformDTOs` in `NotificationTemplateServiceImpl`.

✅ **This pull request closes** [#8961](https://github.com/ita-social-projects/GreenCity/issues/8961) **once merged.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced utility functions for mapping notification entities to their corresponding DTOs, improving consistency in notification data handling.

* **Refactor**
  * Simplified and centralized notification mapping logic across multiple components for improved maintainability and readability.

* **Tests**
  * Added unit tests to verify the accuracy of the new notification mapping functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->