### PR TITLE
Fixed the issue with accessing order info for editing it

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -288,7 +288,9 @@ public class SecurityConfig {
                     EXPORT_SETTINGS_LINKS,
                     UBS_LINK + "/findAll-order-address",
                     UBS_LINK + "/order-details-for-tariff",
-                    UBS_LINK + "/personal-data")
+                    UBS_LINK + "/personal-data",
+                    UBS_LINK + "/details-for-existing-order/{orderId}",
+                    UBS_LINK + "/orders/{id}/tariff")
                 .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.GET,
                     TELEGRAM_LINK + "/**",


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/GreenCity/issues/9011">#9011</a>

## Changed
- Added access for /details-for-existing-order.
- Added access for /orders/{id}/tariff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Authorized users can now retrieve existing order details via UBS links.
  - Authorized users can now view tariff information for specific orders via UBS links.
  - These endpoints are accessible via GET for users with the appropriate roles (USER, ADMIN, UBS_EMPLOYEE).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->