### PR TITLE
Feature: 1822 add handling for incorrect message format

### DIFF
--- a/dao/src/main/java/greencity/enums/AssetType.java
+++ b/dao/src/main/java/greencity/enums/AssetType.java
@@ -1,5 +1,5 @@
 package greencity.enums;
 
 public enum AssetType {
-    IMAGE, VIDEO, FILE, AUDIO
+    IMAGE, VIDEO, FILE, AUDIO, STICKER
 }

--- a/service-api/src/main/java/greencity/exceptions/bots/UnsupportedTelegramAssetException.java
+++ b/service-api/src/main/java/greencity/exceptions/bots/UnsupportedTelegramAssetException.java
@@ -1,0 +1,7 @@
+package greencity.exceptions.bots;
+
+import lombok.experimental.StandardException;
+
+@StandardException
+public class UnsupportedTelegramAssetException extends RuntimeException {
+}

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -36,6 +36,8 @@ import org.telegram.telegrambots.meta.api.objects.Document;
 import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.PhotoSize;
+import org.telegram.telegrambots.meta.api.objects.games.Animation;
+import org.telegram.telegrambots.meta.api.objects.stickers.Sticker;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -62,7 +64,6 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
      */
     @Override
     @Transactional
-
     public SendMessage processSupportMessage(Message message, String lang) {
         Optional<TelegramChat> optionalChat = telegramChatRepository.findByChatId(message.getFrom().getId().toString());
         if (optionalChat.isEmpty()) {
@@ -149,16 +150,65 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
             resultMessage = setPhotoInfo(message, telegramMessage, telegramMessageOpt, fileInfo, lang);
         } else if (message.hasDocument()) {
             resultMessage = setDocumentInfo(message, telegramMessage, telegramMessageOpt, fileInfo, lang);
+        } else if (message.hasSticker()) {
+            resultMessage = setStickerInfo(message, telegramMessage, telegramMessageOpt, fileInfo, lang);
+        } else if (message.hasAnimation()) {
+            resultMessage = setAnimationInfo(message, telegramMessage, telegramMessageOpt, fileInfo, lang);
         }
 
         if (fileInfo.getFileId() != null) {
             return setFileAsMessageAsset(message, telegramMessage, telegramMessageOpt, fileInfo, lang);
-        } else if (!message.hasText() && !message.hasPhoto() && !message.hasDocument()) {
+        } else if (!message.hasText()
+            && !message.hasPhoto()
+            && !message.hasDocument()
+            && !message.hasSticker()
+            && !message.hasAnimation()) {
             log.warn("No text or supported file found in message from chat ID: {}", chat.getChatId());
             resultMessage = MessageFactory.buildMessage(message.getChatId().toString(),
                 MessageProvider.get(lang, "manager.file.failed"));
         }
         return resultMessage;
+    }
+
+    private SendMessage setStickerInfo(Message message, TelegramMessage telegramMessage,
+        Optional<TelegramMessage> telegramMessageOpt, FileInfo fileInfo, String lang) {
+        Sticker sticker = message.getSticker();
+        if (sticker == null) {
+            if (telegramMessageOpt.isEmpty()) {
+                telegramMessageRepository.delete(telegramMessage);
+            }
+            return MessageFactory.buildMessage(message.getChatId().toString(),
+                MessageProvider.get(lang, "manager.file.failed"));
+        } else {
+            fileInfo.setFileId(sticker.getFileId());
+            fileInfo.setFileSize(sticker.getFileSize() != null ? sticker.getFileSize().longValue() : 0L);
+            fileInfo.setContentType("image/webp");
+            fileInfo.setOriginalFileName("sticker.webp");
+            return null;
+        }
+    }
+
+    private SendMessage setAnimationInfo(Message message,
+        TelegramMessage telegramMessage,
+        Optional<TelegramMessage> telegramMessageOpt,
+        FileInfo fileInfo,
+        String lang) {
+        Animation animation = message.getAnimation();
+        if (animation == null) {
+            if (telegramMessageOpt.isEmpty()) {
+                telegramMessageRepository.delete(telegramMessage);
+            }
+            return MessageFactory.buildMessage(message.getChatId().toString(),
+                MessageProvider.get(lang, "manager.file.failed"));
+        } else {
+            fileInfo.setFileId(animation.getFileId());
+            fileInfo.setFileSize(animation.getFileSize() != null ? animation.getFileSize() : 0L);
+            fileInfo.setContentType(animation.getMimetype());
+            fileInfo.setOriginalFileName(animation.getFileName() != null
+                ? animation.getFileName()
+                : "animation.mp4");
+            return null;
+        }
     }
 
     private SendMessage setPhotoInfo(Message message,

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -12,6 +12,7 @@ import greencity.enums.ChatState;
 import greencity.enums.MessageDeliveryStatus;
 import greencity.enums.MessageViewingStatus;
 import greencity.exceptions.bots.TelegramBotExecutionException;
+import greencity.exceptions.bots.UnsupportedTelegramAssetException;
 import greencity.producers.TelegramChatProducer;
 import greencity.repository.MessageAssetRepository;
 import greencity.repository.TelegramChatRepository;
@@ -164,10 +165,20 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
             && !message.hasSticker()
             && !message.hasAnimation()) {
             log.warn("No text or supported file found in message from chat ID: {}", chat.getChatId());
+            resetTelegramChatDataToInternalStatus(chat, telegramMessage);
             resultMessage = MessageFactory.buildMessage(message.getChatId().toString(),
                 MessageProvider.get(lang, "manager.file.failed"));
         }
         return resultMessage;
