### PR TITLE
#9096 - Implement endpoint for user category retrieval

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementNotificationController.java
+++ b/core/src/main/java/greencity/controller/ManagementNotificationController.java
@@ -11,6 +11,7 @@ import greencity.dto.pageble.PageableDto;
 import greencity.service.notification.NotificationTemplateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -168,7 +169,7 @@ public class ManagementNotificationController {
     @Operation(summary = "Get all user categories")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
-            content = @Content(schema = @Schema(implementation = UserCategoryDto.class))),
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = UserCategoryDto.class)))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content)
     })

--- a/core/src/main/java/greencity/controller/ManagementNotificationController.java
+++ b/core/src/main/java/greencity/controller/ManagementNotificationController.java
@@ -12,6 +12,7 @@ import greencity.service.notification.NotificationTemplateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.Positive;
@@ -166,7 +167,8 @@ public class ManagementNotificationController {
      */
     @Operation(summary = "Get all user categories")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK, content = @Content),
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
+            content = @Content(schema = @Schema(implementation = UserCategoryDto.class))),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content)
     })

--- a/core/src/main/java/greencity/controller/ManagementNotificationController.java
+++ b/core/src/main/java/greencity/controller/ManagementNotificationController.java
@@ -6,6 +6,7 @@ import greencity.dto.notification.AddNotificationTemplateWithPlatformsDto;
 import greencity.dto.notification.NotificationTemplateDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsUpdateDto;
+import greencity.dto.notification.UserCategoryDto;
 import greencity.dto.pageble.PageableDto;
 import greencity.service.notification.NotificationTemplateService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestBody;
+import java.util.List;
 
 @RestController
 @RequestMapping("/admin/notification")
@@ -157,5 +159,19 @@ public class ManagementNotificationController {
     public ResponseEntity<HttpStatus> removeNotificationTemplate(@Positive @PathVariable Long id) {
         notificationTemplateService.removeNotificationTemplate(id);
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /**
+     * Controller that returns a list of all user categories.
+     */
+    @Operation(summary = "Get all user categories")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK, content = @Content),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN, content = @Content)
+    })
+    @GetMapping("/get-all-user-categories")
+    public ResponseEntity<List<UserCategoryDto>> getAllUserCategories() {
+        return ResponseEntity.status(HttpStatus.OK).body(notificationTemplateService.getAllUserCategories());
     }
 }

--- a/core/src/test/java/greencity/controller/ManagementNotificationControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementNotificationControllerTest.java
@@ -213,4 +213,11 @@ class ManagementNotificationControllerTest {
 
         verify(notificationTemplateService).removeNotificationTemplate(any());
     }
+
+    @Test
+    void getAllUserCategoriesTest() throws Exception {
+        mockMvc.perform(get(url + "/get-all-user-categories")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+    }
 }

--- a/service-api/src/main/java/greencity/dto/notification/UserCategoryDto.java
+++ b/service-api/src/main/java/greencity/dto/notification/UserCategoryDto.java
@@ -1,5 +1,6 @@
 package greencity.dto.notification;
 
+import greencity.enums.UserCategory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class UserCategoryDto {
-    private String name;
+    private UserCategory userCategory;
     private String descriptionUk;
     private String descriptionEn;
 }

--- a/service-api/src/main/java/greencity/dto/notification/UserCategoryDto.java
+++ b/service-api/src/main/java/greencity/dto/notification/UserCategoryDto.java
@@ -1,0 +1,16 @@
+package greencity.dto.notification;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserCategoryDto {
+    private String name;
+    private String descriptionUk;
+    private String descriptionEn;
+}

--- a/service-api/src/main/java/greencity/service/notification/NotificationTemplateService.java
+++ b/service-api/src/main/java/greencity/service/notification/NotificationTemplateService.java
@@ -4,8 +4,10 @@ import greencity.dto.notification.AddNotificationTemplateWithPlatformsDto;
 import greencity.dto.notification.NotificationTemplateDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsUpdateDto;
+import greencity.dto.notification.UserCategoryDto;
 import greencity.dto.pageble.PageableDto;
 import org.springframework.data.domain.Pageable;
+import java.util.List;
 
 public interface NotificationTemplateService {
     /**
@@ -50,4 +52,9 @@ public interface NotificationTemplateService {
      * @author Denys Ryhal
      */
     void removeNotificationTemplate(Long id);
+
+    /**
+     * Method that returns all user categories.
+     */
+    List<UserCategoryDto> getAllUserCategories();
 }

--- a/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
@@ -201,7 +201,7 @@ public class NotificationTemplateServiceImpl implements NotificationTemplateServ
     public List<UserCategoryDto> getAllUserCategories() {
         return Arrays.stream(UserCategory.values())
             .map(userCategory -> new UserCategoryDto(
-                userCategory.name(),
+                userCategory,
                 userCategory.getDescriptionUk(),
                 userCategory.getDescriptionEn()))
             .toList();

--- a/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
@@ -6,12 +6,14 @@ import greencity.dto.notification.NotificationPlatformDto;
 import greencity.dto.notification.NotificationTemplateDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsUpdateDto;
+import greencity.dto.notification.UserCategoryDto;
 import greencity.dto.pageble.PageableDto;
 import greencity.entity.notifications.NotificationPlatform;
 import greencity.entity.notifications.NotificationTemplate;
 import greencity.enums.NotificationReceiverType;
 import greencity.enums.NotificationStatus;
 import greencity.enums.NotificationType;
+import greencity.enums.UserCategory;
 import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.ForbiddenException;
@@ -195,6 +197,16 @@ public class NotificationTemplateServiceImpl implements NotificationTemplateServ
         restartNotificationSchedule(NotificationType.CUSTOM);
     }
 
