### PR TITLE
8964 Introduce hibernate second level cache provider and apply it on translation tables

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -144,6 +144,10 @@
             <artifactId>hibernate-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-jcache</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
@@ -232,6 +236,12 @@
             <groupId>com.ivan.softserve</groupId>
             <artifactId>ldm-spring-boot-starter</artifactId>
             <version>${ldm.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+            <version>3.10.8</version>
+            <classifier>jakarta</classifier>
         </dependency>
     </dependencies>
 

--- a/core/src/main/resources/application-dev.properties
+++ b/core/src/main/resources/application-dev.properties
@@ -11,7 +11,7 @@ spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.properties.hibernate.cache.use_second_level_cache=true
 spring.jpa.properties.hibernate.cache.use_query_cache=true
 spring.jpa.properties.hibernate.cache.region.factory_class=org.hibernate.cache.jcache.internal.JCacheRegionFactory
-spring.jpa.properties.hibernate.javax.cache.uri=ehcache.xml
+spring.jpa.properties.hibernate.javax.cache.uri=classpath:ehcache.xml
 spring.jpa.properties.hibernate.javax.cache.provider=org.ehcache.jsr107.EhcacheCachingProvider
 
 # Liquibase

--- a/core/src/main/resources/application-dev.properties
+++ b/core/src/main/resources/application-dev.properties
@@ -8,6 +8,11 @@ server.port=8050
 # Hibernate
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.jpa.properties.hibernate.cache.use_second_level_cache=true
+spring.jpa.properties.hibernate.cache.use_query_cache=true
+spring.jpa.properties.hibernate.cache.region.factory_class=org.hibernate.cache.jcache.internal.JCacheRegionFactory
+spring.jpa.properties.hibernate.javax.cache.uri=ehcache.xml
+spring.jpa.properties.hibernate.javax.cache.provider=org.ehcache.jsr107.EhcacheCachingProvider
 
 # Liquibase
 spring.liquibase.url=${DATASOURCE_URL_UBS}

--- a/core/src/main/resources/application-docker.properties
+++ b/core/src/main/resources/application-docker.properties
@@ -11,7 +11,7 @@ spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.properties.hibernate.cache.use_second_level_cache=${HIBERNATE_L2C_ENABLED:true}
 spring.jpa.properties.hibernate.cache.use_query_cache=${HIBERNATE_L2C_ENABLED:true}
 spring.jpa.properties.hibernate.cache.region.factory_class=org.hibernate.cache.jcache.internal.JCacheRegionFactory
-spring.jpa.properties.hibernate.javax.cache.uri=ehcache.xml
+spring.jpa.properties.hibernate.javax.cache.uri=classpath:ehcache.xml
 spring.jpa.properties.hibernate.javax.cache.provider=org.ehcache.jsr107.EhcacheCachingProvider
 
 # Liquibase

--- a/core/src/main/resources/application-docker.properties
+++ b/core/src/main/resources/application-docker.properties
@@ -8,6 +8,11 @@ server.port=8050
 # Hibernate
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.jpa.properties.hibernate.cache.use_second_level_cache=${HIBERNATE_L2C_ENABLED:true}
+spring.jpa.properties.hibernate.cache.use_query_cache=${HIBERNATE_L2C_ENABLED:true}
+spring.jpa.properties.hibernate.cache.region.factory_class=org.hibernate.cache.jcache.internal.JCacheRegionFactory
+spring.jpa.properties.hibernate.javax.cache.uri=ehcache.xml
+spring.jpa.properties.hibernate.javax.cache.provider=org.ehcache.jsr107.EhcacheCachingProvider
 
 # Liquibase
 spring.liquibase.url=${DATASOURCE_URL}

--- a/core/src/main/resources/application-prod.properties
+++ b/core/src/main/resources/application-prod.properties
@@ -20,6 +20,11 @@ spring.liquibase.change-log=${LIQUIBASE_LOG}
 spring.jpa.hibernate.ddl-auto=${HIBERNATE_CONFIG}
 #spring.jpa.show-sql=${SHOW_SQL}
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=${JDBC_LOB}
+spring.jpa.properties.hibernate.cache.use_second_level_cache=${HIBERNATE_L2C_ENABLED:true}
+spring.jpa.properties.hibernate.cache.use_query_cache=${HIBERNATE_L2C_ENABLED:true}
+spring.jpa.properties.hibernate.cache.region.factory_class=org.hibernate.cache.jcache.internal.JCacheRegionFactory
+spring.jpa.properties.hibernate.javax.cache.uri=ehcache.xml
+spring.jpa.properties.hibernate.javax.cache.provider=org.ehcache.jsr107.EhcacheCachingProvider
 
 #RestTemplate
 greencity.redirect.user-server-address=https://greencity-user.greencity.cx.ua/

--- a/core/src/main/resources/application-prod.properties
+++ b/core/src/main/resources/application-prod.properties
@@ -23,7 +23,7 @@ spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=${JDBC_LOB}
 spring.jpa.properties.hibernate.cache.use_second_level_cache=${HIBERNATE_L2C_ENABLED:true}
 spring.jpa.properties.hibernate.cache.use_query_cache=${HIBERNATE_L2C_ENABLED:true}
 spring.jpa.properties.hibernate.cache.region.factory_class=org.hibernate.cache.jcache.internal.JCacheRegionFactory
-spring.jpa.properties.hibernate.javax.cache.uri=ehcache.xml
+spring.jpa.properties.hibernate.javax.cache.uri=classpath:ehcache.xml
 spring.jpa.properties.hibernate.javax.cache.provider=org.ehcache.jsr107.EhcacheCachingProvider
 
 #RestTemplate

--- a/core/src/main/resources/application-test.properties
+++ b/core/src/main/resources/application-test.properties
@@ -2,6 +2,11 @@
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.jpa.properties.hibernate.cache.use_second_level_cache=false
+spring.jpa.properties.hibernate.cache.use_query_cache=false
+spring.jpa.properties.hibernate.cache.region.factory_class=org.hibernate.cache.jcache.internal.JCacheRegionFactory
+spring.jpa.properties.hibernate.javax.cache.uri=ehcache.xml
+spring.jpa.properties.hibernate.javax.cache.provider=org.ehcache.jsr107.EhcacheCachingProvider
 
 #RestTemplate
 greencity.redirect.user-server-address=http://localhost:8060

--- a/core/src/main/resources/application-test.properties
+++ b/core/src/main/resources/application-test.properties
@@ -5,7 +5,7 @@ spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.properties.hibernate.cache.use_second_level_cache=false
 spring.jpa.properties.hibernate.cache.use_query_cache=false
 spring.jpa.properties.hibernate.cache.region.factory_class=org.hibernate.cache.jcache.internal.JCacheRegionFactory
-spring.jpa.properties.hibernate.javax.cache.uri=ehcache.xml
+spring.jpa.properties.hibernate.javax.cache.uri=classpath:ehcache.xml
 spring.jpa.properties.hibernate.javax.cache.provider=org.ehcache.jsr107.EhcacheCachingProvider
 
 #RestTemplate

--- a/core/src/main/resources/ehcache.xml
+++ b/core/src/main/resources/ehcache.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.ehcache.org/v3"
+        xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core.xsd">
+
+    <cache-template name="translation-entities">
+        <resources>
+            <heap>1000</heap>
+        </resources>
+    </cache-template>
+
+    <cache alias="greencity.entity.order.OrderStatusTranslation" uses-template="translation-entities"></cache>
+    <cache alias="greencity.entity.order.OrderPaymentStatusTranslation" uses-template="translation-entities"></cache>
+
+</config>

--- a/core/src/main/resources/ehcache.xml
+++ b/core/src/main/resources/ehcache.xml
@@ -3,6 +3,17 @@
         xmlns="http://www.ehcache.org/v3"
         xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core.xsd">
 
+    <default-copiers>
+        <copier type="java.lang.Object">org.ehcache.impl.copy.IdentityCopier</copier>
+    </default-copiers>
+
+    <cache alias="default-update-timestamps-region">
+        <expiry>
+            <ttl unit="minutes">5</ttl>
+        </expiry>
+        <heap>100</heap>
+    </cache>
+
     <cache-template name="translation-entities">
         <resources>
             <heap>1000</heap>

--- a/dao/src/main/java/greencity/entity/order/OrderPaymentStatusTranslation.java
+++ b/dao/src/main/java/greencity/entity/order/OrderPaymentStatusTranslation.java
@@ -1,5 +1,6 @@
 package greencity.entity.order;
 
+import jakarta.persistence.Cacheable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -10,8 +11,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/dao/src/main/java/greencity/entity/order/OrderStatusTranslation.java
+++ b/dao/src/main/java/greencity/entity/order/OrderStatusTranslation.java
@@ -1,5 +1,6 @@
 package greencity.entity.order;
 
+import jakarta.persistence.Cacheable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -10,8 +11,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 @Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/dao/src/main/java/greencity/repository/OrderPaymentStatusTranslationRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderPaymentStatusTranslationRepository.java
@@ -1,7 +1,10 @@
 package greencity.repository;
 
 import greencity.entity.order.OrderPaymentStatusTranslation;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.QueryHints;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -19,6 +22,7 @@ public interface OrderPaymentStatusTranslationRepository
      * @return {@link List}.
      * @author Yuriy Bahlay.
      */
+    @QueryHints(@QueryHint(name = "org.hibernate.cacheable", value = "true"))
     List<OrderPaymentStatusTranslation> getAllBy();
 
     /**
@@ -28,6 +32,7 @@ public interface OrderPaymentStatusTranslationRepository
      * @return {@link OrderPaymentStatusTranslation}.
      * @author Olet Postolovskyi.
      */
+    @QueryHints(@QueryHint(name = "org.hibernate.cacheable", value = "true"))
     Optional<OrderPaymentStatusTranslation> getOrderPaymentStatusTranslationById(Long id);
 
     /**

--- a/dao/src/main/java/greencity/repository/OrderPaymentStatusTranslationRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderPaymentStatusTranslationRepository.java
@@ -4,7 +4,6 @@ import greencity.entity.order.OrderPaymentStatusTranslation;
 import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.QueryHints;
-
 import java.util.List;
 import java.util.Optional;
 

--- a/dao/src/main/java/greencity/repository/OrderStatusTranslationRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderStatusTranslationRepository.java
@@ -1,7 +1,10 @@
 package greencity.repository;
 
 import greencity.entity.order.OrderStatusTranslation;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.QueryHints;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -18,6 +21,7 @@ public interface OrderStatusTranslationRepository extends JpaRepository<OrderSta
      * @return {@link OrderStatusTranslation}.
      * @author Oleksandr Khomiakov.
      */
+    @QueryHints(@QueryHint(name = "org.hibernate.cacheable", value = "true"))
     Optional<OrderStatusTranslation> getOrderStatusTranslationById(Long id);
 
     /**
@@ -27,5 +31,6 @@ public interface OrderStatusTranslationRepository extends JpaRepository<OrderSta
      *
      * @author Yuriy Bahlay.
      */
+    @QueryHints(@QueryHint(name = "org.hibernate.cacheable", value = "true"))
     List<OrderStatusTranslation> findAllBy();
 }

--- a/dao/src/main/java/greencity/repository/OrderStatusTranslationRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderStatusTranslationRepository.java
@@ -4,7 +4,6 @@ import greencity.entity.order.OrderStatusTranslation;
 import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.QueryHints;
-
 import java.util.List;
 import java.util.Optional;
 


### PR DESCRIPTION
### 🔗 **Issue:** [#8895](https://github.com/ita-social-projects/GreenCity/issues/8895)

This pull request introduces JCache with Ehcache provider for Hibernate 2nd Level Caching in order to cache results for mostly static translation tables and therefore improves performance for related requests, removing unneeded additional queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled second-level and query caching for faster data retrieval.
  * Added caches for order status and payment status translations.

* **Performance**
  * Reduced repeated database reads and improved response times via JCache/Ehcache.

* **Configuration**
  * Added profile-specific properties to enable/disable caching and point to the cache config.
  * Test profile keeps caching disabled.

* **Chores**
  * Added JCache/Ehcache provider dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->