### PR TITLE
Feature #1786 allowed only localhost in origin

### DIFF
--- a/greencity-ubs-chart/values.yaml
+++ b/greencity-ubs-chart/values.yaml
@@ -25,7 +25,7 @@ ingress:
   # Example: "https://origin-site.com:4443, http://origin-site.com, https://example.org:1199"
   # "https://*.origin-site.com:4443, http://*.origin-site.com"
   # If not set will be used "*" instead. Example: cors_allow_origin: ""
-  cors_allow_origin: "http://localhost:4200, http://localhost:4200/, https://www.greencity.cx.ua/"
+  cors_allow_origin: "http://localhost:4200"
 
   # Only when cors_allow_origin is not "*"
   cors_allow_credentials: "true"


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#1786](https://github.com/ita-social-projects/GreenCityUBS/issues/1786)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ingress CORS configuration to allow requests only from http://localhost:4200.
  * No changes to CORS enablement or credential settings.

* **Impact**
  * Cross-origin requests from domains other than http://localhost:4200 will be blocked.
  * Users accessing the app from previously allowed external domains may experience blocked requests or failed loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->