### PR TITLE
Bugfix/1800 hide start command from manager

### DIFF
--- a/service/src/main/java/greencity/ubstelegrambot/messages/MessageFactory.java
+++ b/service/src/main/java/greencity/ubstelegrambot/messages/MessageFactory.java
@@ -402,6 +402,18 @@ public class MessageFactory {
     }
 
     /**
+     * Method for creating a message for the user when the chat with the manager is
+     * already open.
+     *
+     * @param chatId {@link String} is the Telegram chat ID.
+     * @param lang   {@link String} is the language code of the Telegram chat.
+     * @return {@link SendMessage} configured with the chat already open message.
+     */
+    public static SendMessage createChatAlreadyOpenMessage(String chatId, String lang) {
+        return buildMessage(chatId, MessageProvider.get(lang, "manager.chat.already.open.message"));
+    }
+
+    /**
      * Builds a SendMessage object with the specified chat ID and text.
      *
      * @param chatId the telegram chat ID

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -73,11 +73,11 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
 
         TelegramChat chat = optionalChat.get();
 
-        if (message.hasText() && message.getText().startsWith("/start")) {
-            if (chat.getChatState() == ChatState.IN_SUPPORT) {
-                log.info("User is already in support chat {}. Filtering system /start message", chat.getChatId());
-                return MessageFactory.createChatAlreadyOpenMessage(chat.getChatId(), lang);
-            }
+        if (message.hasText()
+            && message.getText().startsWith("/start")
+            && chat.getChatState() == ChatState.IN_SUPPORT) {
+            log.info("User is already in support chat {}. Filtering system /start message", chat.getChatId());
+            return MessageFactory.createChatAlreadyOpenMessage(chat.getChatId(), lang);
         }
 
         if (message.hasText() && message.getText().contains(MessageProvider.get(lang, "client.end.support.mode"))) {

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -73,6 +73,13 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
 
         TelegramChat chat = optionalChat.get();
 
+        if (message.hasText() && message.getText().startsWith("/start")) {
+            if (chat.getChatState() == ChatState.IN_SUPPORT) {
+                log.info("User is already in support chat {}. Filtering system /start message", chat.getChatId());
+                return MessageFactory.createChatAlreadyOpenMessage(chat.getChatId(), lang);
+            }
+        }
+
         if (message.hasText() && message.getText().contains(MessageProvider.get(lang, "client.end.support.mode"))) {
             SendMessage endSupportSendMessage =
                 telegramUtils.updateChatStateAndRespond(chat.getChatId(), ChatState.NORMAL,

--- a/service/src/main/resources/messages_en.yaml
+++ b/service/src/main/resources/messages_en.yaml
@@ -132,3 +132,4 @@ previous.session.expired: "Previous session expired. Please choose a command fro
 photo.content: "Photo content"
 login.failed: "Incorrect login or password. Please check your credentials and try again."
 client.support.message.change.language: "Language was switched"
+manager.chat.already.open.message: "Chat with manager is already open. You can send a message whenever you're ready."

--- a/service/src/main/resources/messages_uk.yaml
+++ b/service/src/main/resources/messages_uk.yaml
@@ -132,3 +132,4 @@ previous.session.expired: "Час попередньої сесії минув. 
 photo.content: "Фото контент"
 login.failed: "Неправильний логін або пароль. Перевірте введені дані та спробуйте ще раз."
 client.support.message.change.language: "Мова змінена"
+manager.chat.already.open.message: "Чат із менеджером уже відкрито. Ви можете залишити своє повідомлення, коли будете готові."

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
@@ -606,4 +606,33 @@ class TelegramSupportServiceTest {
         verify(userRemoteWebClient).uploadFile(any(MultipartFile.class));
         verify(messageAssetRepository).save(any(MessageAsset.class));
     }
+
+    @Test
+    void testProcessSupportMessage_StartCommandWhileInSupport_ShouldReturnAlreadyOpenMessage() {
+        String chatId = "123";
+        String lang = TelegramBotConstants.UK;
+
+        Message message = mock(Message.class);
+        User user = mock(User.class);
+        when(message.getFrom()).thenReturn(user);
+        when(user.getId()).thenReturn(123L);
+        when(message.hasText()).thenReturn(true);
+        when(message.getText()).thenReturn("/start");
+
+        TelegramChat chatEntity = TelegramChat.builder()
+            .chatId(chatId)
+            .chatState(ChatState.IN_SUPPORT)
+            .build();
+        when(telegramChatRepository.findByChatId(chatId))
+            .thenReturn(Optional.of(chatEntity));
+
+        SendMessage result = telegramSupportService.processSupportMessage(message, lang);
+
+        assertNotNull(result);
+        assertEquals(chatId, result.getChatId());
+        assertTrue(result.getText()
+            .contains(MessageProvider.get(lang, "manager.chat.already.open.message")));
+
+        verify(telegramChatRepository).findByChatId(chatId);
+    }
 }


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#1800 ](https://github.com/ita-social-projects/GreenCityUBS/issues/1800)

When a user is already in an active support chat and presses the Telegram button in their personal account, the /start + uuid system command is now correctly filtered out from the manager’s chat view.
Instead, the user automatically receives a notification indicating that their support chat is already active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bot now notifies users that a support chat is already open when sending /start during an active session.
  * Localized notice added in English and Ukrainian.

* **Bug Fixes**
  * Prevents further processing of the /start command during an active support session.
  * Fixed formatting issue in the Ukrainian translations.

* **Tests**
  * Added a unit test covering the /start-while-in-support scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->