+    @Override
+    public List<UserCategoryDto> getAllUserCategories() {
+        return Arrays.stream(UserCategory.values())
+            .map(userCategory -> new UserCategoryDto(
+                userCategory.name(),
+                userCategory.getDescriptionUk(),
+                userCategory.getDescriptionEn()))
+            .toList();
+    }
+
     private void checkTemplateIsCustom(Long id) {
         NotificationTemplate template = getById(id);
         if (!template.getNotificationType().equals(NotificationType.CUSTOM)) {
@@ -206,9 +218,6 @@ public class NotificationTemplateServiceImpl implements NotificationTemplateServ
         notificationTemplateRepository.deleteById(id);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     private NotificationTemplate getById(Long id) {
         return notificationTemplateRepository.findById(id)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.NOTIFICATION_TEMPLATE_NOT_FOUND_BY_ID + id));

--- a/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
+++ b/service/src/main/java/greencity/service/notification/NotificationTemplateServiceImpl.java
@@ -43,6 +43,13 @@ public class NotificationTemplateServiceImpl implements NotificationTemplateServ
     private final NotificationPlanner notificationPlanner;
     private final ModelMapper modelMapper;
 
+    private static final List<UserCategoryDto> USER_CATEGORIES = Arrays.stream(UserCategory.values())
+        .map(userCategory -> new UserCategoryDto(
+            userCategory,
+            userCategory.getDescriptionUk(),
+            userCategory.getDescriptionEn()))
+        .toList();
+
     /**
      * {@inheritDoc}
      */
@@ -199,12 +206,7 @@ public class NotificationTemplateServiceImpl implements NotificationTemplateServ
 
     @Override
     public List<UserCategoryDto> getAllUserCategories() {
-        return Arrays.stream(UserCategory.values())
-            .map(userCategory -> new UserCategoryDto(
-                userCategory,
-                userCategory.getDescriptionUk(),
-                userCategory.getDescriptionEn()))
-            .toList();
+        return USER_CATEGORIES;
     }
 
     private void checkTemplateIsCustom(Long id) {

--- a/service/src/test/java/greencity/service/notification/NotificationTemplateServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationTemplateServiceImplTest.java
@@ -4,6 +4,7 @@ import greencity.ModelUtils;
 import greencity.constant.ErrorMessage;
 import greencity.dto.notification.NotificationTemplateDto;
 import greencity.dto.notification.NotificationTemplateWithPlatformsDto;
+import greencity.dto.notification.UserCategoryDto;
 import greencity.entity.notifications.NotificationTemplate;
 import greencity.enums.NotificationReceiverType;
 import greencity.enums.NotificationType;
@@ -322,6 +323,22 @@ class NotificationTemplateServiceImplTest {
 
         assertThrows(TemplateDeleteException.class, () -> notificationService.removeNotificationTemplate(1L));
         verify(templateRepository).findById(anyLong());
+    }
+
+    @Test
+    void getAllUserCategoriesTest() {
+        List<UserCategoryDto> userCategories = notificationService.getAllUserCategories();
+
+        assertEquals(UserCategory.values().length, userCategories.size());
+
+        for (int i = 0; i < UserCategory.values().length; i++) {
+            UserCategory enumVal = UserCategory.values()[i];
+            UserCategoryDto dto = userCategories.get(i);
+
+            assertEquals(enumVal.name(), dto.getName());
+            assertEquals(enumVal.getDescriptionUk(), dto.getDescriptionUk());
+            assertEquals(enumVal.getDescriptionEn(), dto.getDescriptionEn());
+        }
     }
 
 }

--- a/service/src/test/java/greencity/service/notification/NotificationTemplateServiceImplTest.java
+++ b/service/src/test/java/greencity/service/notification/NotificationTemplateServiceImplTest.java
@@ -335,7 +335,7 @@ class NotificationTemplateServiceImplTest {
             UserCategory enumVal = UserCategory.values()[i];
             UserCategoryDto dto = userCategories.get(i);
 
-            assertEquals(enumVal.name(), dto.getName());
+            assertEquals(enumVal, dto.getUserCategory());
             assertEquals(enumVal.getDescriptionUk(), dto.getDescriptionUk());
             assertEquals(enumVal.getDescriptionEn(), dto.getDescriptionEn());
         }


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link :clipboard:
[#9096](https://github.com/ita-social-projects/GreenCity/issues/9096)

## Summary Of Changes :fire:
* Implemented mechanism for user category retrieval and related tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Admin API endpoint to retrieve all notification user categories, each with English and Ukrainian descriptions.

- **Documentation**
  - Added API metadata and response docs for the new endpoint.

- **Tests**
  - Added controller test to confirm successful retrieval.
  - Added service test to verify all categories are returned with correct names and descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->