### PR TITLE
Bugfix #8952 - Implement status check for notifications

### DIFF
--- a/service-api/src/main/java/greencity/client/UserRemoteClient.java
+++ b/service-api/src/main/java/greencity/client/UserRemoteClient.java
@@ -53,6 +53,15 @@ public interface UserRemoteClient {
     boolean checkIfUserExistsByUuid(@RequestParam(UUID) String uuid);
 
     /**
+     * Method checks the existence of an active user by uuid.
+     *
+     * @param uuid {@link User}'s UUID.
+     * @return {@link Boolean}
+     */
+    @GetMapping("user/checkActiveUserByUuid")
+    boolean checkIfActiveUserExistsByUuid(@RequestParam(UUID) String uuid);
+
+    /**
      * Gets user's positions and all possible related authorities to these positions
      * by user's email.
      *

--- a/service-api/src/main/java/greencity/client/UserRemoteClient.java
+++ b/service-api/src/main/java/greencity/client/UserRemoteClient.java
@@ -58,7 +58,7 @@ public interface UserRemoteClient {
      * @param uuid {@link User}'s UUID.
      * @return {@link Boolean}
      */
-    @GetMapping("user/checkActiveUserByUuid")
+    @GetMapping("/user/checkActiveUserByUuid")
     boolean checkIfActiveUserExistsByUuid(@RequestParam(UUID) String uuid);
 
     /**

--- a/service-api/src/main/java/greencity/client/config/UserRemoteClientFallbackFactory.java
+++ b/service-api/src/main/java/greencity/client/config/UserRemoteClientFallbackFactory.java
@@ -36,6 +36,11 @@ public class UserRemoteClientFallbackFactory implements FallbackFactory<UserRemo
             }
 
             @Override
+            public boolean checkIfActiveUserExistsByUuid(String uuid) {
+                throw new RemoteServerUnavailableException(ErrorMessage.COULD_NOT_RETRIEVE_USER_DATA, throwable);
+            }
+
+            @Override
             public void markUserDeactivated(String uuid, DeactivateUserRequestDto request) {
                 throw new RemoteServerUnavailableException(ErrorMessage.USER_HAS_NOT_BEEN_DEACTIVATED, throwable);
             }

--- a/service-api/src/test/java/greencity/client/config/UserRemoteClientFallbackFactoryTest.java
+++ b/service-api/src/test/java/greencity/client/config/UserRemoteClientFallbackFactoryTest.java
@@ -45,6 +45,11 @@ class UserRemoteClientFallbackFactoryTest {
     }
 
     @Test
+    void checkIfActiveUserExistsByUuid() {
+        assertThrows(RemoteServerUnavailableException.class, () -> client.checkIfActiveUserExistsByUuid(USER_UUID));
+    }
+
+    @Test
     void markUserDeactivated() {
         DeactivateUserRequestDto request = DeactivateUserRequestDto.builder()
             .reason("test")

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -697,13 +697,15 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     private void fillAndSendCustomNotification(User user, Long templateId) {
-        UserNotification userNotification = new UserNotification();
-        userNotification.setNotificationType(NotificationType.CUSTOM);
-        userNotification.setTemplateId(templateId);
-        userNotification.setUser(user);
-        UserNotification created = userNotificationRepository.save(userNotification);
-        created.setParameters(new HashSet<>());
-        sendNotificationsForBotsAndEmail(created, 0L);
+        if (isUserActive(user)) {
+            UserNotification userNotification = new UserNotification();
+            userNotification.setNotificationType(NotificationType.CUSTOM);
+            userNotification.setTemplateId(templateId);
+            userNotification.setUser(user);
+            UserNotification created = userNotificationRepository.save(userNotification);
+            created.setParameters(new HashSet<>());
+            sendNotificationsForBotsAndEmail(created, 0L);
+        }
     }
 
     /**
@@ -1079,14 +1081,21 @@ public class NotificationServiceImpl implements NotificationService {
 
     private void fillAndSendNotification(Set<NotificationParameter> parameters, Order order,
         NotificationType notificationType) {
+        User user = order.getUser();
         UserNotification userNotification = new UserNotification();
-        userNotification.setNotificationType(notificationType);
-        userNotification.setUser(order.getUser());
-        userNotification.setOrder(order);
-        UserNotification created = userNotificationRepository.save(userNotification);
-        parameters.forEach(parameter -> parameter.setUserNotification(created));
-        List<NotificationParameter> notificationParameters = notificationParameterRepository.saveAll(parameters);
-        created.setParameters(new HashSet<>(notificationParameters));
-        sendNotificationsForBotsAndEmail(created, 0L);
+        if (isUserActive(user)) {
+            userNotification.setNotificationType(notificationType);
+            userNotification.setUser(user);
+            userNotification.setOrder(order);
+            UserNotification created = userNotificationRepository.save(userNotification);
+            parameters.forEach(parameter -> parameter.setUserNotification(created));
+            List<NotificationParameter> notificationParameters = notificationParameterRepository.saveAll(parameters);
+            created.setParameters(new HashSet<>(notificationParameters));
+            sendNotificationsForBotsAndEmail(created, 0L);
+        }
+    }
+
+    private boolean isUserActive(User user) {
+        return userRemoteClient.checkIfActiveUserExistsByUuid(user.getUuid());
     }
 }

--- a/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationServiceImpl.java
@@ -1082,8 +1082,8 @@ public class NotificationServiceImpl implements NotificationService {
     private void fillAndSendNotification(Set<NotificationParameter> parameters, Order order,
         NotificationType notificationType) {
         User user = order.getUser();
-        UserNotification userNotification = new UserNotification();
         if (isUserActive(user)) {
+            UserNotification userNotification = new UserNotification();
             userNotification.setNotificationType(notificationType);
             userNotification.setUser(user);
             userNotification.setOrder(order);

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -257,6 +257,7 @@ class NotificationServiceImplTest {
             created.setId(1L);
             created.setOrder(orders.getFirst());
 
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
             when(userNotificationRepository.save(any())).thenReturn(created);
 
             Set<NotificationParameter> notificationParameters = Set.of(
@@ -339,12 +340,13 @@ class NotificationServiceImplTest {
         @Test
         @SneakyThrows
         void testNotifyPaidOrder() {
-            Order order = Order.builder().id(1L).build();
+            Order order = Order.builder().id(1L).user(getUser()).build();
             NotificationParameter orderNumber = NotificationParameter.builder()
                 .key("orderNumber")
                 .value(order.getId().toString())
                 .build();
             when(notificationParameterRepository.saveAll(Set.of(orderNumber))).thenReturn(List.of(orderNumber));
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
             when(userNotificationRepository.save(any())).thenReturn(TEST_USER_NOTIFICATION);
 
             notificationService.notifyPaidOrder(order);
@@ -357,9 +359,12 @@ class NotificationServiceImplTest {
         @Test
         void testNotifyUnpaidOrderPermanently() {
             long amountToPay = 10000L;
+            User user = getUser();
 
             when(mockOrder.getOrderPaymentStatus()).thenReturn(OrderPaymentStatus.UNPAID);
             when(mockUserNotification.getOrder()).thenReturn(mockOrder);
+            when(mockOrder.getUser()).thenReturn(user);
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
             when(userNotificationRepository.save(any(UserNotification.class))).thenReturn(mockUserNotification);
             when(notificationParameterRepository.saveAll(any())).thenAnswer(
                 invocation -> new ArrayList<>(invocation.getArgument(0)));
@@ -394,6 +399,7 @@ class NotificationServiceImplTest {
             UserNotification userNotification = getInternallyFormedOrderUserNotification(order);
 
             List<NotificationParameter> parameters = courierInternallyFormedParameters(order);
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
             when(userNotificationRepository.save(any())).thenReturn(userNotification);
 
             parameters.forEach(parameter -> parameter.setUserNotification(userNotification));
@@ -416,6 +422,7 @@ class NotificationServiceImplTest {
             when(orderRepository.findAllByOrderStatusAndOrderPaymentStatus(
                 OrderStatus.ADJUSTMENT, OrderPaymentStatus.PAID)).thenReturn(orders);
 
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
             when(userNotificationRepository.save(any())).thenReturn(userNotification);
 
             parameters.forEach(parameter -> parameter.setUserNotification(userNotification));
@@ -460,6 +467,7 @@ class NotificationServiceImplTest {
             TEST_NOTIFICATION_PARAMETER_SET
                 .forEach(parameter -> parameter.setUserNotification(TEST_USER_NOTIFICATION_2));
 
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
             when(notificationParameterRepository.saveAll(TEST_NOTIFICATION_PARAMETER_SET))
                 .thenReturn(new LinkedList<>(TEST_NOTIFICATION_PARAMETER_SET));
 
@@ -486,6 +494,7 @@ class NotificationServiceImplTest {
             TEST_NOTIFICATION_PARAMETER_SET2
                 .forEach(parameter -> parameter.setUserNotification(TEST_USER_NOTIFICATION_5));
 
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
             when(notificationParameterRepository.saveAll(TEST_NOTIFICATION_PARAMETER_SET2))
                 .thenReturn(new LinkedList<>(TEST_NOTIFICATION_PARAMETER_SET2));
 
@@ -523,6 +532,7 @@ class NotificationServiceImplTest {
             Violation violation = TEST_VIOLATION.setOrder(TEST_ORDER_4);
             when(violationRepository.findActiveViolationByOrderId(TEST_ORDER_4.getId()))
                 .thenReturn(Optional.of(violation));
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
             when(userNotificationRepository.save(TEST_USER_NOTIFICATION_3)).thenReturn(TEST_USER_NOTIFICATION_3);
             parameters.forEach(p -> p.setUserNotification(TEST_USER_NOTIFICATION_3));
             when(notificationParameterRepository.saveAll(parameters)).thenReturn(new LinkedList<>(parameters));
@@ -541,6 +551,7 @@ class NotificationServiceImplTest {
                 .value("46")
                 .build());
             Violation violation = TEST_VIOLATION.setOrder(TEST_ORDER_4);
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
             when(userNotificationRepository.save(TEST_USER_NOTIFICATION_6)).thenReturn(TEST_USER_NOTIFICATION_6);
             parameters.forEach(p -> p.setUserNotification(TEST_USER_NOTIFICATION_6));
             when(notificationParameterRepository.saveAll(parameters)).thenReturn(new LinkedList<>(parameters));
@@ -561,6 +572,7 @@ class NotificationServiceImplTest {
             Violation violation = TEST_VIOLATION.setOrder(TEST_ORDER_4);
             when(violationRepository.findCanceledViolationByOrderId(TEST_ORDER_4.getId()))
                 .thenReturn(Optional.of(violation));
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
             when(userNotificationRepository.save(TEST_USER_NOTIFICATION_7)).thenReturn(TEST_USER_NOTIFICATION_7);
             parameters.forEach(p -> p.setUserNotification(TEST_USER_NOTIFICATION_7));
             when(notificationParameterRepository.saveAll(parameters)).thenReturn(new LinkedList<>(parameters));
@@ -584,6 +596,7 @@ class NotificationServiceImplTest {
                 .thenReturn(orders);
             when(violationRepository.findActiveViolationByOrderId(anyLong())).thenReturn(Optional.of(violation));
             mockFillAndSendNotification(parameters, order, NotificationType.VIOLATION_THE_RULES);
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
 
             notificationService.notifyAllAddedViolations();
 
@@ -636,6 +649,7 @@ class NotificationServiceImplTest {
             when(orderRepository.findAllWithEventsByEventNames(CHANGES_VIOLATION_UK, DELETE_VIOLATION_UK))
                 .thenReturn(orders);
             mockFillAndSendNotification(parameters, order, NotificationType.CHANGED_IN_RULE_VIOLATION_STATUS);
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
 
             notificationService.notifyAllChangedViolations();
 
@@ -669,6 +683,7 @@ class NotificationServiceImplTest {
             when(orderRepository.findAllWithEventsByEventNames(DELETE_VIOLATION_UK)).thenReturn(orders);
             mockFillAndSendNotification(parameters, order,
                 NotificationType.CANCELED_VIOLATION_THE_RULES_BY_THE_MANAGER);
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
 
             notificationService.notifyAllCanceledViolations();
 
@@ -699,6 +714,7 @@ class NotificationServiceImplTest {
                 List.of(OrderStatus.DONE, OrderStatus.CANCELED))).thenReturn(orders);
             when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
             mockFillAndSendNotification(parameters, order, NotificationType.DONE_OR_CANCELED_UNPAID_ORDER);
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
 
             notificationService.notifyAllDoneOrCanceledUnpaidOrders();
 
@@ -734,6 +750,7 @@ class NotificationServiceImplTest {
             when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
             mockFillAndSendNotification(parameters, order,
                 NotificationType.HALF_PAID_ORDER_WITH_STATUS_BROUGHT_BY_HIMSELF);
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
 
             notificationService.notifyAllHalfPaidOrdersWithStatusBroughtByHimself();
 
@@ -753,6 +770,7 @@ class NotificationServiceImplTest {
             mockUserNeedNotificationCheck(order, NotificationType.ORDER_STATUS_CHANGED);
             when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
             mockFillAndSendNotification(parameters, order, NotificationType.ORDER_STATUS_CHANGED);
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
 
             notificationService.notifyAllChangedOrderStatuses();
 
@@ -788,6 +806,7 @@ class NotificationServiceImplTest {
             mockUserNeedNotificationCheck(order, NotificationType.UNPAID_PACKAGE);
             when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
             mockFillAndSendNotification(parameters, order, NotificationType.UNPAID_PACKAGE);
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
 
             notificationService.notifyUnpaidPackages();
 
@@ -829,6 +848,7 @@ class NotificationServiceImplTest {
             when(orderRepository.findAllUnpaidOrdersWithUsersByBagId(anyInt())).thenReturn(orders);
             when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
             mockFillAndSendNotification(parameters, order, NotificationType.TARIFF_PRICE_WAS_CHANGED);
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
 
             notificationService.notifyAllOrdersWithIncreasedTariffPrice(anyInt());
             verify(orderRepository).findAllUnpaidOrdersWithUsersByBagId(any());
@@ -921,6 +941,7 @@ class NotificationServiceImplTest {
             userNotification.setTemplateId(templateId);
 
             when(userRepository.findAll(any(UserSpecification.class))).thenReturn(Collections.singletonList(user));
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
             when(userNotificationRepository.save(any())).thenReturn(userNotification);
 
             notificationService.notifyCustom(templateId, UserCategory.USERS_WITH_ORDERS_MADE_LESS_THAN_3_MONTHS);
@@ -1037,6 +1058,8 @@ class NotificationServiceImplTest {
             notification.setUser(user);
             notification.setOrder(orders.getFirst());
             notification.setNotificationTime(LocalDateTime.now(fixedClock).minusWeeks(2));
+
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
 
             when(userNotificationRepository.findFirstByOrderIdAndNotificationTypeInOrderByNotificationTimeDesc(
                 orders.get(0).getId(),
@@ -1476,6 +1499,7 @@ class NotificationServiceImplTest {
         notification.setOrder(order);
 
         when(userNotificationRepository.save(any())).thenReturn(notification);
+        when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
         when(notificationParameterRepository.saveAll(any())).thenReturn(new ArrayList<>(new HashSet<>()));
         when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
         notificationService.notifyUnpaidOrder(order, PAYMENT_LINK);
@@ -1504,6 +1528,7 @@ class NotificationServiceImplTest {
         notification.setUser(user);
         notification.setOrder(order);
 
+        when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
         when(userNotificationRepository.save(any())).thenReturn(notification);
         when(notificationParameterRepository.saveAll(any())).thenReturn(new ArrayList<>(new HashSet<>()));
         when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
@@ -1534,6 +1559,7 @@ class NotificationServiceImplTest {
         notification.setUser(user);
         notification.setOrder(order);
 
+        when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
         when(userNotificationRepository.save(any())).thenReturn(notification);
         when(notificationParameterRepository.saveAll(any())).thenReturn(new ArrayList<>(new HashSet<>()));
         when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
@@ -1564,6 +1590,7 @@ class NotificationServiceImplTest {
         notification.setUser(user);
         notification.setOrder(order);
 
+        when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
         when(userNotificationRepository.save(any())).thenReturn(notification);
         when(notificationParameterRepository.saveAll(any())).thenReturn(new ArrayList<>(new HashSet<>()));
         when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
@@ -1590,6 +1617,7 @@ class NotificationServiceImplTest {
         notification.setUser(user);
         notification.setOrder(order);
 
+        when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
         when(userNotificationRepository.save(any())).thenReturn(notification);
         when(notificationParameterRepository.saveAll(any())).thenReturn(new ArrayList<>(new HashSet<>()));
         when(orderBagService.findAllBagsByOrderId(any())).thenReturn(getBag4list());
@@ -1669,6 +1697,7 @@ class NotificationServiceImplTest {
             .userNotification(notification)
             .build());
 
+        when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
         when(userNotificationRepository.save(any())).thenReturn(notification);
         when(notificationParameterRepository.saveAll(any())).thenReturn(new ArrayList<>(parameters));
 
@@ -1720,6 +1749,7 @@ class NotificationServiceImplTest {
                 .value(newOrder.getUser().getRecipientName())
                 .build());
 
+        when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
         when(userNotificationRepository.save(any())).thenReturn(notification);
         when(notificationParameterRepository.saveAll(any())).thenReturn(new ArrayList<>(parameters));
 
@@ -1760,6 +1790,7 @@ class NotificationServiceImplTest {
         notification.setUser(user);
         notification.setOrder(order);
 
+        when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(true);
         when(userNotificationRepository.save(any())).thenReturn(notification);
         when(notificationParameterRepository.saveAll(any())).thenReturn(new ArrayList<>(new HashSet<>()));
 

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -697,8 +697,6 @@ class NotificationServiceImplTest {
             Order order = TEST_ORDER_4;
             List<Order> orders = Collections.singletonList(order);
             setEventsToOrder(order, DELETE_VIOLATION_UK);
-            Set<NotificationParameter> parameters = getViolationParameter(order);
-
             mockUserNeedNotificationCheck(order, NotificationType.CANCELED_VIOLATION_THE_RULES_BY_THE_MANAGER);
             when(orderRepository.findAllWithEventsByEventNames(DELETE_VIOLATION_UK)).thenReturn(orders);
             when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(false);

--- a/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationServiceImplTest.java
@@ -692,6 +692,22 @@ class NotificationServiceImplTest {
             verifyFillAndSendNotification();
         }
 
+        @Test
+        void testNotifyAllCanceledViolationsForInactiveUser() {
+            Order order = TEST_ORDER_4;
+            List<Order> orders = Collections.singletonList(order);
+            setEventsToOrder(order, DELETE_VIOLATION_UK);
+            Set<NotificationParameter> parameters = getViolationParameter(order);
+
+            mockUserNeedNotificationCheck(order, NotificationType.CANCELED_VIOLATION_THE_RULES_BY_THE_MANAGER);
+            when(orderRepository.findAllWithEventsByEventNames(DELETE_VIOLATION_UK)).thenReturn(orders);
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(any())).thenReturn(false);
+
+            notificationService.notifyAllCanceledViolations();
+
+            verify(userNotificationRepository, never()).save(any());
+        }
+
         private Set<NotificationParameter> getViolationParameter(Order order) {
             Set<NotificationParameter> parameters = new HashSet<>();
             parameters.add(NotificationParameter.builder()
@@ -948,6 +964,20 @@ class NotificationServiceImplTest {
 
             verify(userNotificationRepository).save(any());
             verify(userRepository).findAll(any(UserSpecification.class));
+        }
+
+        @Test
+        void testNotifyCustomForInactiveUser() {
+            User user = TEST_USER;
+            List<User> userList = List.of(user);
+
+            when(userRepository.findAll(any(UserSpecification.class))).thenReturn(userList);
+            when(userRemoteClient.checkIfActiveUserExistsByUuid(user.getUuid())).thenReturn(false);
+
+            notificationService.notifyCustom(1L, UserCategory.USERS_WITH_ORDERS_MADE_LESS_THAN_3_MONTHS);
+
+            verify(userNotificationRepository, never()).save(any());
+
         }
 
         @Test


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link :clipboard:
[#8952](https://github.com/ita-social-projects/GreenCity/issues/8952)


## Summary Of Changes :fire:
* Implemented user status check before sending notifications to ensure that the user is still active by making request to **GreenCityUser**.
* Provided existing tests with required stubs to match modified functionality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Notifications are now created and dispatched only for active user accounts, reducing unwanted messages and improving relevance.
  * Notification processing is skipped for inactive users, improving efficiency and avoiding unnecessary persistence and dispatch.

* Tests
  * Expanded coverage for active/inactive user paths, including new tests ensuring notifications are not saved or sent for inactive users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->