### PR TITLE
Refactor: 1826 remove the manager ability to delete message

### DIFF
--- a/core/src/main/java/greencity/controller/TelegramController.java
+++ b/core/src/main/java/greencity/controller/TelegramController.java
@@ -37,7 +37,6 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
 import static greencity.constant.AppConstant.TELEGRAM_LINK;
 
 /**

--- a/core/src/main/java/greencity/controller/TelegramController.java
+++ b/core/src/main/java/greencity/controller/TelegramController.java
@@ -18,7 +18,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -27,7 +26,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,6 +37,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
 import static greencity.constant.AppConstant.TELEGRAM_LINK;
 
 /**
@@ -225,38 +224,6 @@ public class TelegramController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public ResponseEntity<Void> editMessage(@RequestBody @Valid EditTelegramMessageRequest request) {
         telegramService.editManagerMessage(request);
-        return ResponseEntity.noContent().build();
-    }
-
-    @Operation(summary = "Delete full telegram manager message (with all assets)")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "204", description = HttpStatuses.NO_CONTENT),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
-    })
-    @PreAuthorize("@preAuthorizer.hasAuthority('TELEGRAM_MANAGEMENT', authentication)")
-    @DeleteMapping(value = "/message/{messageId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> deleteMessage(@PathVariable @NotNull @Positive Long messageId,
-        @RequestParam @NotNull @Positive Long chatId) {
-        telegramService.deleteManagerMessage(messageId, chatId);
-        return ResponseEntity.noContent().build();
-    }
-
-    @Operation(summary = "Delete only one telegram manager asset")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "204", description = HttpStatuses.NO_CONTENT),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
-    })
-    @PreAuthorize("@preAuthorizer.hasAuthority('TELEGRAM_MANAGEMENT', authentication)")
-    @DeleteMapping(value = "/asset/{assetId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> deleteAsset(@PathVariable @NotNull @Positive Long assetId,
-        @RequestParam @NotNull @Positive Long chatId) {
-        telegramService.deleteManagerAsset(assetId, chatId);
         return ResponseEntity.noContent().build();
     }
 

--- a/core/src/test/java/greencity/controller/TelegramControllerTest.java
+++ b/core/src/test/java/greencity/controller/TelegramControllerTest.java
@@ -35,7 +35,6 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -178,32 +177,6 @@ class TelegramControllerTest {
             .andExpect(status().isNoContent());
 
         verify(telegramService).toggleNotifications(any(), eq(request));
-    }
-
-    @Test
-    void deleteMessage_ShouldReturnNoContent() throws Exception {
-        Long chatId = 1L;
-        Long messageId = 123L;
-
-        mockMvc.perform(delete("/ubs/telegram/message/{messageId}", messageId)
-            .param("chatId", chatId.toString())
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNoContent());
-
-        verify(telegramService).deleteManagerMessage(messageId, chatId);
-    }
-
-    @Test
-    void deleteAsset_ShouldReturnNoContent() throws Exception {
-        Long chatId = 1L;
-        Long assetId = 123L;
-
-        mockMvc.perform(delete("/ubs/telegram/asset/{assetId}", assetId)
-            .param("chatId", chatId.toString())
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNoContent());
-
-        verify(telegramService).deleteManagerAsset(assetId, chatId);
     }
 
     @Test

--- a/dao/src/main/java/greencity/repository/MessageAssetRepository.java
+++ b/dao/src/main/java/greencity/repository/MessageAssetRepository.java
@@ -2,8 +2,6 @@ package greencity.repository;
 
 import greencity.entity.telegram.MessageAsset;
 import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.List;
 
 public interface MessageAssetRepository extends JpaRepository<MessageAsset, Long> {
-    List<MessageAsset> findByTelegramMessageId(Integer telegramMessageId);
 }

--- a/dao/src/main/java/greencity/repository/TelegramChatRepository.java
+++ b/dao/src/main/java/greencity/repository/TelegramChatRepository.java
@@ -15,18 +15,6 @@ import java.util.Optional;
 public interface TelegramChatRepository
     extends JpaRepository<TelegramChat, Long>, JpaSpecificationExecutor<TelegramChat> {
     /**
-     * The method finds telegram bot by user and chat id and isNotify.
-     *
-     * @param user     {@link User}.
-     * @param chatId   {@link Long}.
-     * @param isNotify {@link Boolean}
-     * @return {@link Optional} {@link TelegramChat}.
-     *
-     * @author Julia Seti
-     */
-    Optional<TelegramChat> findByUserAndChatIdAndIsNotify(User user, String chatId, Boolean isNotify);
-
-    /**
      * The method finds telegram bot by user.
      *
      * @param user {@link User}.

--- a/dao/src/main/java/greencity/repository/TelegramMessageRepository.java
+++ b/dao/src/main/java/greencity/repository/TelegramMessageRepository.java
@@ -4,7 +4,6 @@ import greencity.entity.telegram.TelegramMessage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
 
 public interface TelegramMessageRepository extends JpaRepository<TelegramMessage, Long> {

--- a/dao/src/main/java/greencity/repository/TelegramMessageRepository.java
+++ b/dao/src/main/java/greencity/repository/TelegramMessageRepository.java
@@ -1,10 +1,10 @@
 package greencity.repository;
 
-import greencity.entity.telegram.TelegramChat;
 import greencity.entity.telegram.TelegramMessage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.Optional;
 
 public interface TelegramMessageRepository extends JpaRepository<TelegramMessage, Long> {
@@ -28,14 +28,4 @@ public interface TelegramMessageRepository extends JpaRepository<TelegramMessage
      *         otherwise empty
      */
     Optional<TelegramMessage> findByMediaGroupId(String mediaGroupId);
