### PR TITLE
Remove hardcoded uk locale in tg bot

### DIFF
--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
@@ -1,7 +1,6 @@
 package greencity.ubstelegrambot.service;
 
 import greencity.client.UserRemoteClient;
-import greencity.constant.TelegramBotConstants;
 import greencity.dto.TestersSignInRequest;
 import greencity.entity.telegram.TelegramManager;
 import greencity.entity.user.employee.Employee;

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
@@ -47,7 +47,7 @@ public class TelegramLoginServiceImpl implements TelegramLoginService {
 
         if (parts.length < 2) {
             return MessageFactory.createFailLoginMessage(message.getChatId().toString(),
-                MessageProvider.get(lang, "incorrect.login.format"), TelegramBotConstants.UK);
+                MessageProvider.get(lang, "incorrect.login.format"), lang);
         }
 
         String login = parts[0];
@@ -57,14 +57,14 @@ public class TelegramLoginServiceImpl implements TelegramLoginService {
 
         if (employee.isEmpty()) {
             return MessageFactory.createFailLoginMessage(message.getChatId().toString(),
-                MessageProvider.get(lang, "user.not.employee"), TelegramBotConstants.UK);
+                MessageProvider.get(lang, "user.not.employee"), lang);
         }
 
         boolean isManager = telegramUtils.checkIsEmployeeManager(employee.get());
 
         if (!isManager) {
             return MessageFactory.createFailLoginMessage(message.getChatId().toString(),
-                MessageProvider.get(TelegramBotConstants.UK, "employee.not.manager"), TelegramBotConstants.UK);
+                MessageProvider.get(lang, "employee.not.manager"), lang);
         }
 
         try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Login error messages in the Telegram bot now appear in the user’s selected language instead of a fixed locale.
  * Improves localization for scenarios like incorrect login format, non-employee accounts, and non-manager roles.
  * Ensures consistent, language-aware feedback during login without altering other behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->