### PR TITLE
Feature: 9076 show updated user messages in admin panel after telegram edit

### DIFF
--- a/dao/src/main/java/greencity/repository/TelegramMessageRepository.java
+++ b/dao/src/main/java/greencity/repository/TelegramMessageRepository.java
@@ -38,4 +38,6 @@ public interface TelegramMessageRepository extends JpaRepository<TelegramMessage
      *         this chat, otherwise empty
      */
     Optional<TelegramMessage> findFirstByChatOrderBySendAtDesc(TelegramChat chat);
+
+    Optional<TelegramMessage> findByTelegramMessageId(Integer messageId);
 }

--- a/dao/src/main/java/greencity/repository/TelegramMessageRepository.java
+++ b/dao/src/main/java/greencity/repository/TelegramMessageRepository.java
@@ -39,5 +39,14 @@ public interface TelegramMessageRepository extends JpaRepository<TelegramMessage
      */
     Optional<TelegramMessage> findFirstByChatOrderBySendAtDesc(TelegramChat chat);
 
-    Optional<TelegramMessage> findByTelegramMessageId(Integer messageId);
+    /**
+     * Finds the most recent {@link TelegramMessage} in a given chat, ordered by
+     * send time descending.
+     *
+     * @param telegramChat the {@link TelegramChat} entity
+     * @param messageId    the {@link Integer} telegram message ID
+     * @return an {@link Optional} containing the latest {@link TelegramMessage} in
+     *         this chat, otherwise empty
+     */
+    Optional<TelegramMessage> findByChatAndTelegramMessageId(TelegramChat telegramChat, Integer messageId);
 }

--- a/service-api/src/main/java/greencity/service/ubs/TelegramSupportService.java
+++ b/service-api/src/main/java/greencity/service/ubs/TelegramSupportService.java
@@ -15,5 +15,15 @@ public interface TelegramSupportService {
      */
     SendMessage processSupportMessage(Message message, String lang);
 
+    /**
+     * Processes an incoming support message from a Telegram user.
+     *
+     * @param edited the incoming Telegram {@link Message} containing user text,
+     *                photos, or command.
+     * @param lang {@link String} the current language
+     * @return a {@link SendMessage} object to be sent back to the user via
+     *         Telegram, confirming that the message was received or an error
+     *         occurred.
+     */
     SendMessage processEditedSupportMessage(Message edited, String lang);
 }

--- a/service-api/src/main/java/greencity/service/ubs/TelegramSupportService.java
+++ b/service-api/src/main/java/greencity/service/ubs/TelegramSupportService.java
@@ -14,4 +14,6 @@ public interface TelegramSupportService {
      *         occurred.
      */
     SendMessage processSupportMessage(Message message, String lang);
+
+    SendMessage processEditedSupportMessage(Message edited, String lang);
 }