-
-    /**
-     * Finds the most recent {@link TelegramMessage} in a given chat, ordered by
-     * send time descending.
-     *
-     * @param chat the {@link TelegramChat} entity
-     * @return an {@link Optional} containing the latest {@link TelegramMessage} in
-     *         this chat, otherwise empty
-     */
-    Optional<TelegramMessage> findFirstByChatOrderBySendAtDesc(TelegramChat chat);
 }

--- a/service-api/src/main/java/greencity/service/ubs/TelegramService.java
+++ b/service-api/src/main/java/greencity/service/ubs/TelegramService.java
@@ -108,20 +108,4 @@ public interface TelegramService {
      *                ID, message ID and new text.
      */
     void editManagerMessage(EditTelegramMessageRequest request);
-
-    /**
-     * Delete full manager message (with all assets).
-     *
-     * @param messageId {@link Long} message ID.
-     * @param chatId    {@link Long} telegram chat ID
-     */
-    void deleteManagerMessage(Long messageId, Long chatId);
-
-    /**
-     * Delete manager asset.
-     *
-     * @param assetId {@link Long} asset ID.
-     * @param chatId  {@link Long} telegram chat ID
-     */
-    void deleteManagerAsset(Long assetId, Long chatId);
 }

--- a/service/src/main/java/greencity/ubstelegrambot/messages/MessageFactory.java
+++ b/service/src/main/java/greencity/ubstelegrambot/messages/MessageFactory.java
@@ -18,7 +18,6 @@ import org.telegram.telegrambots.meta.api.objects.media.InputMedia;
 import org.telegram.telegrambots.meta.api.objects.media.InputMediaPhoto;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardRemove;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/service/src/main/java/greencity/ubstelegrambot/messages/MessageFactory.java
+++ b/service/src/main/java/greencity/ubstelegrambot/messages/MessageFactory.java
@@ -11,8 +11,6 @@ import org.telegram.telegrambots.meta.api.methods.send.SendDocument;
 import org.telegram.telegrambots.meta.api.methods.send.SendMediaGroup;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
