### PR TITLE
Bugfix - Added access for multiple requests in security config

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -284,7 +284,10 @@ public class SecurityConfig {
                     UBS_LINK + "/check-if-tariff-exists/{id}",
                     UBS_LINK + "/locations",
                     LOGS_LINKS,
-                    EXPORT_SETTINGS_LINKS)
+                    EXPORT_SETTINGS_LINKS,
+                    UBS_LINK + "/findAll-order-address",
+                    UBS_LINK + "/order-details-for-tariff",
+                    UBS_LINK + "/personal-data")
                 .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.GET,
                     TELEGRAM_LINK + "/**",


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/8996">#8996</a>
<a href="https://github.com/ita-social-projects/GreenCity/issues/8997">#8997</a>
<a href="https://github.com/ita-social-projects/GreenCity/issues/8998">#8998</a>

## Changed
- Added access for /findAll-order-address.
- Added access for /order-details-for-tariff.
- Added access for /personal-data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded read-only access in the UBS module for authorized roles (User, Admin, UBS Employee). Eligible users can now view:
    - Order addresses
    - Order details by tariff
    - Personal data
  * Improves availability of key UBS information without changing existing permissions or other routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->