--- a/service-api/src/main/java/greencity/service/ubs/TelegramSupportService.java
+++ b/service-api/src/main/java/greencity/service/ubs/TelegramSupportService.java
@@ -19,8 +19,8 @@ public interface TelegramSupportService {
      * Processes an incoming support message from a Telegram user.
      *
      * @param edited the incoming Telegram {@link Message} containing user text,
-     *                photos, or command.
-     * @param lang {@link String} the current language
+     *               photos, or command.
+     * @param lang   {@link String} the current language
      * @return a {@link SendMessage} object to be sent back to the user via
      *         Telegram, confirming that the message was received or an error
      *         occurred.

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
@@ -705,7 +705,7 @@ public class TelegramServiceImpl implements TelegramService {
 
     private TelegramUpdateProcessor handleDefaultUpdate(Update update) {
         String chatId;
-        if(update.hasCallbackQuery()){
+        if (update.hasCallbackQuery()) {
             chatId = update.getCallbackQuery().getFrom().getId().toString();
         } else if (update.hasMessage()) {
             chatId = update.getMessage().getChatId().toString();

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
@@ -704,9 +704,14 @@ public class TelegramServiceImpl implements TelegramService {
     }
 
     private TelegramUpdateProcessor handleDefaultUpdate(Update update) {
-        String chatId = update.hasCallbackQuery()
-            ? update.getCallbackQuery().getFrom().getId().toString()
-            : update.getMessage().getChatId().toString();
+        String chatId;
+        if(update.hasCallbackQuery()){
+            chatId = update.getCallbackQuery().getFrom().getId().toString();
+        } else if (update.hasMessage()) {
+            chatId = update.getMessage().getChatId().toString();
+        } else {
+            chatId = update.getEditedMessage().getChatId().toString();
+        }
 
         telegramChatRepository.findByChatId(chatId).ifPresent(chat -> {
             Instant updatedAt = chat.getChatStateUpdatedAt();

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -226,10 +226,10 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
     }
 
     private SendMessage setStickerInfo(Message message, TelegramMessage telegramMessage,
-        Optional<TelegramMessage> telegramMessageOpt, FileInfo fileInfo, String lang) {
+        Optional<TelegramMessage> previouslySavedMessage, FileInfo fileInfo, String lang) {
         Sticker sticker = message.getSticker();
         if (sticker == null) {
-            if (telegramMessageOpt.isEmpty()) {
+            if (previouslySavedMessage.isEmpty()) {
                 telegramMessageRepository.delete(telegramMessage);
             }
             return MessageFactory.buildMessage(message.getChatId().toString(),
@@ -245,12 +245,12 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
 
     private SendMessage setAnimationInfo(Message message,
         TelegramMessage telegramMessage,
-        Optional<TelegramMessage> telegramMessageOpt,
+        Optional<TelegramMessage> previouslySavedMessage,
         FileInfo fileInfo,
         String lang) {
         Animation animation = message.getAnimation();
         if (animation == null) {
-            if (telegramMessageOpt.isEmpty()) {
+            if (previouslySavedMessage.isEmpty()) {
                 telegramMessageRepository.delete(telegramMessage);
             }
             return MessageFactory.buildMessage(message.getChatId().toString(),
@@ -268,7 +268,7 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
 
     private SendMessage setPhotoInfo(Message message,
         TelegramMessage telegramMessage,
-        Optional<TelegramMessage> telegramMessageOpt,
+        Optional<TelegramMessage> previouslySavedMessage,
         FileInfo fileInfo,
         String lang) {
         PhotoSize largestPhoto = message.getPhoto().stream()
@@ -276,7 +276,7 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
             .orElse(null);
 
         if (largestPhoto == null) {
-            if (telegramMessageOpt.isEmpty()) {
+            if (previouslySavedMessage.isEmpty()) {
                 telegramMessageRepository.delete(telegramMessage);
             }
             return MessageFactory.buildMessage(message.getChatId().toString(),
@@ -290,12 +290,12 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
 
     private SendMessage setDocumentInfo(Message message,
         TelegramMessage telegramMessage,
-        Optional<TelegramMessage> telegramMessageOpt,
+        Optional<TelegramMessage> previouslySavedMessage,
         FileInfo fileInfo,
         String lang) {
         Document document = message.getDocument();
         if (document == null) {
-            if (telegramMessageOpt.isEmpty()) {
+            if (previouslySavedMessage.isEmpty()) {
                 telegramMessageRepository.delete(telegramMessage);
             }
             return MessageFactory.buildMessage(message.getChatId().toString(),
@@ -311,7 +311,7 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
 
     private SendMessage setFileAsMessageAsset(Message message,
         TelegramMessage telegramMessage,
-        Optional<TelegramMessage> telegramMessageOpt,
+        Optional<TelegramMessage> previouslySavedMessage,
         FileInfo fileInfo,
         String lang) {
         try {
@@ -353,10 +353,11 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
                 .message(telegramMessage)
                 .build();
 
-            if (telegramMessageOpt.isPresent()) {
-                List<MessageAsset> existingAssets = new ArrayList<>(telegramMessage.getAssets());
-                existingAssets.add(asset);
-                telegramMessage.getAssets().addAll(existingAssets);
+            if (previouslySavedMessage.isPresent()) {
+                if (telegramMessage.getAssets() == null) {
+                    telegramMessage.setAssets(new ArrayList<>());
+                }
+                telegramMessage.getAssets().add(asset);
             } else {
                 telegramMessage.setAssets((new ArrayList<>(List.of(asset))));
             }
@@ -376,7 +377,7 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
         Message message,
         String mediaGroupId,
         TelegramMessage telegramMessage,
-        Optional<TelegramMessage> telegramMessageOpt) {
+        Optional<TelegramMessage> previouslySavedMessage) {
         List<MessageAssetDto> assetDtos = Optional.ofNullable(telegramMessage.getAssets())
             .orElse(Collections.emptyList())
             .stream()
@@ -400,7 +401,7 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
             .assets(assetDtos)
             .build();
 
-        if (telegramMessageOpt.isEmpty()) {
+        if (previouslySavedMessage.isEmpty()) {
             telegramChatProducer.notifyNewMessage(telegramMessageDto, chat.getId());
 
             String contentForNotification = buildContentForNotification(telegramMessage);

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -66,9 +66,8 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
     @Override
     @Transactional
     public SendMessage processSupportMessage(Message message, String lang) {
-        Optional<TelegramChat> optionalChat = telegramChatRepository.findByChatId(message.getFrom().getId().toString());
+        Optional<TelegramChat> optionalChat = findAndValidateChat(message.getFrom().getId().toString());
         if (optionalChat.isEmpty()) {
-            log.warn("Telegram chat not found by ID: {}", message.getFrom().getId());
             return MessageFactory.createUnknownErrorOccurredMessage(message.getChatId().toString(),
                 TelegramBotConstants.UK);
         }
@@ -99,9 +98,8 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
     @Override
     @Transactional
     public SendMessage processEditedSupportMessage(Message edited, String lang) {
-        Optional<TelegramChat> optionalChat = telegramChatRepository.findByChatId(edited.getFrom().getId().toString());
+        Optional<TelegramChat> optionalChat = findAndValidateChat(edited.getFrom().getId().toString());
         if (optionalChat.isEmpty()) {
-            log.warn("Telegram chat not found by ID: {}", edited.getFrom().getId());
             return MessageFactory.createUnknownErrorOccurredMessage(edited.getChatId().toString(),
                     TelegramBotConstants.UK);
         }
@@ -129,6 +127,14 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
 
         telegramMessageRepository.save(telegramMessage);
         return null;
+    }
+
+    private Optional<TelegramChat> findAndValidateChat(String chatId) {
+        Optional<TelegramChat> optionalChat = telegramChatRepository.findByChatId(chatId);
+        if (optionalChat.isEmpty()) {
+            log.warn("Telegram chat not found by ID: {}", chatId);
+        }
+        return optionalChat;
     }
 
     private SendMessage processMessageContent(TelegramChat chat, Message message) {

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -96,6 +96,41 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
         return processMessageContent(chat, message);
     }
 
+    @Override
+    @Transactional
+    public SendMessage processEditedSupportMessage(Message edited, String lang) {
+        Optional<TelegramChat> optionalChat = telegramChatRepository.findByChatId(edited.getFrom().getId().toString());
+        if (optionalChat.isEmpty()) {
+            log.warn("Telegram chat not found by ID: {}", edited.getFrom().getId());
+            return MessageFactory.createUnknownErrorOccurredMessage(edited.getChatId().toString(),
+                    TelegramBotConstants.UK);
+        }
+        TelegramChat chat = optionalChat.get();
+
+        if (edited.hasText()
+                && edited.getText().startsWith("/start")
+                && chat.getChatState() == ChatState.IN_SUPPORT) {
+            log.info("User is already in support chat {}. Filtering system /start edited", chat.getChatId());
+            return MessageFactory.createChatAlreadyOpenMessage(chat.getChatId(), lang);
+        }
+
+        TelegramMessage telegramMessage =
+                telegramMessageRepository.findByTelegramMessageId(edited.getMessageId()).orElse(null);
+
+        if (telegramMessage == null) {
+            log.warn("Edited message {} not found in DB", edited.getMessageId());
+            return null;
+        }
+        if (edited.hasText()) {
+            telegramMessage.setText(edited.getText());
+        } else if (edited.getCaption() != null) {
+            telegramMessage.setText(edited.getCaption());
+        }
+
+        telegramMessageRepository.save(telegramMessage);
+        return null;
+    }
+
     private SendMessage processMessageContent(TelegramChat chat, Message message) {
         String mediaGroupId = message.getMediaGroupId();
         Optional<TelegramMessage> previouslySavedMessage = mediaGroupId == null
@@ -113,9 +148,9 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
     private TelegramMessage getOrSaveTelegramMessage(TelegramChat chat,
         Message message,
         String mediaGroupId,
-        Optional<TelegramMessage> telegramMessageOpt) {
-        if (telegramMessageOpt.isPresent()) {
-            return telegramMessageOpt.get();
+        Optional<TelegramMessage> previouslySavedMessage) {
+        if (previouslySavedMessage.isPresent()) {
+            return previouslySavedMessage.get();
         }
 
         String messageText = Optional.ofNullable(message.getText())
@@ -129,6 +164,7 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
             .sendAt(Instant.now())
             .text(messageText)
             .messageViewingStatus(MessageViewingStatus.UNREAD)
+            .telegramMessageId(message.getMessageId())
             .build();
 
         telegramMessageRepository.save(telegramMessage);
@@ -142,23 +178,23 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
     private SendMessage processMessageFiles(TelegramChat chat,
         Message message,
         TelegramMessage telegramMessage,
-        Optional<TelegramMessage> telegramMessageOpt,
+        Optional<TelegramMessage> previouslySavedMessage,
         String lang) {
         SendMessage resultMessage = null;
         FileInfo fileInfo = new FileInfo();
 
         if (message.hasPhoto()) {
-            resultMessage = setPhotoInfo(message, telegramMessage, telegramMessageOpt, fileInfo, lang);
+            resultMessage = setPhotoInfo(message, telegramMessage, previouslySavedMessage, fileInfo, lang);
         } else if (message.hasDocument()) {
-            resultMessage = setDocumentInfo(message, telegramMessage, telegramMessageOpt, fileInfo, lang);
+            resultMessage = setDocumentInfo(message, telegramMessage, previouslySavedMessage, fileInfo, lang);
         } else if (message.hasSticker()) {
-            resultMessage = setStickerInfo(message, telegramMessage, telegramMessageOpt, fileInfo, lang);
+            resultMessage = setStickerInfo(message, telegramMessage, previouslySavedMessage, fileInfo, lang);
         } else if (message.hasAnimation()) {
-            resultMessage = setAnimationInfo(message, telegramMessage, telegramMessageOpt, fileInfo, lang);
+            resultMessage = setAnimationInfo(message, telegramMessage, previouslySavedMessage, fileInfo, lang);
         }
 
         if (fileInfo.getFileId() != null) {
-            return setFileAsMessageAsset(message, telegramMessage, telegramMessageOpt, fileInfo, lang);
+            return setFileAsMessageAsset(message, telegramMessage, previouslySavedMessage, fileInfo, lang);
         } else if (!message.hasText()
             && !message.hasPhoto()
             && !message.hasDocument()

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -101,19 +101,19 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
         Optional<TelegramChat> optionalChat = findAndValidateChat(edited.getFrom().getId().toString());
         if (optionalChat.isEmpty()) {
             return MessageFactory.createUnknownErrorOccurredMessage(edited.getChatId().toString(),
-                    TelegramBotConstants.UK);
+                TelegramBotConstants.UK);
         }
         TelegramChat chat = optionalChat.get();
 
         if (edited.hasText()
-                && edited.getText().startsWith("/start")
-                && chat.getChatState() == ChatState.IN_SUPPORT) {
+            && edited.getText().startsWith("/start")
+            && chat.getChatState() == ChatState.IN_SUPPORT) {
             log.info("User is already in support chat {}. Filtering system /start edited", chat.getChatId());
             return MessageFactory.createChatAlreadyOpenMessage(chat.getChatId(), lang);
         }
 
         TelegramMessage telegramMessage =
-                telegramMessageRepository.findByTelegramMessageId(edited.getMessageId()).orElse(null);
+            telegramMessageRepository.findByTelegramMessageId(edited.getMessageId()).orElse(null);
 
         if (telegramMessage == null) {
             log.warn("Edited message {} not found in DB", edited.getMessageId());
@@ -123,6 +123,8 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
             telegramMessage.setText(edited.getText());
         } else if (edited.getCaption() != null) {
             telegramMessage.setText(edited.getCaption());
+        } else {
+            telegramMessage.setText(null);
         }
 
         telegramMessageRepository.save(telegramMessage);

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -113,7 +113,7 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
         }
 
         TelegramMessage telegramMessage =
-            telegramMessageRepository.findByTelegramMessageId(edited.getMessageId()).orElse(null);
+            telegramMessageRepository.findByChatAndTelegramMessageId(chat, edited.getMessageId()).orElse(null);
 
         if (telegramMessage == null) {
             log.warn("Edited message {} not found in DB", edited.getMessageId());

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -350,7 +350,7 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
                 existingAssets.add(asset);
                 telegramMessage.setAssets(existingAssets);
             } else {
-                telegramMessage.setAssets(List.of(asset));
+                telegramMessage.setAssets(new ArrayList<>(List.of(asset)));
             }
 
             messageAssetRepository.save(asset);

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -348,9 +348,9 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
             if (telegramMessageOpt.isPresent()) {
                 List<MessageAsset> existingAssets = new ArrayList<>(telegramMessage.getAssets());
                 existingAssets.add(asset);
-                telegramMessage.setAssets(existingAssets);
+                telegramMessage.getAssets().addAll(existingAssets);
             } else {
-                telegramMessage.setAssets(new ArrayList<>(List.of(asset)));
+                telegramMessage.setAssets((new ArrayList<>(List.of(asset))));
             }
 
             messageAssetRepository.save(asset);

--- a/service/src/main/java/greencity/ubstelegrambot/service/UserUpdateProcessor.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/UserUpdateProcessor.java
@@ -127,10 +127,7 @@ public class UserUpdateProcessor implements TelegramUpdateProcessor {
             }
 
             String lang = chatOpt.get().getLanguageCode();
-            TelegramChat chat = chatOpt.get();
-            //TODO: can a user edit his message outside the chat(after 15 min)?
-            if(chat.getChatState() == ChatState.IN_SUPPORT)
-                return telegramSupportService.processEditedSupportMessage(edited, lang);
+            return telegramSupportService.processEditedSupportMessage(edited, lang);
         }
         return null;
     }

--- a/service/src/main/java/greencity/ubstelegrambot/service/UserUpdateProcessor.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/UserUpdateProcessor.java
@@ -89,7 +89,7 @@ public class UserUpdateProcessor implements TelegramUpdateProcessor {
                         MessageFactory.createAvailableCommandsMessage(chatId, lang));
                 }
             }
-        } else if (update.hasMessage()){
+        } else if (update.hasMessage()) {
             var message = update.getMessage();
 
             Optional<TelegramChat> chatOpt = telegramChatRepository.findByChatId(message.getChatId().toString());

--- a/service/src/main/java/greencity/ubstelegrambot/service/UserUpdateProcessor.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/UserUpdateProcessor.java
@@ -89,7 +89,7 @@ public class UserUpdateProcessor implements TelegramUpdateProcessor {
                         MessageFactory.createAvailableCommandsMessage(chatId, lang));
                 }
             }
-        } else {
+        } else if (update.hasMessage()){
             var message = update.getMessage();
 
             Optional<TelegramChat> chatOpt = telegramChatRepository.findByChatId(message.getChatId().toString());
@@ -117,6 +117,21 @@ public class UserUpdateProcessor implements TelegramUpdateProcessor {
                     return telegramCommandsService.processCommand(message, lang);
                 }
             }
+        } else if (update.hasEditedMessage()) {
+            Message edited = update.getEditedMessage();
+            String chatId = edited.getChatId().toString();
+
+            Optional<TelegramChat> chatOpt = telegramChatRepository.findByChatId(chatId);
+            if (chatOpt.isEmpty()) {
+                return MessageFactory.createUnknownErrorOccurredMessage(chatId, TelegramBotConstants.UK);
+            }
+
+            String lang = chatOpt.get().getLanguageCode();
+            TelegramChat chat = chatOpt.get();
+            //TODO: can a user edit his message outside the chat(after 15 min)?
+            if(chat.getChatState() == ChatState.IN_SUPPORT)
+                return telegramSupportService.processEditedSupportMessage(edited, lang);
         }
+        return null;
     }
 }

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
@@ -839,7 +839,7 @@ class TelegramSupportServiceTest {
 
         when(telegramChatRepository.findByChatId("67890")).thenReturn(Optional.of(chat));
         when(telegramMessageRepository.findByTelegramMessageId(editedMessage.getMessageId()))
-                .thenReturn(Optional.empty());
+            .thenReturn(Optional.empty());
 
         // When
         SendMessage result = telegramSupportService.processEditedSupportMessage(editedMessage, "uk");
@@ -857,12 +857,11 @@ class TelegramSupportServiceTest {
         chat.setChatId(String.valueOf(editedMessage.getFrom().getId()));
         when(telegramChatRepository.findByChatId("67890")).thenReturn(Optional.of(chat));
 
-
         TelegramMessage existingMessage = new TelegramMessage();
         existingMessage.setTelegramMessageId(editedMessage.getMessageId());
         existingMessage.setText("Old text");
         when(telegramMessageRepository.findByTelegramMessageId(editedMessage.getMessageId()))
-                .thenReturn(Optional.of(existingMessage));
+            .thenReturn(Optional.of(existingMessage));
 
         // When
         SendMessage result = telegramSupportService.processEditedSupportMessage(editedMessage, "uk");
@@ -892,7 +891,7 @@ class TelegramSupportServiceTest {
         existingMessage.setTelegramMessageId(editedMessage.getMessageId());
         existingMessage.setText("Old text");
         when(telegramMessageRepository.findByTelegramMessageId(editedMessage.getMessageId()))
-                .thenReturn(Optional.of(existingMessage));
+            .thenReturn(Optional.of(existingMessage));
 
         // When
         SendMessage result = telegramSupportService.processEditedSupportMessage(editedMessage, "uk");
@@ -900,6 +899,35 @@ class TelegramSupportServiceTest {
         // Then
         assertNull(result);
         assertEquals("New edited caption", existingMessage.getText());
+        verify(telegramMessageRepository).save(existingMessage);
+    }
+
+    @Test
+    void processEditedSupportMessage_HasNone_UpdatesMessageAndSaves() {
+        // Given
+        Message editedMessage = new Message();
+        editedMessage.setMessageId(98765);
+
+        User user = new User();
+        user.setId(67890L);
+        editedMessage.setFrom(user);
+
+        TelegramChat chat = new TelegramChat();
+        chat.setChatId(String.valueOf(user.getId()));
+        when(telegramChatRepository.findByChatId(user.getId().toString())).thenReturn(Optional.of(chat));
+
+        TelegramMessage existingMessage = new TelegramMessage();
+        existingMessage.setTelegramMessageId(editedMessage.getMessageId());
+        existingMessage.setText("Old text");
+        when(telegramMessageRepository.findByTelegramMessageId(editedMessage.getMessageId()))
+            .thenReturn(Optional.of(existingMessage));
+
+        // When
+        SendMessage result = telegramSupportService.processEditedSupportMessage(editedMessage, "uk");
+
+        // Then
+        assertNull(result);
+        assertNull(existingMessage.getText());
         verify(telegramMessageRepository).save(existingMessage);
     }
 

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
@@ -838,7 +838,7 @@ class TelegramSupportServiceTest {
         chat.setChatId(String.valueOf(editedMessage.getFrom().getId()));
 
         when(telegramChatRepository.findByChatId("67890")).thenReturn(Optional.of(chat));
-        when(telegramMessageRepository.findByTelegramMessageId(editedMessage.getMessageId()))
+        when(telegramMessageRepository.findByChatAndTelegramMessageId(chat, editedMessage.getMessageId()))
             .thenReturn(Optional.empty());
 
         // When
@@ -860,7 +860,7 @@ class TelegramSupportServiceTest {
         TelegramMessage existingMessage = new TelegramMessage();
         existingMessage.setTelegramMessageId(editedMessage.getMessageId());
         existingMessage.setText("Old text");
-        when(telegramMessageRepository.findByTelegramMessageId(editedMessage.getMessageId()))
+        when(telegramMessageRepository.findByChatAndTelegramMessageId(chat, editedMessage.getMessageId()))
             .thenReturn(Optional.of(existingMessage));
 
         // When
@@ -890,7 +890,7 @@ class TelegramSupportServiceTest {
         TelegramMessage existingMessage = new TelegramMessage();
         existingMessage.setTelegramMessageId(editedMessage.getMessageId());
         existingMessage.setText("Old text");
-        when(telegramMessageRepository.findByTelegramMessageId(editedMessage.getMessageId()))
+        when(telegramMessageRepository.findByChatAndTelegramMessageId(chat, editedMessage.getMessageId()))
             .thenReturn(Optional.of(existingMessage));
 
         // When
@@ -919,7 +919,7 @@ class TelegramSupportServiceTest {
         TelegramMessage existingMessage = new TelegramMessage();
         existingMessage.setTelegramMessageId(editedMessage.getMessageId());
         existingMessage.setText("Old text");
-        when(telegramMessageRepository.findByTelegramMessageId(editedMessage.getMessageId()))
+        when(telegramMessageRepository.findByChatAndTelegramMessageId(chat, editedMessage.getMessageId()))
             .thenReturn(Optional.of(existingMessage));
 
         // When

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.multipart.MultipartFile;
 import org.telegram.telegrambots.meta.api.methods.GetFile;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Chat;
 import org.telegram.telegrambots.meta.api.objects.Document;
 import org.telegram.telegrambots.meta.api.objects.File;
 import org.telegram.telegrambots.meta.api.objects.Message;
@@ -798,4 +799,122 @@ class TelegramSupportServiceTest {
         verify(messageAssetRepository).save(argThat(asset -> asset.getFileName().equals("animation.mp4")));
     }
 
+    @Test
+    void processEditedSupportMessage_ChatNotFound_ReturnsError() {
+        // Given
+        Message editedMessage = createMessage(12345L, 67890L, 98765, "Hello");
+
+        when(telegramChatRepository.findByChatId("67890")).thenReturn(Optional.empty());
+        // When
+        SendMessage result = telegramSupportService.processEditedSupportMessage(editedMessage, "uk");
+
+        // Then
+        assertNotNull(result);
+        assertEquals(String.valueOf(12345), result.getChatId());
+    }
+
+    @Test
+    void processEditedSupportMessage_StartCommandInSupport_ReturnsAlreadyInSupportMessage() {
+        // Given
+        Message editedMessage = createMessage(12345L, 67890L, 98765, "/start");
+        TelegramChat chat = new TelegramChat();
+        chat.setChatId(String.valueOf(editedMessage.getFrom().getId()));
+        chat.setChatState(ChatState.IN_SUPPORT);
+        when(telegramChatRepository.findByChatId("67890")).thenReturn(Optional.of(chat));
+
+        // When
+        SendMessage result = telegramSupportService.processEditedSupportMessage(editedMessage, "en");
+
+        // Then
+        assertNotNull(result);
+        assertEquals(String.valueOf(67890), result.getChatId());
+    }
+
+    @Test
+    void processEditedSupportMessage_EditedMessageNotFound_ReturnsNull() {
+        // Given
+        Message editedMessage = createMessage(12345L, 67890L, 98765, "New edited text");
+        TelegramChat chat = new TelegramChat();
+        chat.setChatId(String.valueOf(editedMessage.getFrom().getId()));
+
+        when(telegramChatRepository.findByChatId("67890")).thenReturn(Optional.of(chat));
+        when(telegramMessageRepository.findByTelegramMessageId(editedMessage.getMessageId()))
+                .thenReturn(Optional.empty());
+
+        // When
+        SendMessage result = telegramSupportService.processEditedSupportMessage(editedMessage, "uk");
+
+        // Then
+        assertNull(result);
+        verify(telegramMessageRepository, never()).save(any());
+    }
+
+    @Test
+    void processEditedSupportMessage_HasText_UpdatesMessageAndSaves() {
+        // Given
+        Message editedMessage = createMessage(12345L, 67890L, 98765, "New edited text");
+        TelegramChat chat = new TelegramChat();
+        chat.setChatId(String.valueOf(editedMessage.getFrom().getId()));
+        when(telegramChatRepository.findByChatId("67890")).thenReturn(Optional.of(chat));
+
+
+        TelegramMessage existingMessage = new TelegramMessage();
+        existingMessage.setTelegramMessageId(editedMessage.getMessageId());
+        existingMessage.setText("Old text");
+        when(telegramMessageRepository.findByTelegramMessageId(editedMessage.getMessageId()))
+                .thenReturn(Optional.of(existingMessage));
+
+        // When
+        SendMessage result = telegramSupportService.processEditedSupportMessage(editedMessage, "uk");
+
+        // Then
+        assertNull(result);
+        assertEquals("New edited text", existingMessage.getText());
+        verify(telegramMessageRepository).save(existingMessage);
+    }
+
+    @Test
+    void processEditedSupportMessage_HasCaption_UpdatesMessageAndSaves() {
+        // Given
+        Message editedMessage = new Message();
+        editedMessage.setMessageId(98765);
+        editedMessage.setCaption("New edited caption");
+
+        User user = new User();
+        user.setId(67890L);
+        editedMessage.setFrom(user);
+
+        TelegramChat chat = new TelegramChat();
+        chat.setChatId(String.valueOf(user.getId()));
+        when(telegramChatRepository.findByChatId(user.getId().toString())).thenReturn(Optional.of(chat));
+
+        TelegramMessage existingMessage = new TelegramMessage();
+        existingMessage.setTelegramMessageId(editedMessage.getMessageId());
+        existingMessage.setText("Old text");
+        when(telegramMessageRepository.findByTelegramMessageId(editedMessage.getMessageId()))
+                .thenReturn(Optional.of(existingMessage));
+
+        // When
+        SendMessage result = telegramSupportService.processEditedSupportMessage(editedMessage, "uk");
+
+        // Then
+        assertNull(result);
+        assertEquals("New edited caption", existingMessage.getText());
+        verify(telegramMessageRepository).save(existingMessage);
+    }
+
+    private Message createMessage(Long id, Long chatId, Integer messageId, String text) {
+        Message message = new Message();
+        Chat chat = new Chat();
+        chat.setId(id);
+        message.setChat(chat);
+        message.setMessageId(messageId);
+        message.setText(text);
+
+        User user = new User();
+        user.setId(chatId);
+        message.setFrom(user);
+
+        return message;
+    }
 }

--- a/service/src/test/java/greencity/ubstelegrambot/UserUpdateProcessorTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/UserUpdateProcessorTest.java
@@ -395,7 +395,7 @@ class UserUpdateProcessorTest {
         SendMessage expectedMessage = new SendMessage(CHAT_ID, "Processed edited message");
         when(telegramChatRepository.findByChatId(CHAT_ID)).thenReturn(Optional.of(mockChat));
         when(telegramSupportService.processEditedSupportMessage(any(Message.class), eq("uk")))
-                .thenReturn(expectedMessage);
+            .thenReturn(expectedMessage);
 
         // When
         SendMessage actualMessage = updateProcessor.process(update);
@@ -416,8 +416,9 @@ class UserUpdateProcessorTest {
 
         SendMessage expectedError = new SendMessage(CHAT_ID, "Сталася невідома помилка, спробуйте, будь ласка, знову");
         try (MockedStatic<MessageFactory> mockedMessageFactory = mockStatic(MessageFactory.class)) {
-            mockedMessageFactory.when(() -> MessageFactory.createUnknownErrorOccurredMessage(anyString(), eq(TelegramBotConstants.UK)))
-                    .thenReturn(expectedError);
+            mockedMessageFactory
+                .when(() -> MessageFactory.createUnknownErrorOccurredMessage(anyString(), eq(TelegramBotConstants.UK)))
+                .thenReturn(expectedError);
         }
         // When
         SendMessage actualError = updateProcessor.process(update);
@@ -506,6 +507,7 @@ class UserUpdateProcessorTest {
         message.setChat(chat);
         return update;
     }
+
     private TelegramChat createTelegramChat(ChatState state) {
         return TelegramChat.builder()
             .chatId(CHAT_ID)

--- a/service/src/test/java/greencity/ubstelegrambot/UserUpdateProcessorTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/UserUpdateProcessorTest.java
@@ -4,7 +4,12 @@ import greencity.constant.TelegramBotConstants;
 import greencity.entity.telegram.TelegramChat;
 import greencity.enums.ChatState;
 import greencity.repository.TelegramChatRepository;
-import greencity.service.ubs.*;
+import greencity.service.ubs.TelegramCommandsService;
+import greencity.service.ubs.TelegramFeedbackService;
+import greencity.service.ubs.TelegramGreenOfficeService;
+import greencity.service.ubs.TelegramLanguageService;
+import greencity.service.ubs.TelegramLoginService;
+import greencity.service.ubs.TelegramSupportService;
 import greencity.ubstelegrambot.messages.MessageFactory;
 import greencity.ubstelegrambot.messages.MessageProvider;
 import greencity.ubstelegrambot.service.TelegramUtils;
@@ -14,13 +19,30 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
-import org.telegram.telegrambots.meta.api.objects.*;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.api.objects.Chat;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
+
 import java.util.Optional;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class UserUpdateProcessorTest {
@@ -362,6 +384,74 @@ class UserUpdateProcessorTest {
         verify(telegramLoginService).processInputManagerCredentialsRequest(any(), nullable(String.class));
     }
 
+    @Test
+    void process_HasEditedMessageAndChatFound_CallsSupportService() {
+        // Given
+        Update update = createUpdateWithEditedMessage(CHAT_ID);
+        TelegramChat mockChat = new TelegramChat();
+        mockChat.setChatId(CHAT_ID);
+        mockChat.setLanguageCode("uk");
+
+        SendMessage expectedMessage = new SendMessage(CHAT_ID, "Processed edited message");
+        when(telegramChatRepository.findByChatId(CHAT_ID)).thenReturn(Optional.of(mockChat));
+        when(telegramSupportService.processEditedSupportMessage(any(Message.class), eq("uk")))
+                .thenReturn(expectedMessage);
+
+        // When
+        SendMessage actualMessage = updateProcessor.process(update);
+
+        // Then
+        assertNotNull(actualMessage);
+        assertEquals(expectedMessage, actualMessage);
+        verify(telegramChatRepository).findByChatId(CHAT_ID);
+        verify(telegramSupportService).processEditedSupportMessage(update.getEditedMessage(), "uk");
+    }
+
+    @Test
+    void process_HasEditedMessageAndChatNotFound_ReturnsError() {
+        // Given
+        Update update = createUpdateWithEditedMessage(CHAT_ID);
+
+        when(telegramChatRepository.findByChatId(CHAT_ID)).thenReturn(Optional.empty());
+
+        SendMessage expectedError = new SendMessage(CHAT_ID, "Сталася невідома помилка, спробуйте, будь ласка, знову");
+        try (MockedStatic<MessageFactory> mockedMessageFactory = mockStatic(MessageFactory.class)) {
+            mockedMessageFactory.when(() -> MessageFactory.createUnknownErrorOccurredMessage(anyString(), eq(TelegramBotConstants.UK)))
+                    .thenReturn(expectedError);
+        }
+        // When
+        SendMessage actualError = updateProcessor.process(update);
+
+        // Then
+        assertNotNull(actualError);
+        assertEquals(expectedError.getText(), actualError.getText());
+        verify(telegramChatRepository).findByChatId(CHAT_ID);
+        verify(telegramSupportService, never()).processEditedSupportMessage(any(), any());
+    }
+
+    @Test
+    void process_NoEditedMessage_ReturnsErrorMessage() {
+        // Given
+        Update update = createUpdateWithoutEditedMessage();
+
+        // When
+        SendMessage result = updateProcessor.process(update);
+
+        // Then
+        assertEquals("Сталася невідома помилка, спробуйте, будь ласка, знову", result.getText());
+        verify(telegramChatRepository).findByChatId(any());
+        verify(telegramSupportService, never()).processEditedSupportMessage(any(), any());
+    }
+
+    @Test
+    void process_NoMessage_ReturnsNull() {
+        Update update = mock(Update.class);
+
+        SendMessage result = updateProcessor.process(update);
+
+        assertNull(result);
+    }
+
     private Update createUpdateWithCallback(String callbackData) {
         Update update = new Update();
         CallbackQuery callbackQuery = new CallbackQuery();
@@ -391,6 +481,31 @@ class UserUpdateProcessorTest {
         return update;
     }
 
+    private Update createUpdateWithEditedMessage(String chatId) {
+        Update update = new Update();
+        Message editedMessage = new Message();
+        Chat chat = new Chat();
+        chat.setId(Long.valueOf(chatId));
+        editedMessage.setChat(chat);
+        editedMessage.setText("Edited text");
+        editedMessage.setMessageId(12345);
+        User user = new User();
+        user.setId(Long.valueOf(chatId));
+        editedMessage.setFrom(user);
+        update.setEditedMessage(editedMessage);
+        return update;
+    }
+
+    private Update createUpdateWithoutEditedMessage() {
+        Update update = new Update();
+        Message message = new Message();
+        Chat chat = new Chat();
+        chat.setId(Long.valueOf(CHAT_ID));
+        message.setText("Normal text");
+        update.setMessage(message);
+        message.setChat(chat);
+        return update;
+    }
     private TelegramChat createTelegramChat(ChatState state) {
         return TelegramChat.builder()
             .chatId(CHAT_ID)


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#9076](https://github.com/ita-social-projects/GreenCity/issues/9076)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support for edited Telegram messages in support chats, updating originals while preserving chat state; public API extended to accept edited messages.

- Bug Fixes
  - More reliable chat detection across callbacks, messages, and edited messages.
  - Improved handling when a message lacks text or supported files, with consistent chat-state cleanup.

- Refactor
  - Centralized chat validation and consolidated message/media processing to attach media to the correct message.

- Tests
  - Added unit tests covering edited-message handling and update-processing flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->