-import org.telegram.telegrambots.meta.api.methods.updatingmessages.DeleteMessage;
-import org.telegram.telegrambots.meta.api.methods.updatingmessages.DeleteMessages;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageCaption;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
@@ -20,6 +18,7 @@ import org.telegram.telegrambots.meta.api.objects.media.InputMedia;
 import org.telegram.telegrambots.meta.api.objects.media.InputMediaPhoto;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardRemove;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -584,40 +583,6 @@ public class MessageFactory {
             .chatId(chatId)
             .messageId(telegramMessageId)
             .caption(text)
-            .build();
-    }
-
-    /**
-     * Builds a DeleteMessage object with the specified chat ID and text to delete
-     * message.
-     *
-     * @param chatId            {@link String} the telegram chat ID
-     * @param telegramMessageId {@link Integer} the ID from telegram API
-     * @return a DeleteMessage object configured with the specified chat ID and
-     *         telegram message ID
-     */
-    public static DeleteMessage buildDeleteMessage(String chatId, Integer telegramMessageId) {
-        validationChatId(chatId);
-        return DeleteMessage.builder()
-            .chatId(chatId)
-            .messageId(telegramMessageId)
-            .build();
-    }
-
-    /**
-     * Builds a DeleteMessages object with the specified chat ID and text to delete
-     * message.
-     *
-     * @param chatId             {@link String} the telegram chat ID
-     * @param telegramMessagesId {@link List} the List of IDs from telegram API
-     * @return a DeleteMessages object configured with the specified chat ID and
-     *         telegram message IDs
-     */
-    public static DeleteMessages buildDeleteMessages(String chatId, List<Integer> telegramMessagesId) {
-        validationChatId(chatId);
-        return DeleteMessages.builder()
-            .chatId(chatId)
-            .messageIds(telegramMessagesId)
             .build();
     }
 

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
@@ -54,7 +54,6 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import org.telegram.telegrambots.meta.api.methods.send.SendMediaGroup;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
-import org.telegram.telegrambots.meta.api.methods.updatingmessages.DeleteMessage;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageCaption;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
 import org.telegram.telegrambots.meta.api.objects.Message;
@@ -605,69 +604,6 @@ public class TelegramServiceImpl implements TelegramService {
         }, () -> {
             throw new NotFoundException();
         });
