### PR TITLE
Bugfix #7220 changed a default locale for password restoration email

### DIFF
--- a/service-api/src/main/java/greencity/client/UserRemoteClient.java
+++ b/service-api/src/main/java/greencity/client/UserRemoteClient.java
@@ -127,7 +127,7 @@ public interface UserRemoteClient {
      * @param dto {@link EmployeeSignUpDto}
      */
     @PostMapping("/ownSecurity/sign-up-employee")
-    void signUpEmployee(@RequestBody EmployeeSignUpDto dto);
+    void signUpEmployee(@RequestBody EmployeeSignUpDto dto, @RequestParam String lang);
 
     /**
      * Update employee email.

--- a/service-api/src/main/java/greencity/client/config/UserRemoteClientFallbackFactory.java
+++ b/service-api/src/main/java/greencity/client/config/UserRemoteClientFallbackFactory.java
@@ -80,7 +80,7 @@ public class UserRemoteClientFallbackFactory implements FallbackFactory<UserRemo
             }
 
             @Override
-            public void signUpEmployee(EmployeeSignUpDto dto) {
+            public void signUpEmployee(EmployeeSignUpDto dto, String language) {
                 log.error(ErrorMessage.EMPLOYEE_WAS_NOT_SUCCESSFULLY_SAVED, throwable);
                 throw new RemoteServerUnavailableException(ErrorMessage.EMPLOYEE_WAS_NOT_SUCCESSFULLY_SAVED, throwable);
             }

--- a/service-api/src/test/java/greencity/client/config/UserRemoteClientFallbackFactoryTest.java
+++ b/service-api/src/test/java/greencity/client/config/UserRemoteClientFallbackFactoryTest.java
@@ -101,7 +101,7 @@ class UserRemoteClientFallbackFactoryTest {
     @Test
     void signUpEmployee() {
         EmployeeSignUpDto dto = EmployeeSignUpDto.builder().build();
-        assertThrows(RemoteServerUnavailableException.class, () -> client.signUpEmployee(dto));
+        assertThrows(RemoteServerUnavailableException.class, () -> client.signUpEmployee(dto, "en"));
     }
 
     @Test

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -156,7 +156,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
             .isUbs(true)
             .build();
         try {
-            userRemoteClient.signUpEmployee(signUpDto);
+            userRemoteClient.signUpEmployee(signUpDto, "uk");
         } catch (HystrixRuntimeException e) {
             throw new BadRequestException(
                 "Error to create user(): User with this email already exists or not valid data ");


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link :clipboard:
[#7220](https://github.com/ita-social-projects/GreenCity/issues/7220)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Employee sign-up now accepts a required language parameter.
* **Refactor**
  * Service layer updated to pass a language value during employee sign-up.
* **Chores**
  * Internal fallbacks and tests aligned with the new API contract.
* **Documentation**
  * Note for API consumers: requests to the employee sign-up endpoint must include a language code as a query parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->