### PR TITLE
Fix/9074 notifications time send

### DIFF
--- a/service/src/main/java/greencity/notificator/scheduler/NotificationTaskScheduler.java
+++ b/service/src/main/java/greencity/notificator/scheduler/NotificationTaskScheduler.java
@@ -2,6 +2,7 @@ package greencity.notificator.scheduler;
 
 import greencity.constant.AppConstant;
 import greencity.enums.NotificationType;
+import java.time.ZoneId;
 import java.util.concurrent.ScheduledFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +26,8 @@ public class NotificationTaskScheduler {
     private ScheduledFuture<Void> scheduleTask(Runnable task, String schedule, NotificationType notificationType) {
         ScheduledFuture<Void> scheduledFuture = null;
         if (isExpressionCorrect(schedule, notificationType)) {
-            scheduledFuture = (ScheduledFuture<Void>) taskScheduler.schedule(task, new CronTrigger(schedule));
+            scheduledFuture = (ScheduledFuture<Void>) taskScheduler.schedule(task,
+                new CronTrigger(schedule, ZoneId.of("Europe/Kyiv")));
             log.info(AppConstant.NOTIFICATOR_SUCCESSFULLY_START_LOG_MESSAGE, notificationType, schedule);
         }
         return scheduledFuture;


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#9074](https://github.com/ita-social-projects/GreenCity/issues/9074)

## Changed
- Notification scheduling uses Kyiv timezone instead of server timezone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled notifications now run in the Europe/Kyiv timezone, ensuring consistent delivery times aligned with Kyiv local time.
  * Prevents timing drift that could occur when servers used different default timezones or during daylight saving transitions.
  * Cron expressions and existing schedules remain unchanged; only the timezone context is updated.
  * No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->