+    }
+
+    private void resetTelegramChatDataToInternalStatus(TelegramChat chat, TelegramMessage telegramMessage) {
+        telegramMessageRepository.delete(telegramMessage);
+        var lastMessage = telegramMessageRepository.findFirstByChatOrderBySendAtDesc(chat).orElse(null);
+        var messageCount = chat.getUnreadMessagesCount() - 1;
+        chat.setLastMessage(lastMessage);
+        chat.setUnreadMessagesCount(messageCount);
+        telegramChatRepository.save(chat);
     }
 
     private SendMessage setStickerInfo(Message message, TelegramMessage telegramMessage,
@@ -307,7 +318,7 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
             }
 
             messageAssetRepository.save(asset);
-        } catch (TelegramBotExecutionException | IOException e) {
+        } catch (TelegramBotExecutionException | UnsupportedTelegramAssetException | IOException e) {
             log.error("Error loading or saving file from Telegram (Filename: {}): {}", fileInfo.getOriginalFileName(),
                 e.getMessage(), e);
             return MessageFactory.buildMessage(message.getChatId().toString(),

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramUtils.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramUtils.java
@@ -51,7 +51,7 @@ public class TelegramUtils {
      * Detects the asset type based on the given content type string.
      *
      * <ul>
-     * <li>If {@code fileType} is {@code null}, returns {@link AssetType#FILE}.</li>
+     * <li>If {@code fileType} is {@code null}, throws {@link UnsupportedTelegramAssetException}.</li>
      * <li>If content type starts with {@code image/webp} or
      * {@code application/x-tgsticker}, returns {@link AssetType#STICKER}.</li>
      * <li>If content type starts with {@code image/} (excluding SVG), returns

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramUtils.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramUtils.java
@@ -7,6 +7,7 @@ import greencity.entity.user.employee.Position;
 import greencity.enums.AssetType;
 import greencity.enums.ChatState;
 import greencity.exceptions.NotFoundException;
+import greencity.exceptions.bots.UnsupportedTelegramAssetException;
 import greencity.repository.PositionRepository;
 import greencity.repository.TelegramChatRepository;
 import greencity.ubstelegrambot.messages.MessageFactory;
@@ -50,7 +51,9 @@ public class TelegramUtils {
      * Detects the asset type based on the given content type string.
      *
      * <ul>
-     * <li>If {@code file} is {@code null}, returns {@link AssetType#FILE}.</li>
+     * <li>If {@code fileType} is {@code null}, returns {@link AssetType#FILE}.</li>
+     * <li>If content type starts with {@code image/webp} or
+     * {@code application/x-tgsticker}, returns {@link AssetType#STICKER}.</li>
      * <li>If content type starts with {@code image/} (excluding SVG), returns
      * {@link AssetType#IMAGE}.</li>
      * <li>If content type starts with {@code video/}, returns
@@ -60,25 +63,31 @@ public class TelegramUtils {
      * <li>Otherwise, returns {@link AssetType#FILE}.</li>
      * </ul>
      *
-     * @param file the MIME type string
+     * @param fileType the MIME type string
      * @return the corresponding {@link AssetType}
      */
-    public static AssetType detectAssetType(String file) {
-        if (file == null) {
+    public static AssetType detectAssetType(String fileType) {
+        if (fileType == null) {
+            throw new UnsupportedTelegramAssetException("Unsupported asset: no content type");
+        }
+
+        if (fileType.equals("image/webp") || fileType.equals("application/x-tgsticker")) {
+            return AssetType.STICKER;
+        }
+        if (fileType.startsWith("image/") && !fileType.contains("svg")) {
+            return AssetType.IMAGE;
+        }
+        if (fileType.startsWith("video/")) {
+            return AssetType.VIDEO;
+        }
+        if (fileType.startsWith("audio/")) {
+            return AssetType.AUDIO;
+        }
+        if (fileType.startsWith("application/") || fileType.startsWith("text/") || fileType.contains("svg")) {
             return AssetType.FILE;
         }
 
-        if (file.startsWith("image/") && !file.contains("svg")) {
-            return AssetType.IMAGE;
-        }
-        if (file.startsWith("video/")) {
-            return AssetType.VIDEO;
-        }
-        if (file.startsWith("audio/")) {
-            return AssetType.AUDIO;
-        }
-
-        return AssetType.FILE;
+        throw new UnsupportedTelegramAssetException("Unsupported asset type: " + fileType);
     }
 
     /**

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramUtils.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramUtils.java
@@ -51,7 +51,8 @@ public class TelegramUtils {
      * Detects the asset type based on the given content type string.
      *
      * <ul>
-     * <li>If {@code fileType} is {@code null}, throws {@link UnsupportedTelegramAssetException}.</li>
+     * <li>If {@code fileType} is {@code null}, throws
+     * {@link UnsupportedTelegramAssetException}.</li>
      * <li>If content type starts with {@code image/webp} or
      * {@code application/x-tgsticker}, returns {@link AssetType#STICKER}.</li>
      * <li>If content type starts with {@code image/} (excluding SVG), returns

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramUtils.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramUtils.java
@@ -74,7 +74,10 @@ public class TelegramUtils {
         if (fileType.equals("image/webp") || fileType.equals("application/x-tgsticker")) {
             return AssetType.STICKER;
         }
-        if (fileType.startsWith("image/") && !fileType.contains("svg")) {
+        if (fileType.startsWith("application/") || fileType.startsWith("text/") || fileType.contains("svg")) {
+            return AssetType.FILE;
+        }
+        if (fileType.startsWith("image/")) {
             return AssetType.IMAGE;
         }
         if (fileType.startsWith("video/")) {
@@ -82,9 +85,6 @@ public class TelegramUtils {
         }
         if (fileType.startsWith("audio/")) {
             return AssetType.AUDIO;
-        }
-        if (fileType.startsWith("application/") || fileType.startsWith("text/") || fileType.contains("svg")) {
-            return AssetType.FILE;
         }
 
         throw new UnsupportedTelegramAssetException("Unsupported asset type: " + fileType);

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
@@ -193,27 +193,27 @@ class TelegramServiceTest {
         verify(telegramChatRepository).save(any(TelegramChat.class));
     }
 
-    @Test
-    void testSendMessageToUser_FileUnknownContentType_MessageSentAndPhotoUploaded() {
-        CreateTelegramMessageRequest request = new CreateTelegramMessageRequest();
-        request.setChatId(1L);
-        request.setText("Hi");
-
-        TelegramChat chat = new TelegramChat();
-        chat.setChatId("123456");
-
-        when(executor.executeSendFile(any(SendDocument.class))).thenReturn(mockTelegramResponse(10));
-        when(telegramChatRepository.findById(1L)).thenReturn(Optional.of(chat));
-        when(file.getOriginalFilename()).thenReturn("image.svg");
-        when(file.getSize()).thenReturn(2048L);
-        when(file.getContentType()).thenReturn(null);
-        when(userRemoteWebClient.uploadFile(file)).thenReturn("http://image");
-
-        telegramService.sendMessageToUser(request, new MultipartFile[] {file});
-
-        verify(userRemoteWebClient).uploadFile(file);
-        verify(executor).executeSendFile(any(SendDocument.class));
-    }
+//    @Test
+//    void testSendMessageToUser_FileUnknownContentType_MessageSentAndPhotoUploaded() {
+//        CreateTelegramMessageRequest request = new CreateTelegramMessageRequest();
+//        request.setChatId(1L);
+//        request.setText("Hi");
+//
+//        TelegramChat chat = new TelegramChat();
+//        chat.setChatId("123456");
+//
+//        when(executor.executeSendFile(any(SendDocument.class))).thenReturn(mockTelegramResponse(10));
+//        when(telegramChatRepository.findById(1L)).thenReturn(Optional.of(chat));
+//        when(file.getOriginalFilename()).thenReturn("image.svg");
+//        when(file.getSize()).thenReturn(2048L);
+//        when(file.getContentType()).thenReturn(null);
+//        when(userRemoteWebClient.uploadFile(file)).thenReturn("http://image");
+//
+//        telegramService.sendMessageToUser(request, new MultipartFile[] {file});
+//
+//        verify(userRemoteWebClient).uploadFile(file);
+//        verify(executor).executeSendFile(any(SendDocument.class));
+// }
 
     @Test
     void testSendMessageToUser_FileImageContentTypeLargeDimensions_MessageSentAndPhotoUploaded() throws IOException {
@@ -1191,29 +1191,29 @@ class TelegramServiceTest {
         return apiUser;
     }
 
-    @Test
-    void testSendMessageToUser_FileTooLarge_ShouldThrowException() {
-        CreateTelegramMessageRequest request = new CreateTelegramMessageRequest();
-        request.setChatId(1L);
-
-        TelegramChat chat = new TelegramChat();
-        chat.setChatId("123456");
-
-        when(telegramChatRepository.findById(1L)).thenReturn(Optional.of(chat));
-        when(file.getName()).thenReturn("large_file.pdf");
-        when(file.getSize()).thenReturn(51L * 1024 * 1024);
-
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> telegramService.sendMessageToUser(request, new MultipartFile[] {file}));
-
-        assertEquals("File size exceeds Telegram bot limit (50MB)", exception.getMessage());
-
-        verify(telegramChatRepository).findById(1L);
-        verifyNoInteractions(userRemoteWebClient);
-        verifyNoInteractions(executor);
-        verify(telegramMessageRepository, never()).save(any());
-    }
+//    @Test
+//    void testSendMessageToUser_FileTooLarge_ShouldThrowException() {
+//        CreateTelegramMessageRequest request = new CreateTelegramMessageRequest();
+//        request.setChatId(1L);
+//
+//        TelegramChat chat = new TelegramChat();
+//        chat.setChatId("123456");
+//
+//        when(telegramChatRepository.findById(1L)).thenReturn(Optional.of(chat));
+//        when(file.getName()).thenReturn("large_file.pdf");
+//        when(file.getSize()).thenReturn(51L * 1024 * 1024);
+//
+//        IllegalArgumentException exception = assertThrows(
+//            IllegalArgumentException.class,
+//            () -> telegramService.sendMessageToUser(request, new MultipartFile[] {file}));
+//
+//        assertEquals("File size exceeds Telegram bot limit (50MB)", exception.getMessage());
+//
+//        verify(telegramChatRepository).findById(1L);
+//        verifyNoInteractions(userRemoteWebClient);
+//        verifyNoInteractions(executor);
+//        verify(telegramMessageRepository, never()).save(any());
+//    }
 
     @Test
     void testSendMessageToUser_FileAssetType_ShouldSendDocument() {
@@ -1235,25 +1235,25 @@ class TelegramServiceTest {
         verify(telegramMessageRepository).save(any());
     }
 
-    @Test
-    void testSendMessageToUser_WhenFileSendingFails_ShouldThrowTelegramBotExecutionException() throws IOException {
-        Long chatId = 123L;
-        CreateTelegramMessageRequest request =
-            new CreateTelegramMessageRequest(chatId, "test caption");
-
-        TelegramChat chat = new TelegramChat();
-        chat.setChatId(chatId.toString());
-
-        when(telegramChatRepository.findById(chatId)).thenReturn(Optional.of(chat));
-
-        MultipartFile badFile = mock(MultipartFile.class);
-        when(badFile.getInputStream()).thenThrow(new IOException("fake IO fail"));
-
-        MultipartFile[] files = new MultipartFile[] {badFile};
-
-        assertThrows(TelegramBotExecutionException.class,
-            () -> telegramService.sendMessageToUser(request, files));
-    }
+//    @Test
+//    void testSendMessageToUser_WhenFileSendingFails_ShouldThrowTelegramBotExecutionException() throws IOException {
+//        Long chatId = 123L;
+//        CreateTelegramMessageRequest request =
+//            new CreateTelegramMessageRequest(chatId, "test caption");
+//
+//        TelegramChat chat = new TelegramChat();
+//        chat.setChatId(chatId.toString());
+//
+//        when(telegramChatRepository.findById(chatId)).thenReturn(Optional.of(chat));
+//
+//        MultipartFile badFile = mock(MultipartFile.class);
+//        when(badFile.getInputStream()).thenThrow(new IOException("fake IO fail"));
+//
+//        MultipartFile[] files = new MultipartFile[] {badFile};
+//
+//        assertThrows(TelegramBotExecutionException.class,
+//            () -> telegramService.sendMessageToUser(request, files));
+//    }
 
     @Test
     void testMarkMessagesAsRead_IdsSpecified_MessagesMarkedAsRead() {
@@ -1678,24 +1678,24 @@ class TelegramServiceTest {
         verify(telegramChatRepository, never()).save(chat);
     }
 
-    @Test
-    void sendMessageToUser_shouldThrowIOException() {
-        TelegramChat chat = new TelegramChat();
-        chat.setChatId("123");
-        when(telegramChatRepository.findById(any())).thenReturn(Optional.of(chat));
-
-        when(file.getSize()).thenReturn(1024L);
-
-        CreateTelegramMessageRequest request = new CreateTelegramMessageRequest();
-        request.setChatId(1L);
-
-        try (MockedStatic<MessageFactory> mf = mockStatic(MessageFactory.class)) {
-            mf.when(() -> MessageFactory.createSendPhoto(anyString(), any(), any())).thenThrow(IOException.class);
-
-            assertThrows(RuntimeException.class,
-                () -> telegramService.sendMessageToUser(request, new MultipartFile[] {file}));
-        }
-    }
+//    @Test
+//    void sendMessageToUser_shouldThrowIOException() {
+//        TelegramChat chat = new TelegramChat();
+//        chat.setChatId("123");
+//        when(telegramChatRepository.findById(any())).thenReturn(Optional.of(chat));
+//
+//        when(file.getSize()).thenReturn(1024L);
+//
+//        CreateTelegramMessageRequest request = new CreateTelegramMessageRequest();
+//        request.setChatId(1L);
+//
+//        try (MockedStatic<MessageFactory> mf = mockStatic(MessageFactory.class)) {
+//            mf.when(() -> MessageFactory.createSendPhoto(anyString(), any(), any())).thenThrow(IOException.class);
+//
+//            assertThrows(RuntimeException.class,
+//                () -> telegramService.sendMessageToUser(request, new MultipartFile[] {file}));
+//        }
+//    }
 
     @Test
     void sendMessageToUser_WithMultipleImages_ShouldUseSendAsMediaGroup() throws IOException {

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
@@ -23,6 +23,7 @@ import greencity.enums.MessageDeliveryStatus;
 import greencity.enums.MessageViewingStatus;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.bots.TelegramBotExecutionException;
+import greencity.exceptions.bots.UnsupportedTelegramAssetException;
 import greencity.producers.TelegramChatProducer;
 import greencity.repository.EmployeeRepository;
 import greencity.repository.MessageAssetRepository;
@@ -193,27 +194,25 @@ class TelegramServiceTest {
         verify(telegramChatRepository).save(any(TelegramChat.class));
     }
 
-//    @Test
-//    void testSendMessageToUser_FileUnknownContentType_MessageSentAndPhotoUploaded() {
-//        CreateTelegramMessageRequest request = new CreateTelegramMessageRequest();
-//        request.setChatId(1L);
-//        request.setText("Hi");
-//
-//        TelegramChat chat = new TelegramChat();
-//        chat.setChatId("123456");
-//
-//        when(executor.executeSendFile(any(SendDocument.class))).thenReturn(mockTelegramResponse(10));
-//        when(telegramChatRepository.findById(1L)).thenReturn(Optional.of(chat));
-//        when(file.getOriginalFilename()).thenReturn("image.svg");
-//        when(file.getSize()).thenReturn(2048L);
-//        when(file.getContentType()).thenReturn(null);
-//        when(userRemoteWebClient.uploadFile(file)).thenReturn("http://image");
-//
-//        telegramService.sendMessageToUser(request, new MultipartFile[] {file});
-//
-//        verify(userRemoteWebClient).uploadFile(file);
-//        verify(executor).executeSendFile(any(SendDocument.class));
-// }
+    @Test
+    void testSendMessageToUser_FileUnknownContentType_MessageSentAndPhotoUploaded() {
+        CreateTelegramMessageRequest request = new CreateTelegramMessageRequest();
+        request.setChatId(1L);
+        request.setText("Hi");
+
+        TelegramChat chat = new TelegramChat();
+        chat.setChatId("123456");
+
+        when(telegramChatRepository.findById(1L)).thenReturn(Optional.of(chat));
+        when(file.getContentType()).thenReturn(null);
+
+        assertThrows(UnsupportedTelegramAssetException.class,
+            () -> telegramService.sendMessageToUser(request, new MultipartFile[] {file}));
+
+        verify(telegramChatRepository).findById(1L);
+        verifyNoInteractions(userRemoteWebClient);
+        verifyNoInteractions(executor);
+    }
 
     @Test
     void testSendMessageToUser_FileImageContentTypeLargeDimensions_MessageSentAndPhotoUploaded() throws IOException {
@@ -1191,29 +1190,30 @@ class TelegramServiceTest {
         return apiUser;
     }
 
-//    @Test
-//    void testSendMessageToUser_FileTooLarge_ShouldThrowException() {
-//        CreateTelegramMessageRequest request = new CreateTelegramMessageRequest();
-//        request.setChatId(1L);
-//
-//        TelegramChat chat = new TelegramChat();
-//        chat.setChatId("123456");
-//
-//        when(telegramChatRepository.findById(1L)).thenReturn(Optional.of(chat));
-//        when(file.getName()).thenReturn("large_file.pdf");
-//        when(file.getSize()).thenReturn(51L * 1024 * 1024);
-//
-//        IllegalArgumentException exception = assertThrows(
-//            IllegalArgumentException.class,
-//            () -> telegramService.sendMessageToUser(request, new MultipartFile[] {file}));
-//
-//        assertEquals("File size exceeds Telegram bot limit (50MB)", exception.getMessage());
-//
-//        verify(telegramChatRepository).findById(1L);
-//        verifyNoInteractions(userRemoteWebClient);
-//        verifyNoInteractions(executor);
-//        verify(telegramMessageRepository, never()).save(any());
-//    }
+    @Test
+    void testSendMessageToUser_FileTooLarge_ShouldThrowException() {
+        CreateTelegramMessageRequest request = new CreateTelegramMessageRequest();
+        request.setChatId(1L);
+
+        TelegramChat chat = new TelegramChat();
+        chat.setChatId("123456");
+
+        when(telegramChatRepository.findById(1L)).thenReturn(Optional.of(chat));
+        when(file.getContentType()).thenReturn("application/pdf");
+        when(file.getName()).thenReturn("large_file.pdf");
+        when(file.getSize()).thenReturn(51L * 1024 * 1024);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> telegramService.sendMessageToUser(request, new MultipartFile[] {file}));
+
+        assertEquals("File size exceeds Telegram bot limit (50MB)", exception.getMessage());
+
+        verify(telegramChatRepository).findById(1L);
+        verifyNoInteractions(userRemoteWebClient);
+        verifyNoInteractions(executor);
+        verify(telegramMessageRepository, never()).save(any());
+    }
 
     @Test
     void testSendMessageToUser_FileAssetType_ShouldSendDocument() {
@@ -1235,25 +1235,26 @@ class TelegramServiceTest {
         verify(telegramMessageRepository).save(any());
     }
 
-//    @Test
-//    void testSendMessageToUser_WhenFileSendingFails_ShouldThrowTelegramBotExecutionException() throws IOException {
-//        Long chatId = 123L;
-//        CreateTelegramMessageRequest request =
-//            new CreateTelegramMessageRequest(chatId, "test caption");
-//
-//        TelegramChat chat = new TelegramChat();
-//        chat.setChatId(chatId.toString());
-//
-//        when(telegramChatRepository.findById(chatId)).thenReturn(Optional.of(chat));
-//
-//        MultipartFile badFile = mock(MultipartFile.class);
-//        when(badFile.getInputStream()).thenThrow(new IOException("fake IO fail"));
-//
-//        MultipartFile[] files = new MultipartFile[] {badFile};
-//
-//        assertThrows(TelegramBotExecutionException.class,
-//            () -> telegramService.sendMessageToUser(request, files));
-//    }
+    @Test
+    void testSendMessageToUser_WhenFileSendingFails_ShouldThrowTelegramBotExecutionException() throws IOException {
+        Long chatId = 123L;
+        CreateTelegramMessageRequest request =
+            new CreateTelegramMessageRequest(chatId, "test caption");
+
+        TelegramChat chat = new TelegramChat();
+        chat.setChatId(chatId.toString());
+
+        when(telegramChatRepository.findById(chatId)).thenReturn(Optional.of(chat));
+
+        MultipartFile badFile = mock(MultipartFile.class);
+        when(badFile.getContentType()).thenReturn("application/pdf");
+        when(badFile.getInputStream()).thenThrow(new IOException("fake IO fail"));
+
+        MultipartFile[] files = new MultipartFile[] {badFile};
+
+        assertThrows(TelegramBotExecutionException.class,
+            () -> telegramService.sendMessageToUser(request, files));
+    }
 
     @Test
     void testMarkMessagesAsRead_IdsSpecified_MessagesMarkedAsRead() {
@@ -1678,24 +1679,22 @@ class TelegramServiceTest {
         verify(telegramChatRepository, never()).save(chat);
     }
 
-//    @Test
-//    void sendMessageToUser_shouldThrowIOException() {
-//        TelegramChat chat = new TelegramChat();
-//        chat.setChatId("123");
-//        when(telegramChatRepository.findById(any())).thenReturn(Optional.of(chat));
-//
-//        when(file.getSize()).thenReturn(1024L);
-//
-//        CreateTelegramMessageRequest request = new CreateTelegramMessageRequest();
-//        request.setChatId(1L);
-//
-//        try (MockedStatic<MessageFactory> mf = mockStatic(MessageFactory.class)) {
-//            mf.when(() -> MessageFactory.createSendPhoto(anyString(), any(), any())).thenThrow(IOException.class);
-//
-//            assertThrows(RuntimeException.class,
-//                () -> telegramService.sendMessageToUser(request, new MultipartFile[] {file}));
-//        }
-//    }
+    @Test
+    void sendMessageToUser_shouldThrowIOException() {
+        TelegramChat chat = new TelegramChat();
+        chat.setChatId("123");
+        when(telegramChatRepository.findById(any())).thenReturn(Optional.of(chat));
+
+        CreateTelegramMessageRequest request = new CreateTelegramMessageRequest();
+        request.setChatId(1L);
+
+        try (MockedStatic<MessageFactory> mf = mockStatic(MessageFactory.class)) {
+            mf.when(() -> MessageFactory.createSendPhoto(anyString(), any(), any())).thenThrow(IOException.class);
+
+            assertThrows(RuntimeException.class,
+                () -> telegramService.sendMessageToUser(request, new MultipartFile[] {file}));
+        }
+    }
 
     @Test
     void sendMessageToUser_WithMultipleImages_ShouldUseSendAsMediaGroup() throws IOException {

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
@@ -18,6 +18,7 @@ import greencity.ubstelegrambot.messages.MessageProvider;
 import greencity.ubstelegrambot.service.TelegramExecutor;
 import greencity.ubstelegrambot.service.TelegramSupportServiceImpl;
 import greencity.ubstelegrambot.service.TelegramUtils;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,8 @@ import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.PhotoSize;
 import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.api.objects.games.Animation;
+import org.telegram.telegrambots.meta.api.objects.stickers.Sticker;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -47,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
@@ -60,6 +64,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@Slf4j
 class TelegramSupportServiceTest {
 
     @InjectMocks
@@ -635,4 +640,167 @@ class TelegramSupportServiceTest {
 
         verify(telegramChatRepository).findByChatId(chatId);
     }
+
+    @Test
+    void testProcessSupportMessage_WithSticker_ShouldSaveFileAsset() throws Exception {
+        TelegramChat chat = new TelegramChat();
+        chat.setId(1L);
+        chat.setChatId("12345");
+        chat.setChatState(ChatState.IN_SUPPORT);
+        chat.setLanguageCode("en");
+
+        Sticker sticker = mock(Sticker.class);
+        Message message = mock(Message.class);
+
+        User from = new User();
+        from.setId(111L);
+        when(message.getFrom()).thenReturn(from);
+        when(telegramChatRepository.findByChatId("111")).thenReturn(Optional.of(chat));
+        when(message.hasSticker()).thenReturn(true);
+        when(message.getSticker()).thenReturn(sticker);
+        when(sticker.getFileId()).thenReturn("sticker-file-id");
+        when(sticker.getFileSize()).thenReturn(100);
+
+        File tgFile = new File();
+        tgFile.setFilePath("files/sticker.webp");
+        when(telegramExecutor.executeGetFile(any())).thenReturn(tgFile);
+        when(telegramUtils.fileToByteArray(any())).thenReturn("bytes".getBytes());
+        when(userRemoteWebClient.uploadFile(any())).thenReturn("http://cdn/sticker.webp");
+
+        SendMessage result = telegramSupportService.processSupportMessage(message, "en");
+
+        assertNotNull(result);
+        assertTrue(result.getText().contains("message.sent.to.manager"));
+        verify(messageAssetRepository).save(any(MessageAsset.class));
+    }
+
+    @Test
+    void testProcessSupportMessage_WithNullSticker_ShouldReturnErrorMessage() {
+        TelegramChat chat = new TelegramChat();
+        chat.setId(1L);
+        chat.setChatId("12345");
+        chat.setChatState(ChatState.IN_SUPPORT);
+        chat.setLanguageCode("en");
+
+        Sticker sticker = mock(Sticker.class);
+        Message message = mock(Message.class);
+
+        User from = new User();
+        from.setId(111L);
+        when(message.getFrom()).thenReturn(from);
+        when(telegramChatRepository.findByChatId("111")).thenReturn(Optional.of(chat));
+        when(message.hasSticker()).thenReturn(true);
+        when(message.getSticker()).thenReturn(sticker);
+
+        when(message.hasSticker()).thenReturn(true);
+        when(message.getSticker()).thenReturn(null);
+        when(message.getChatId()).thenReturn(12345L);
+
+        SendMessage result = telegramSupportService.processSupportMessage(message, "en");
+
+        assertNotNull(result);
+        assertTrue(result.getText().contains("file.failed"));
+
+        verify(telegramMessageRepository).delete(any());
+    }
+
+    @Test
+    void testProcessSupportMessage_WithAnimation_ShouldSaveFileAsset() throws Exception {
+        TelegramChat chat = new TelegramChat();
+        chat.setId(1L);
+        chat.setChatId("12345");
+        chat.setChatState(ChatState.IN_SUPPORT);
+        chat.setLanguageCode("en");
+
+        Message message = mock(Message.class);
+
+        User from = new User();
+        from.setId(111L);
+        when(message.getFrom()).thenReturn(from);
+        when(telegramChatRepository.findByChatId("111")).thenReturn(Optional.of(chat));
+
+        Animation animation = mock(Animation.class);
+        when(message.hasAnimation()).thenReturn(true);
+        when(message.getAnimation()).thenReturn(animation);
+        when(animation.getFileId()).thenReturn("anim-file-id");
+        when(animation.getFileSize()).thenReturn(200L);
+        when(animation.getMimetype()).thenReturn("video/mp4");
+        when(animation.getFileName()).thenReturn("clip.mp4");
+
+        File tgFile = new File();
+        tgFile.setFilePath("files/clip.mp4");
+        when(telegramExecutor.executeGetFile(any())).thenReturn(tgFile);
+        when(telegramUtils.fileToByteArray(any())).thenReturn("video".getBytes());
+        when(userRemoteWebClient.uploadFile(any())).thenReturn("http://cdn/clip.mp4");
+
+        SendMessage result = telegramSupportService.processSupportMessage(message, "en");
+
+        assertNotNull(result);
+        log.info(result.getText());
+        assertTrue(result.getText().contains("sent"));
+        verify(messageAssetRepository).save(any(MessageAsset.class));
+    }
+
+    @Test
+    void testProcessSupportMessage_WithNullAnimation_ShouldReturnErrorMessage() {
+        TelegramChat chat = new TelegramChat();
+        chat.setId(1L);
+        chat.setChatId("12345");
+        chat.setChatState(ChatState.IN_SUPPORT);
+        chat.setLanguageCode("en");
+
+        Message message = mock(Message.class);
+
+        User from = new User();
+        from.setId(111L);
+        when(telegramChatRepository.findByChatId("111")).thenReturn(Optional.of(chat));
+
+        when(message.getFrom()).thenReturn(from);
+        when(message.hasAnimation()).thenReturn(true);
+        when(message.getAnimation()).thenReturn(null);
+        when(message.getChatId()).thenReturn(98765L);
+
+        SendMessage result = telegramSupportService.processSupportMessage(message, "en");
+
+        assertNotNull(result);
+        assertTrue(result.getText().contains("file.failed"));
+        verify(telegramMessageRepository).delete(any());
+    }
+
+    @Test
+    void testProcessSupportMessage_AnimationWithoutFileName_DefaultFileNameUsed() throws IOException {
+        // given
+        TelegramChat chat = new TelegramChat();
+        chat.setChatId("123");
+        chat.setChatState(ChatState.IN_SUPPORT);
+        chat.setLanguageCode("en");
+
+        when(telegramChatRepository.findByChatId(anyString())).thenReturn(Optional.of(chat));
+
+        Animation animation = mock(Animation.class);
+        when(animation.getFileId()).thenReturn("file123");
+        when(animation.getFileSize()).thenReturn(1024L);
+        when(animation.getMimetype()).thenReturn("video/mp4");
+        when(animation.getFileName()).thenReturn(null);
+
+        Message message = mock(Message.class);
+        when(message.getFrom()).thenReturn(mock(User.class));
+        when(message.hasAnimation()).thenReturn(true);
+        when(message.getAnimation()).thenReturn(animation);
+
+        // file download
+        File telegramFile = new File();
+        telegramFile.setFilePath("video/file.mp4");
+        when(telegramExecutor.executeGetFile(any(GetFile.class))).thenReturn(telegramFile);
+        when(telegramUtils.fileToByteArray(any(File.class))).thenReturn(new byte[] {1, 2, 3});
+        when(userRemoteWebClient.uploadFile(any(MultipartFile.class))).thenReturn("http://file-url");
+
+        // when
+        SendMessage result = telegramSupportService.processSupportMessage(message, "en");
+
+        // then
+        assertNotNull(result);
+        verify(messageAssetRepository).save(argThat(asset -> asset.getFileName().equals("animation.mp4")));
+    }
+
 }

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
@@ -736,7 +736,6 @@ class TelegramSupportServiceTest {
         SendMessage result = telegramSupportService.processSupportMessage(message, "en");
 
         assertNotNull(result);
-        log.info(result.getText());
         assertTrue(result.getText().contains("sent"));
         verify(messageAssetRepository).save(any(MessageAsset.class));
     }

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
@@ -645,7 +645,7 @@ class TelegramSupportServiceTest {
     void testProcessSupportMessage_WithSticker_ShouldSaveFileAsset() throws Exception {
         TelegramChat chat = new TelegramChat();
         chat.setId(1L);
-        chat.setChatId("12345");
+        chat.setChatId("111");
         chat.setChatState(ChatState.IN_SUPPORT);
         chat.setLanguageCode("en");
 
@@ -670,7 +670,7 @@ class TelegramSupportServiceTest {
         SendMessage result = telegramSupportService.processSupportMessage(message, "en");
 
         assertNotNull(result);
-        assertTrue(result.getText().contains("message.sent.to.manager"));
+        assertEquals(MessageProvider.get("en", "message.sent.to.manager"), result.getText());
         verify(messageAssetRepository).save(any(MessageAsset.class));
     }
 
@@ -678,11 +678,10 @@ class TelegramSupportServiceTest {
     void testProcessSupportMessage_WithNullSticker_ShouldReturnErrorMessage() {
         TelegramChat chat = new TelegramChat();
         chat.setId(1L);
-        chat.setChatId("12345");
+        chat.setChatId("111");
         chat.setChatState(ChatState.IN_SUPPORT);
         chat.setLanguageCode("en");
 
-        Sticker sticker = mock(Sticker.class);
         Message message = mock(Message.class);
 
         User from = new User();
@@ -690,16 +689,13 @@ class TelegramSupportServiceTest {
         when(message.getFrom()).thenReturn(from);
         when(telegramChatRepository.findByChatId("111")).thenReturn(Optional.of(chat));
         when(message.hasSticker()).thenReturn(true);
-        when(message.getSticker()).thenReturn(sticker);
-
-        when(message.hasSticker()).thenReturn(true);
         when(message.getSticker()).thenReturn(null);
-        when(message.getChatId()).thenReturn(12345L);
+        when(message.getChatId()).thenReturn(111L);
 
         SendMessage result = telegramSupportService.processSupportMessage(message, "en");
 
         assertNotNull(result);
-        assertTrue(result.getText().contains("file.failed"));
+        assertEquals(MessageProvider.get("en", "manager.file.failed"), result.getText());
 
         verify(telegramMessageRepository).delete(any());
     }
@@ -708,7 +704,7 @@ class TelegramSupportServiceTest {
     void testProcessSupportMessage_WithAnimation_ShouldSaveFileAsset() throws Exception {
         TelegramChat chat = new TelegramChat();
         chat.setId(1L);
-        chat.setChatId("12345");
+        chat.setChatId("111");
         chat.setChatState(ChatState.IN_SUPPORT);
         chat.setLanguageCode("en");
 
@@ -736,7 +732,7 @@ class TelegramSupportServiceTest {
         SendMessage result = telegramSupportService.processSupportMessage(message, "en");
 
         assertNotNull(result);
-        assertTrue(result.getText().contains("sent"));
+        assertTrue(result.getText().contains(MessageProvider.get("en", "message.sent.to.manager")));
         verify(messageAssetRepository).save(any(MessageAsset.class));
     }
 
@@ -744,7 +740,7 @@ class TelegramSupportServiceTest {
     void testProcessSupportMessage_WithNullAnimation_ShouldReturnErrorMessage() {
         TelegramChat chat = new TelegramChat();
         chat.setId(1L);
-        chat.setChatId("12345");
+        chat.setChatId("111");
         chat.setChatState(ChatState.IN_SUPPORT);
         chat.setLanguageCode("en");
 
@@ -757,12 +753,12 @@ class TelegramSupportServiceTest {
         when(message.getFrom()).thenReturn(from);
         when(message.hasAnimation()).thenReturn(true);
         when(message.getAnimation()).thenReturn(null);
-        when(message.getChatId()).thenReturn(98765L);
+        when(message.getChatId()).thenReturn(111L);
 
         SendMessage result = telegramSupportService.processSupportMessage(message, "en");
 
         assertNotNull(result);
-        assertTrue(result.getText().contains("file.failed"));
+        assertEquals((MessageProvider.get("en", "manager.file.failed")), result.getText());
         verify(telegramMessageRepository).delete(any());
     }
 

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramUtilsTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramUtilsTest.java
@@ -76,13 +76,13 @@ class TelegramUtilsTest {
         assertEquals(AssetType.FILE, result);
     }
 
-    @Test
-    void detectAssetTypeMultipartFile_WithNull_ShouldReturnFile() {
-        when(multipartFile.getContentType()).thenReturn(null);
-        AssetType result = TelegramUtils.detectAssetType(multipartFile);
-
-        assertEquals(AssetType.FILE, result);
-    }
+//    @Test
+//    void detectAssetTypeMultipartFile_WithNull_ShouldReturnFile() {
+//        when(multipartFile.getContentType()).thenReturn(null);
+//        AssetType result = TelegramUtils.detectAssetType(multipartFile);
+//
+//        assertEquals(AssetType.FILE, result);
+//    }
 
     @Test
     void detectAssetType_WithImageContentType_ShouldReturnImage() {
@@ -104,10 +104,10 @@ class TelegramUtilsTest {
         assertEquals(AssetType.FILE, TelegramUtils.detectAssetType("application/pdf"));
     }
 
-    @Test
-    void detectAssetType_WithNull_ShouldReturnFile() {
-        assertEquals(AssetType.FILE, TelegramUtils.detectAssetType((String) null));
-    }
+//    @Test
+//    void detectAssetType_WithNull_ShouldReturnFile() {
+//        assertEquals(AssetType.FILE, TelegramUtils.detectAssetType((String) null));
+//    }
 
     @Test
     void getFileNameFromPath_WithSlash_ShouldReturnFileName() {

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramUtilsTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramUtilsTest.java
@@ -7,6 +7,7 @@ import greencity.entity.user.employee.Position;
 import greencity.enums.AssetType;
 import greencity.enums.ChatState;
 import greencity.exceptions.NotFoundException;
+import greencity.exceptions.bots.UnsupportedTelegramAssetException;
 import greencity.repository.PositionRepository;
 import greencity.repository.TelegramChatRepository;
 import greencity.ubstelegrambot.messages.MessageProvider;
@@ -76,13 +77,18 @@ class TelegramUtilsTest {
         assertEquals(AssetType.FILE, result);
     }
 
-//    @Test
-//    void detectAssetTypeMultipartFile_WithNull_ShouldReturnFile() {
-//        when(multipartFile.getContentType()).thenReturn(null);
-//        AssetType result = TelegramUtils.detectAssetType(multipartFile);
-//
-//        assertEquals(AssetType.FILE, result);
-//    }
+    @Test
+    void detectAssetTypeMultipartFile_WithFile_ShouldReturnFile() {
+        assertEquals(AssetType.FILE, TelegramUtils.detectAssetType("application/file"));
+        assertEquals(AssetType.FILE, TelegramUtils.detectAssetType("text/format-file"));
+        assertEquals(AssetType.FILE, TelegramUtils.detectAssetType("image/svg"));
+    }
+
+    @Test
+    void detectAssetTypeMultipartFile_WithSticker_ShouldReturnSticker() {
+        assertEquals(AssetType.STICKER, TelegramUtils.detectAssetType("application/x-tgsticker"));
+        assertEquals(AssetType.STICKER, TelegramUtils.detectAssetType("image/webp"));
+    }
 
     @Test
     void detectAssetType_WithImageContentType_ShouldReturnImage() {
@@ -100,14 +106,17 @@ class TelegramUtilsTest {
     }
 
     @Test
-    void detectAssetType_WithUnknownContentType_ShouldReturnFile() {
-        assertEquals(AssetType.FILE, TelegramUtils.detectAssetType("application/pdf"));
+    void detectAssetTypeMultipartFile_WithNull_ShouldThrowException() {
+        when(multipartFile.getContentType()).thenReturn(null);
+
+        assertThrows(UnsupportedTelegramAssetException.class, () -> TelegramUtils.detectAssetType(multipartFile));
     }
 
-//    @Test
-//    void detectAssetType_WithNull_ShouldReturnFile() {
-//        assertEquals(AssetType.FILE, TelegramUtils.detectAssetType((String) null));
-//    }
+    @Test
+    void detectAssetType_WithUnknownContentType_ShouldThrowException() {
+        assertThrows(UnsupportedTelegramAssetException.class,
+            () -> TelegramUtils.detectAssetType("some/unknown content type"));
+    }
 
     @Test
     void getFileNameFromPath_WithSlash_ShouldReturnFileName() {


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#1822](https://github.com/ita-social-projects/GreenCityUBS/issues/1822)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support for stickers and animations as message attachments; stickers treated as a distinct asset type.

- Improvements
  - Added a new sticker asset type and improved content-type recognition (webp and Telegram sticker formats).
  - Stricter validation for unknown/null or unsupported asset content types with explicit errors.
  - Improved handling of messages with no usable content to keep chat state consistent.

- Tests
  - Expanded tests for stickers, animations, content-type mapping, error paths, and default animation naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->