### PR TITLE
Bugfix #8991 - Update security configuration to allow unregistered users to access tariff info on the first page

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -109,6 +109,7 @@ public class SecurityConfig {
                     UBS_LINK + "/tariffs/{locationId}",
                     USER_AGREEMENT_LINK + "/latest",
                     UBS_LINK + "/districts-for-kyiv",
+                    UBS_LINK + "/order-details-for-tariff",
                     COMMIT_INFO)
                 .permitAll()
                 .requestMatchers("/v2/api-docs/**",

--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -77,7 +77,7 @@ public class OrderController {
      * @return {@link UserPointsAndAllBagsDto}.
      * @author SafarovRenat
      */
-    @Operation(summary = "Get order points by details")
+    @Operation(summary = "Get details for the given tariff and location")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
             content = @Content(schema = @Schema(implementation = UserPointsAndAllBagsDto.class))),

--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -70,8 +70,7 @@ public class OrderController {
     private final RedirectionConfigProp redirectionConfigProp;
 
     /**
-     * Controller returns all available bags and bonus points of current user by
-     * tariff and location ids.
+     * Controller returns all available bags by tariff and location ids.
      *
      * @param tariffId   - id of tariff.
      * @param locationId - id of location.

--- a/service-api/src/main/java/greencity/service/ubs/UBSClientService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSClientService.java
@@ -50,7 +50,7 @@ public interface UBSClientService {
     PaymentResponseWayForPay validatePayment(PaymentResponseDto response);
 
     /**
-     * Methods returns all available for order bags and current user's bonus points.
+     * Method returns all bags available for order.
      *
      * @param tariffId   {@link Long} tariff id.
      * @param locationId {@link Long} location id.


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link :clipboard:
[#8991](https://github.com/ita-social-projects/GreenCity/issues/8991)

## Summary Of Changes :fire:
* Updated `SecurityConfig` to allow everyone to access tariff info on the first page.
* Updated Javadocs for controller and service methods to reflect existing functionality, since the implementation does not take the user’s actual points into account.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - View order details by tariff and location without signing in (read-only GET access).
- **Documentation**
  - Clarified API/docs: responses list available bags for order; user bonus points are no longer described as included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->