### PR TITLE
Feature #1783 added LDM_SECRET_KEY and set cors_allow_origin in ingress config

### DIFF
--- a/greencity-ubs-chart/templates/greencity-ubs.yaml
+++ b/greencity-ubs-chart/templates/greencity-ubs.yaml
@@ -155,6 +155,12 @@ spec:
             secretKeyRef:
               name: {{ .Values.externalSecret.secretName }}
               key: GOOGLE-API-KEY
+
+        - name: LDM_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.externalSecret.secretName }}
+              key: LDM-SECRET-KEY
         
         - name: DOMAIN_NAME
           valueFrom:

--- a/greencity-ubs-chart/values.yaml
+++ b/greencity-ubs-chart/values.yaml
@@ -25,7 +25,7 @@ ingress:
   # Example: "https://origin-site.com:4443, http://origin-site.com, https://example.org:1199"
   # "https://*.origin-site.com:4443, http://*.origin-site.com"
   # If not set will be used "*" instead. Example: cors_allow_origin: ""
-  cors_allow_origin: ""
+  cors_allow_origin: "http://localhost:4200, https://www.greencity.cx.ua/"
 
   # Only when cors_allow_origin is not "*"
   cors_allow_credentials: "false"


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#1783](https://github.com/ita-social-projects/GreenCityUBS/issues/1783)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled cross-origin requests from http://localhost:4200 and https://www.greencity.cx.ua, improving browser access from these domains.

- Chores
  - Updated deployment configuration to include an additional environment variable sourced from a secret, with no changes to other environment settings.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->