### PR TITLE
Feature: 1792/Add number of completed orders to user order data

### DIFF
--- a/dao/src/main/java/greencity/repository/OrderRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderRepository.java
@@ -266,4 +266,13 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
      * @return an Optional containing the latest order, or empty if no orders exist
      */
     Optional<Order> findFirstByUserIdOrderByOrderDateDesc(Long userId);
+
+    /**
+     * Counts the number of orders with status DONE for a specific user.
+     *
+     * @param userId the ID of the user
+     * @param status the completed status (OrderStatus.DONE)
+     * @return the number of completed orders
+     */
+    Long countByUserIdAndOrderStatus(Long userId, OrderStatus status);
 }

--- a/service-api/src/main/java/greencity/dto/order/OrdersDataForUserDto.java
+++ b/service-api/src/main/java/greencity/dto/order/OrdersDataForUserDto.java
@@ -4,16 +4,13 @@ import greencity.dto.address.AddressInfoDto;
 import greencity.dto.bag.BagForUserDto;
 import greencity.dto.certificate.CertificateDto;
 import greencity.dto.notification.SenderInfoDto;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -39,4 +36,5 @@ public class OrdersDataForUserDto {
     private Set<String> additionalOrders;
     private SenderInfoDto sender;
     private AddressInfoDto address;
+    private Long completedOrdersCount;
 }

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
@@ -15,10 +15,7 @@ import greencity.entity.telegram.TelegramChat;
 import greencity.entity.telegram.TelegramManager;
 import greencity.entity.telegram.TelegramMessage;
 import greencity.entity.user.employee.Employee;
-import greencity.enums.AssetType;
-import greencity.enums.ChatState;
-import greencity.enums.MessageDeliveryStatus;
-import greencity.enums.MessageViewingStatus;
+import greencity.enums.*;
 import greencity.exceptions.NotFoundException;
 import greencity.producers.TelegramChatProducer;
 import greencity.exceptions.bots.TelegramBotExecutionException;
@@ -322,7 +319,13 @@ public class TelegramServiceImpl implements TelegramService {
 
         Order order = orderRepository.findFirstByUserIdOrderByOrderDateDesc(telegramChat.getUser().getId())
             .orElseThrow(() -> new NotFoundException("Order not found"));
-        return ubsClientService.getOrdersData(order);
+        OrdersDataForUserDto dto = ubsClientService.getOrdersData(order);
+        Long completedCount = orderRepository.countByUserIdAndOrderStatus(
+            telegramChat.getUser().getId(),
+            OrderStatus.DONE);
+        dto.setCompletedOrdersCount(completedCount);
+
+        return dto;
     }
 
     /**


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#1792 ](https://github.com/ita-social-projects/GreenCityUBS/issues/1792)

Add a new field completedOrdersCount to the OrdersDataForUserDto class. This field will store the total number of completed orders for the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The Telegram bot now displays the number of completed orders when showing your latest order details.
  - Order summaries for users include a completed orders count, providing a clearer view of order history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->