### PR TITLE
feature: add new opportunity search telegram chats by chatId, full name

### DIFF
--- a/dao/src/main/java/greencity/specification/ChatSpecifications.java
+++ b/dao/src/main/java/greencity/specification/ChatSpecifications.java
@@ -17,9 +17,9 @@ public class ChatSpecifications {
             String pattern = "%" + searchTerm.toLowerCase() + "%";
 
             Expression<String> chatId = cb.lower(root.get("chatId"));
-            Expression<String> firstName = cb.lower(root.get("firstName"));
-            Expression<String> lastName = cb.lower(root.get("lastName"));
-            Expression<String> username = cb.lower(root.get("username"));
+            Expression<String> firstName = cb.lower(cb.coalesce(root.get("firstName"), ""));
+            Expression<String> lastName = cb.lower(cb.coalesce(root.get("lastName"), ""));
+            Expression<String> username = cb.lower(cb.coalesce(root.get("username"), ""));
             Expression<String> fullNameFirstAndLast = cb.concat(cb.concat(firstName, " "), lastName);
             Expression<String> fullNameLastAndFirst = cb.concat(cb.concat(lastName, " "), firstName);
 

--- a/dao/src/main/java/greencity/specification/ChatSpecifications.java
+++ b/dao/src/main/java/greencity/specification/ChatSpecifications.java
@@ -24,13 +24,12 @@ public class ChatSpecifications {
             Expression<String> fullNameLastAndFirst = cb.concat(cb.concat(lastName, " "), firstName);
 
             return cb.or(
-                    cb.like(chatId, pattern),
-                    cb.like(firstName, pattern),
-                    cb.like(lastName, pattern),
-                    cb.like(username, pattern),
-                    cb.like(fullNameFirstAndLast, pattern),
-                    cb.like(fullNameLastAndFirst, pattern)
-            );
+                cb.like(chatId, pattern),
+                cb.like(firstName, pattern),
+                cb.like(lastName, pattern),
+                cb.like(username, pattern),
+                cb.like(fullNameFirstAndLast, pattern),
+                cb.like(fullNameLastAndFirst, pattern));
         };
     }
 

--- a/dao/src/main/java/greencity/specification/ChatSpecifications.java
+++ b/dao/src/main/java/greencity/specification/ChatSpecifications.java
@@ -9,17 +9,28 @@ import org.springframework.data.jpa.domain.Specification;
 
 public class ChatSpecifications {
     public static Specification<TelegramChat> hasNameLike(String searchTerm) {
-        return (root, query, criteriaBuilder) -> {
+        return (root, query, cb) -> {
             if (searchTerm == null || searchTerm.trim().isEmpty()) {
-                return criteriaBuilder.conjunction();
+                return cb.conjunction();
             }
 
             String pattern = "%" + searchTerm.toLowerCase() + "%";
 
-            return criteriaBuilder.or(
-                criteriaBuilder.like(criteriaBuilder.lower(root.get("firstName")), pattern),
-                criteriaBuilder.like(criteriaBuilder.lower(root.get("lastName")), pattern),
-                criteriaBuilder.like(criteriaBuilder.lower(root.get("username")), pattern));
+            Expression<String> chatId = cb.lower(root.get("chatId"));
+            Expression<String> firstName = cb.lower(root.get("firstName"));
+            Expression<String> lastName = cb.lower(root.get("lastName"));
+            Expression<String> username = cb.lower(root.get("username"));
+            Expression<String> fullNameFirstAndLast = cb.concat(cb.concat(firstName, " "), lastName);
+            Expression<String> fullNameLastAndFirst = cb.concat(cb.concat(lastName, " "), firstName);
+
+            return cb.or(
+                    cb.like(chatId, pattern),
+                    cb.like(firstName, pattern),
+                    cb.like(lastName, pattern),
+                    cb.like(username, pattern),
+                    cb.like(fullNameFirstAndLast, pattern),
+                    cb.like(fullNameLastAndFirst, pattern)
+            );
         };
     }
 


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#1782  ](https://github.com/ita-social-projects/GreenCityUBS/issues/1782)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded chat search to match across chat ID, first name, last name and username.
  * Supports full-name searches in both "First Last" and "Last First" orders.
  * Case-insensitive, partial matching for broader, more flexible results.
  * Improved null-safe handling so missing name parts won’t break searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->