### PR TITLE
Set API key as default value

### DIFF
--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -19,7 +19,7 @@ ribbon.ConnectTimeout=20000
 ribbon.ReadTimeout=20000
 
 
-greencity.authorization.googleApiKey=${GOOGLE_API_KEY:default-key}
+greencity.authorization.googleApiKey=${GOOGLE_API_KEY:AIzaSyBeM5jAn_6_Qyslj-SZJ7z2koyelyDMGoo}
 
 # Swagger configuration
 springdoc.paths-to-match=/**


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents startup errors and broken features relying on Google APIs when credentials are missing, ensuring more reliable behavior out of the box.
- Chores
  - Adjusted default configuration for Google integrations to supply a working fallback credential when no environment variable is set, improving first-run experience and reducing manual setup in development and test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->