### PR TITLE
Test #1790 replaced rendering cors-allow-origin from variable to hardcoded value because of a wrong rendering of the value

### DIFF
--- a/greencity-ubs-chart/templates/ingress-ubs.yaml
+++ b/greencity-ubs-chart/templates/ingress-ubs.yaml
@@ -6,17 +6,9 @@ metadata:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/proxy-body-size: 150m
-{{- if .Values.ingress.enable_cors}}
     nginx.ingress.kubernetes.io/enable-cors: "true"
-    {{- if eq .Values.ingress.cors_allow_origin "" }}  
-    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
-    {{- else }}
-    nginx.ingress.kubernetes.io/cors-allow-origin: {{ .Values.ingress.cors_allow_origin }} 
-    {{- end }}
-    {{- if eq .Values.ingress.cors_allow_credentials "true" }}
+    nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:4200, https://www.greencity.cx.ua"
     nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
-    {{- end }}
-{{- end }}
 spec:
   tls:
   - hosts:

--- a/greencity-ubs-chart/values.yaml
+++ b/greencity-ubs-chart/values.yaml
@@ -20,15 +20,5 @@ service:
 # https://kubernetes.github.io/ingress-nginx/deploy/
 # https://cert-manager.io/docs/installation/helm/#3-install-customresourcedefinitions
 ingress:
-  enable_cors: true
-
-  # Example: "https://origin-site.com:4443, http://origin-site.com, https://example.org:1199"
-  # "https://*.origin-site.com:4443, http://*.origin-site.com"
-  # If not set will be used "*" instead. Example: cors_allow_origin: ""
-  cors_allow_origin: "http://localhost:4200"
-
-  # Only when cors_allow_origin is not "*"
-  cors_allow_credentials: "true"
-
   hostname: greencity-ubs.greencity.cx.ua
   


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#1790](https://github.com/ita-social-projects/GreenCityUBS/issues/1790)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Cross-origin requests are now consistently enabled with a fixed allowlist: http://localhost:4200 and https://www.greencity.cx.ua. Cookies/credentials are supported for these origins.

- Chores
  - Simplified ingress configuration by removing CORS-related settings from deployment values; CORS behavior is now predefined.
  - This may affect custom deployments that previously relied on configurable CORS options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->