-    }
-
-    @Override
-    @Transactional
-    public void deleteManagerMessage(Long messageId, Long chatId) {
-        TelegramChat chat = telegramChatRepository.findById(chatId).orElseThrow(NotFoundException::new);
-        if (messageId == null || messageId == 0) {
-            throw new NotFoundException("Message id must be provided");
-        }
-        TelegramMessage message = telegramMessageRepository.findById(messageId).orElseThrow(NotFoundException::new);
-        if (!Boolean.TRUE.equals(message.getFromManager())) {
-            return;
-        }
-        if (message.getChat() == null || !message.getChat().getId().equals(chat.getId())) {
-            throw new NotFoundException("Message " + messageId + " does not belong to chat " + chatId);
-        }
-        if (message.getAssets() != null && !message.getAssets().isEmpty()) {
-            executor.executeCommand(MessageFactory.buildDeleteMessages(chat.getChatId(),
-                message.getAssets().stream().map(MessageAsset::getTelegramMessageId).toList()));
-        } else if (message.getTelegramMessageId() != null) {
-            executor.executeCommand(MessageFactory.buildDeleteMessage(chat.getChatId(),
-                message.getTelegramMessageId()));
-        }
-        telegramMessageRepository.delete(message);
-        updateLastMessage(chat);
-    }
-
-    @Override
-    @Transactional
-    public void deleteManagerAsset(Long assetId, Long chatId) {
-        messageAssetRepository.findById(assetId).ifPresent(asset -> {
-            TelegramMessage parent = asset.getMessage();
-            if (parent.getFromManager()) {
-                DeleteMessage deleteMessage = MessageFactory.buildDeleteMessage(parent.getChat().getChatId(),
-                    asset.getTelegramMessageId());
-                executor.executeCommand(deleteMessage);
-
-                MessageAsset nextAsset = parent.getAssets().getFirst();
-                parent.getAssets().remove(asset);
-                messageAssetRepository.delete(asset);
-
-                if (parent.getAssets().isEmpty()) {
-                    telegramMessageRepository.delete(parent);
-                    updateLastMessage(parent.getChat());
-                } else {
-                    if (parent.getText() != null && !parent.getText().isBlank() && asset.equals(nextAsset)) {
-                        nextAsset = parent.getAssets().getFirst();
-                        EditMessageCaption editCaption = MessageFactory.buildEditMessageCaption(
-                            parent.getChat().getChatId(),
-                            nextAsset.getTelegramMessageId(),
-                            parent.getText());
-                        executor.executeCommand(editCaption);
-                    }
-                }
-            }
-        });
-    }
-
-    private void updateLastMessage(TelegramChat chat) {
-        telegramMessageRepository.findFirstByChatOrderBySendAtDesc(chat)
-            .ifPresentOrElse(chat::setLastMessage,
-                () -> chat.setLastMessage(null));
-        telegramChatRepository.save(chat);
     }
 
     private boolean isStartCommand(Message message) {

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
@@ -57,8 +57,6 @@ import org.telegram.telegrambots.meta.api.methods.send.SendDocument;
 import org.telegram.telegrambots.meta.api.methods.send.SendMediaGroup;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
-import org.telegram.telegrambots.meta.api.methods.updatingmessages.DeleteMessage;
-import org.telegram.telegrambots.meta.api.methods.updatingmessages.DeleteMessages;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageCaption;
 import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
@@ -87,9 +85,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
@@ -98,7 +94,6 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @Slf4j
@@ -1298,241 +1293,12 @@ class TelegramServiceTest {
     }
 
     @Test
-    void deleteMessage_shouldDeleteAndUpdateLastMessage() {
-        var chat = new TelegramChat();
-        chat.setId(1L);
-        chat.setChatId("12345");
-
-        var message = new TelegramMessage();
-        message.setId(100L);
-        message.setTelegramMessageId(42);
-        message.setFromManager(true);
-        message.setChat(chat);
-
-        chat.setLastMessage(message);
-
-        when(telegramChatRepository.findById(anyLong())).thenReturn(Optional.of(chat));
-        when(telegramMessageRepository.findById(anyLong()))
-            .thenReturn(Optional.of(message));
-
-        telegramService.deleteManagerMessage(message.getId(), chat.getId());
-
-        verify(executor).executeCommand(any(DeleteMessage.class));
-        verify(telegramMessageRepository).delete(message);
-        verify(telegramChatRepository).save(chat);
-    }
-
-    @Test
-    void deleteAsset_shouldDeleteParentIfNoAssetsLeft() {
-        var chat = new TelegramChat();
-        chat.setId(2L);
-        chat.setChatId("123456");
-
-        var parent = new TelegramMessage();
-        parent.setId(200L);
-        parent.setTelegramMessageId(55);
-        parent.setFromManager(true);
-        parent.setChat(chat);
-
-        var asset = new MessageAsset();
-        asset.setId(300L);
-        asset.setTelegramMessageId(56);
-        asset.setMessage(parent);
-
-        parent.getAssets().add(asset);
-        chat.setLastMessage(parent);
-
-        when(messageAssetRepository.findById(asset.getId())).thenReturn(Optional.of(asset));
-
-        telegramService.deleteManagerAsset(asset.getId(), chat.getId());
-
-        verify(executor).executeCommand(any(DeleteMessage.class));
-        verify(telegramMessageRepository).delete(parent);
-        verify(messageAssetRepository).delete(asset);
-    }
-
-    @Test
-    void deleteAsset_shouldEditCaptionIfTextPresentAndAssetsRemain() {
-        var chat = new TelegramChat();
-        chat.setId(3L);
-        chat.setChatId("123456");
-
-        var parent = new TelegramMessage();
-        parent.setId(201L);
-        parent.setTelegramMessageId(66);
-        parent.setFromManager(true);
-        parent.setChat(chat);
-        parent.setText("hello");
-
-        var asset1 = new MessageAsset();
-        asset1.setId(301L);
-        asset1.setTelegramMessageId(67);
-        asset1.setMessage(parent);
-
-        var asset2 = new MessageAsset();
-        asset2.setId(302L);
-        asset2.setTelegramMessageId(68);
-        asset2.setMessage(parent);
-
-        parent.getAssets().add(asset1);
-        parent.getAssets().add(asset2);
-
-        when(messageAssetRepository.findById(asset1.getId())).thenReturn(Optional.of(asset1));
-
-        telegramService.deleteManagerAsset(asset1.getId(), chat.getId());
-
-        verify(messageAssetRepository).delete(asset1);
-        verify(executor).executeCommand(any(EditMessageCaption.class));
-        verifyNoMoreInteractions(telegramMessageRepository);
-    }
-
-    @Test
-    void deleteAsset_whenFromManagerIsFalse_shouldReturnNoting() {
-        TelegramMessage mess = TelegramMessage.builder()
-            .fromManager(false)
-            .chat(TelegramChat.builder().chatId("123").build())
-            .build();
-
-        MessageAsset asset = MessageAsset.builder()
-            .message(mess)
-            .telegramMessageId(1)
-            .build();
-        when(messageAssetRepository.findById(1L)).thenReturn(Optional.of(asset));
-
-        telegramService.deleteManagerAsset(1L, 1L);
-
-        verify(messageAssetRepository, never()).delete(any());
-        verify(executor, never()).executeCommand(any(DeleteMessage.class));
-    }
-
-    @Test
-    void deleteManagerMessage_shouldThrowNotFoundException_whenMessageIdIsNull() {
-        when(telegramChatRepository.findById(anyLong())).thenReturn(Optional.of(new TelegramChat()));
-        assertThrows(NotFoundException.class, () -> telegramService.deleteManagerMessage(null, 1L));
-    }
-
-    @Test
-    void deleteManagerMessage_WhenHasAssets_ShouldDeleteAllAssets() {
-        Long chatId = 1L;
-        Long messageId = 10L;
-
-        TelegramChat chat = new TelegramChat();
-        chat.setId(1L);
-        chat.setChatId("123");
-
-        MessageAsset asset1 = new MessageAsset();
-        asset1.setTelegramMessageId(111);
-        MessageAsset asset2 = new MessageAsset();
-        asset2.setTelegramMessageId(222);
-
-        TelegramMessage message = new TelegramMessage();
-        message.setFromManager(true);
-        message.setAssets(List.of(asset1, asset2));
-        message.setChat(chat);
-
-        when(telegramChatRepository.findById(chatId)).thenReturn(Optional.of(chat));
-        when(telegramMessageRepository.findById(messageId)).thenReturn(Optional.of(message));
-
-        telegramService.deleteManagerMessage(messageId, chatId);
-
-        verify(executor).executeCommand(
-            argThat(cmd -> cmd instanceof DeleteMessages &&
-                ((DeleteMessages) cmd).getMessageIds().containsAll(List.of(111, 222))));
-        verify(telegramMessageRepository).delete(message);
-        verify(telegramChatRepository).save(chat);
-    }
-
-    @Test
-    void deleteManagerMessage_WhenNoAssets_ShouldDeleteSingleMessage() {
-        Long chatId = 1L;
-        Long messageId = 20L;
-
-        TelegramChat chat = new TelegramChat();
-        chat.setId(1L);
-        chat.setChatId("456");
-
-        TelegramMessage message = new TelegramMessage();
-        message.setFromManager(true);
-        message.setTelegramMessageId(999);
-        message.setChat(chat);
-
-        when(telegramChatRepository.findById(chatId)).thenReturn(Optional.of(chat));
-        when(telegramMessageRepository.findById(messageId)).thenReturn(Optional.of(message));
-
-        telegramService.deleteManagerMessage(messageId, chatId);
-
-        verify(executor).executeCommand(
-            argThat(cmd -> cmd instanceof DeleteMessage &&
-                ((DeleteMessage) cmd).getMessageId() == 999));
-        verify(telegramMessageRepository).delete(message);
-        verify(telegramChatRepository).save(chat);
-    }
-
-    @Test
-    void deleteManagerMessage_WhenMessageIdIsNull_ShouldThrowNotFoundException() {
-        Long chatId = 1L;
-
-        TelegramChat chat = new TelegramChat();
-        chat.setId(chatId);
-        chat.setChatId("123");
-        when(telegramChatRepository.findById(chatId)).thenReturn(Optional.of(chat));
-
-        assertThrows(NotFoundException.class,
-            () -> telegramService.deleteManagerMessage(null, chatId));
-
-        verifyNoInteractions(telegramMessageRepository);
-        verifyNoInteractions(executor);
-    }
-
-    @Test
     void editManagerMessage_shouldThrowNotFoundException_whenChatNotFound() {
         EditTelegramMessageRequest request = new EditTelegramMessageRequest(1L, 100L, "new text");
 
         when(telegramChatRepository.findById(1L)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class, () -> telegramService.editManagerMessage(request));
-    }
-
-    @Test
-    void deleteManagerMessage_WhenMessageIdIsZero_ShouldThrowNotFoundException() {
-        Long chatId = 1L;
-
-        TelegramChat chat = new TelegramChat();
-        chat.setId(chatId);
-        chat.setChatId("123");
-        when(telegramChatRepository.findById(chatId)).thenReturn(Optional.of(chat));
-
-        assertThrows(NotFoundException.class,
-            () -> telegramService.deleteManagerMessage(0L, chatId));
-
-        verifyNoInteractions(telegramMessageRepository);
-        verifyNoInteractions(executor);
-    }
-
-    @Test
-    void deleteManagerMessage_WhenMessageDoesNotBelongToChat_ShouldThrowNotFoundException() {
-        Long chatId = 1L;
-        Long messageId = 10L;
-
-        TelegramChat chat = new TelegramChat();
-        chat.setId(chatId);
-        chat.setChatId("123");
-
-        TelegramChat otherChat = new TelegramChat();
-        otherChat.setId(99L);
-
-        TelegramMessage message = new TelegramMessage();
-        message.setFromManager(true);
-        message.setChat(otherChat);
-
-        when(telegramChatRepository.findById(chatId)).thenReturn(Optional.of(chat));
-        when(telegramMessageRepository.findById(messageId)).thenReturn(Optional.of(message));
-
-        assertThrows(NotFoundException.class,
-            () -> telegramService.deleteManagerMessage(messageId, chatId));
-
-        verifyNoInteractions(executor);
-        verify(telegramMessageRepository, never()).delete(any());
     }
 
     @Test
@@ -1545,28 +1311,6 @@ class TelegramServiceTest {
         when(telegramMessageRepository.findById(100L)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class, () -> telegramService.editManagerMessage(request));
-    }
-
-    @Test
-    void deleteManagerMessage_WhenFromManagerIsFalse_ShouldDoNothing() {
-        Long chatId = 1L;
-        Long messageId = 10L;
-
-        TelegramChat chat = new TelegramChat();
-        chat.setId(chatId);
-        chat.setChatId("123");
-
-        TelegramMessage message = new TelegramMessage();
-        message.setFromManager(false);
-        message.setChat(chat);
-
-        when(telegramChatRepository.findById(chatId)).thenReturn(Optional.of(chat));
-        when(telegramMessageRepository.findById(messageId)).thenReturn(Optional.of(message));
-
-        telegramService.deleteManagerMessage(messageId, chatId);
-
-        verifyNoInteractions(executor);
-        verify(telegramMessageRepository, never()).delete(any());
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#1826](https://github.com/ita-social-projects/GreenCityUBS/issues/1826)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed DELETE API endpoints for Telegram message and asset deletion.
  - Deletion via API is no longer supported; existing messaging, chats, feedback, and notifications remain unchanged.
- Tests
  - Updated tests to reflect the removal of deletion endpoints.
- Chores
  - Cleaned up obsolete deletion-related code paths and imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->