### PR TITLE
#9145 - Add Azure Blob Storage cleanup client

### DIFF
--- a/dao/src/main/java/greencity/repository/EmployeeRepository.java
+++ b/dao/src/main/java/greencity/repository/EmployeeRepository.java
@@ -122,4 +122,12 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
     @Query("SELECT e FROM Employee e LEFT JOIN FETCH e.employeePosition WHERE e.email = :email")
     Optional<Employee> findByEmailWithPositions(@Param("email") String email);
+
+    /**
+     * Returns all distinct non-null image paths.
+     *
+     * @return {@link List} of distinct image paths.
+     */
+    @Query("SELECT DISTINCT e.imagePath FROM Employee e WHERE e.imagePath IS NOT NULL")
+    List<String> findDistinctImagePaths();
 }

--- a/dao/src/main/java/greencity/repository/MessageAssetRepository.java
+++ b/dao/src/main/java/greencity/repository/MessageAssetRepository.java
@@ -2,6 +2,15 @@ package greencity.repository;
 
 import greencity.entity.telegram.MessageAsset;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import java.util.List;
 
 public interface MessageAssetRepository extends JpaRepository<MessageAsset, Long> {
+    /**
+     * Returns all distinct non-null image paths.
+     *
+     * @return {@link List} of distinct image paths.
+     */
+    @Query(value = "SELECT DISTINCT ma.url FROM MessageAsset ma WHERE ma.url IS NOT NULL")
+    List<String> findDistinctImagePaths();
 }

--- a/dao/src/main/java/greencity/repository/OrderRepository.java
+++ b/dao/src/main/java/greencity/repository/OrderRepository.java
@@ -275,4 +275,12 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
      * @return the number of completed orders
      */
     Long countByUserIdAndOrderStatus(Long userId, OrderStatus status);
+
+    /**
+     * Returns all lists of image paths.
+     *
+     * @return {@link List} of lists of image paths.
+     */
+    @Query("SELECT o.imageReasonNotTakingBags FROM Order o")
+    List<List<String>> findImagePaths();
 }

--- a/dao/src/main/java/greencity/repository/PaymentRepository.java
+++ b/dao/src/main/java/greencity/repository/PaymentRepository.java
@@ -38,4 +38,12 @@ public interface PaymentRepository extends CrudRepository<Payment, Long> {
         value = "SELECT p.payment_status FROM payment p WHERE p.order_id = :orderId AND p.id = :paymentId")
     Optional<PaymentStatus> getPaymentStatusByOrderIdAndPaymentId(@Param(value = "orderId") Long orderId,
         @Param(value = "paymentId") Long paymentId);
+
+    /**
+     * Returns all distinct non-null image paths.
+     *
+     * @return {@link List} of distinct image paths.
+     */
+    @Query("SELECT DISTINCT p.imagePath FROM Payment p WHERE p.imagePath IS NOT NULL")
+    List<String> findDistinctImagePaths();
 }

--- a/dao/src/main/java/greencity/repository/ViolationRepository.java
+++ b/dao/src/main/java/greencity/repository/ViolationRepository.java
@@ -4,6 +4,7 @@ import greencity.entity.user.Violation;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+import java.util.List;
 import java.util.Optional;
 
 public interface ViolationRepository extends CrudRepository<Violation, Long> {
@@ -64,4 +65,12 @@ public interface ViolationRepository extends CrudRepository<Violation, Long> {
      */
     @Query(value = "SELECT v FROM Violation v WHERE v.order.id = ?1 AND v.violationStatus = 'DELETED'")
     Optional<Violation> findCanceledViolationByOrderId(Long orderId);
+
+    /**
+     * Returns all distinct non-null image paths.
+     *
+     * @return {@link List} of distinct image paths.
+     */
+    @Query(value = "SELECT DISTINCT vi.image FROM violation_images vi WHERE vi.image IS NOT NULL", nativeQuery = true)
+    List<String> findDistinctImagePaths();
 }

--- a/service-api/src/main/java/greencity/client/config/UserRemoteWebClient.java
+++ b/service-api/src/main/java/greencity/client/config/UserRemoteWebClient.java
@@ -26,7 +26,7 @@ public class UserRemoteWebClient {
      */
     public String uploadFile(UploadFileDto fileDto) {
         return webClient.post()
-            .uri("/files/single")
+            .uri("/files")
             .contentType(MediaType.MULTIPART_FORM_DATA)
             .body(multipartInserter(fileDto))
             .retrieve()
@@ -41,7 +41,7 @@ public class UserRemoteWebClient {
      */
     public void deleteFile(DeleteFileDto fileDto) {
         webClient.method(HttpMethod.DELETE)
-            .uri("/files/single")
+            .uri("/files")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(fileDto)
             .retrieve()

--- a/service-api/src/main/java/greencity/client/config/UserRemoteWebClient.java
+++ b/service-api/src/main/java/greencity/client/config/UserRemoteWebClient.java
@@ -66,5 +66,4 @@ public class UserRemoteWebClient {
 
         return BodyInserters.fromMultipartData(multipartBodyBuilder.build());
     }
-
 }

--- a/service-api/src/main/java/greencity/client/config/UserRemoteWebClient.java
+++ b/service-api/src/main/java/greencity/client/config/UserRemoteWebClient.java
@@ -1,16 +1,16 @@
 package greencity.client.config;
 
+import greencity.dto.files.CleanupFilesDto;
+import greencity.dto.files.DeleteFileDto;
+import greencity.dto.files.UploadFileDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
-import java.util.List;
 
 @Slf4j
 @Service
@@ -19,77 +19,52 @@ public class UserRemoteWebClient {
     private final WebClient webClient;
 
     /**
-     * Method for uploading files.
-     *
-     * @param files files to save.
-     * @return urls of the saved files.
-     */
-    public List<String> uploadAllFiles(List<MultipartFile> files) {
-        MultipartFile[] multipartFiles = files.toArray(new MultipartFile[0]);
-
-        return webClient.post()
-            .uri("/files")
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .body(multipartInserter(multipartFiles))
-            .retrieve()
-            .bodyToMono(new ParameterizedTypeReference<List<String>>() {
-            })
-            .block();
-    }
-
-    /**
      * Method for uploading a file.
      *
-     * @param file file to save.
+     * @param fileDto {@link UploadFileDto} file to save.
      * @return url of the saved file.
      */
-    public String uploadFile(MultipartFile file) {
+    public String uploadFile(UploadFileDto fileDto) {
         return webClient.post()
             .uri("/files/single")
             .contentType(MediaType.MULTIPART_FORM_DATA)
-            .body(multipartInserter(file))
+            .body(multipartInserter(fileDto))
             .retrieve()
             .bodyToMono(String.class)
             .block();
     }
 
     /**
-     * Method for deleting files.
+     * Method for deleting a file.
      *
-     * @param paths urls of files to delete.
+     * @param fileDto {@link DeleteFileDto} file to delete.
      */
-    public void deleteAllFiles(List<String> paths) {
+    public void deleteFile(DeleteFileDto fileDto) {
         webClient.method(HttpMethod.DELETE)
-            .uri("/files")
-            .bodyValue(paths)
+            .uri("/files/single")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(fileDto)
             .retrieve()
             .bodyToMono(Void.class)
             .block();
     }
 
-    /**
-     * Method for deleting files.
-     *
-     * @param path urls of files to delete.
-     */
-    public void deleteFile(String path) {
-        webClient.method(HttpMethod.DELETE)
-            .uri(uriBuilder -> uriBuilder
-                .path("/files/single")
-                .queryParam("path", path)
-                .build())
+    public void cleanUp(CleanupFilesDto cleanupFilesDto) {
+        webClient.post()
+            .uri("/cleanup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(cleanupFilesDto)
             .retrieve()
             .bodyToMono(Void.class)
             .block();
     }
 
-    private BodyInserters.MultipartInserter multipartInserter(MultipartFile... multipartFiles) {
+    private BodyInserters.MultipartInserter multipartInserter(UploadFileDto fileDto) {
         MultipartBodyBuilder multipartBodyBuilder = new MultipartBodyBuilder();
-
-        for (MultipartFile multipartFile : multipartFiles) {
-            multipartBodyBuilder.part("file", multipartFile.getResource());
-        }
+        multipartBodyBuilder.part("file", fileDto.getFile().getResource());
+        multipartBodyBuilder.part("owner", fileDto.getOwner());
 
         return BodyInserters.fromMultipartData(multipartBodyBuilder.build());
     }
+
 }

--- a/service-api/src/main/java/greencity/dto/files/CleanupFilesDto.java
+++ b/service-api/src/main/java/greencity/dto/files/CleanupFilesDto.java
@@ -1,0 +1,18 @@
+package greencity.dto.files;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CleanupFilesDto {
+    private List<String> paths;
+    private String owner;
+}

--- a/service-api/src/main/java/greencity/dto/files/DeleteFileDto.java
+++ b/service-api/src/main/java/greencity/dto/files/DeleteFileDto.java
@@ -1,0 +1,17 @@
+package greencity.dto.files;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteFileDto {
+    private String path;
+    private String owner;
+}

--- a/service-api/src/main/java/greencity/dto/files/UploadFileDto.java
+++ b/service-api/src/main/java/greencity/dto/files/UploadFileDto.java
@@ -1,0 +1,18 @@
+package greencity.dto.files;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UploadFileDto {
+    private MultipartFile file;
+    private String owner;
+}

--- a/service-api/src/main/java/greencity/service/files/FileService.java
+++ b/service-api/src/main/java/greencity/service/files/FileService.java
@@ -17,9 +17,4 @@ public interface FileService {
      * @param path url of the file to delete.
      */
     void deleteFile(String path);
-
-    /**
-     * Method for scheduled Azure Blob Storage cleanup.
-     */
-    void cleanUp();
 }

--- a/service-api/src/main/java/greencity/service/files/FileService.java
+++ b/service-api/src/main/java/greencity/service/files/FileService.java
@@ -1,0 +1,25 @@
+package greencity.service.files;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileService {
+    /**
+     * Method for uploading a file.
+     *
+     * @param file file to save.
+     * @return url of the saved file.
+     */
+    String uploadFile(MultipartFile file);
+
+    /**
+     * Method for deleting a file.
+     *
+     * @param path url of the file to delete.
+     */
+    void deleteFile(String path);
+
+    /**
+     * Method for scheduled Azure Blob Storage cleanup.
+     */
+    void cleanUp();
+}

--- a/service-api/src/main/java/greencity/service/files/StorageCleanupService.java
+++ b/service-api/src/main/java/greencity/service/files/StorageCleanupService.java
@@ -1,0 +1,8 @@
+package greencity.service.files;
+
+public interface StorageCleanupService {
+    /**
+     * Method for scheduled storage cleanup.
+     */
+    void cleanUp();
+}

--- a/service-api/src/test/java/greencity/ModelUtils.java
+++ b/service-api/src/test/java/greencity/ModelUtils.java
@@ -3,11 +3,16 @@ package greencity;
 import greencity.dto.AddNewTariffDto;
 import greencity.dto.CreateAddressRequestDto;
 import greencity.dto.courier.CreateCourierDto;
+import greencity.dto.files.DeleteFileDto;
+import greencity.dto.files.UploadFileDto;
 import greencity.dto.location.CoordinatesDto;
 import greencity.dto.position.PositionDto;
 import greencity.dto.tariff.TariffWithChatAccess;
 import greencity.entity.user.Location;
 import greencity.entity.user.User;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
 import java.util.List;
 
 public class ModelUtils {
@@ -169,5 +174,23 @@ public class ModelUtils {
             .tariffId(1L)
             .hasChat(true)
             .build();
+    }
+
+    public static UploadFileDto getUploadFileDto() {
+        return UploadFileDto.builder()
+            .file(getMultipartFile())
+            .owner("Owner")
+            .build();
+    }
+
+    public static DeleteFileDto getDeleteFileDto() {
+        return DeleteFileDto.builder()
+            .path("file.txt")
+            .owner("Owner")
+            .build();
+    }
+
+    private static MultipartFile getMultipartFile() {
+        return new MockMultipartFile("file.txt", "file.txt", "text/plain", "content".getBytes());
     }
 }

--- a/service-api/src/test/java/greencity/client/config/UserRemoteWebClientTest.java
+++ b/service-api/src/test/java/greencity/client/config/UserRemoteWebClientTest.java
@@ -1,14 +1,13 @@
 package greencity.client.config;
 
+import static greencity.ModelUtils.getDeleteFileDto;
+import static greencity.ModelUtils.getUploadFileDto;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
+import greencity.dto.files.DeleteFileDto;
+import greencity.dto.files.UploadFileDto;
 import lombok.SneakyThrows;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -22,8 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,43 +48,17 @@ class UserRemoteWebClientTest {
 
     @SneakyThrows
     @Test
-    void uploadAllFilesTest() {
-        List<String> expectedUrls = List.of("url1", "url2");
-        String expectedJson = toJson(expectedUrls);
-        String expectedRequestPath = "/files";
-        String expectedRequestMethod = HttpMethod.POST.name();
-
-        MultipartFile file1 = createMockMultipartFile("file1.txt", "content1");
-        MultipartFile file2 = createMockMultipartFile("file2.txt", "content2");
-        List<MultipartFile> files = Arrays.asList(file1, file2);
-
-        mockWebServer.enqueue(new MockResponse()
-            .setBody(expectedJson)
-            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
-
-        List<String> actualResult = userRemoteWebClient.uploadAllFiles(files);
-
-        assertEquals(expectedUrls, actualResult);
-        RecordedRequest recordedRequest = mockWebServer.takeRequest();
-        assertEquals(expectedRequestMethod, recordedRequest.getMethod());
-        assertEquals(expectedRequestPath, recordedRequest.getPath());
-        assertTrue(recordedRequest.getHeader(HttpHeaders.CONTENT_TYPE).startsWith(MediaType.MULTIPART_FORM_DATA_VALUE));
-    }
-
-    @SneakyThrows
-    @Test
     void uploadFileTest() {
         String expectedUrl = "upload-file-url";
         String expectedRequestPath = "/files/single";
         String expectedRequestMethod = HttpMethod.POST.name();
 
-        MultipartFile file = createMockMultipartFile("file.txt", "content");
-
         mockWebServer.enqueue(new MockResponse()
             .setBody(expectedUrl)
             .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
 
-        String actualResult = userRemoteWebClient.uploadFile(file);
+        UploadFileDto uploadFileDto = getUploadFileDto();
+        String actualResult = userRemoteWebClient.uploadFile(uploadFileDto);
 
         assertEquals(expectedUrl, actualResult);
         RecordedRequest recordedRequest = mockWebServer.takeRequest();
@@ -98,60 +69,21 @@ class UserRemoteWebClientTest {
 
     @SneakyThrows
     @Test
-    void deleteAllFilesTest() {
-        List<String> pathToDelete = List.of("path1", "path2");
-        String expectedRequestPath = "/files";
-        String expectedRequestMethod = HttpMethod.DELETE.name();
-
-        mockWebServer.enqueue(new MockResponse()
-            .setResponseCode(200)
-            .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
-
-        userRemoteWebClient.deleteAllFiles(pathToDelete);
-
-        RecordedRequest recordedRequest = mockWebServer.takeRequest();
-        assertEquals(expectedRequestMethod, recordedRequest.getMethod());
-        assertEquals(expectedRequestPath, recordedRequest.getPath());
-
-        String requestBody = recordedRequest.getBody().readUtf8();
-        List<String> actualPath = fromJson(requestBody, new TypeReference<>() {
-        });
-        assertEquals(pathToDelete, actualPath);
-    }
-
-    @SneakyThrows
-    @Test
     void deleteFileTest() {
-        String expectedPath = "delete-file-url";
-        String expectedRequestPath = "/files/single?path=" + URLEncoder.encode(expectedPath, StandardCharsets.UTF_8);
+        DeleteFileDto deleteFileDto = getDeleteFileDto();
+        String expectedRequestBody = objectMapper.writeValueAsString(deleteFileDto);
         String expectedRequestMethod = HttpMethod.DELETE.name();
 
         mockWebServer.enqueue(new MockResponse()
             .setResponseCode(200)
             .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
 
-        userRemoteWebClient.deleteFile(expectedPath);
+        userRemoteWebClient.deleteFile(deleteFileDto);
 
         RecordedRequest recordedRequest = mockWebServer.takeRequest();
-        assertEquals(expectedRequestMethod, recordedRequest.getMethod());
-        assertEquals(expectedRequestPath, recordedRequest.getPath());
-
         String requestBody = recordedRequest.getBody().readUtf8();
-        assertTrue(requestBody.isEmpty());
-    }
 
-    @SneakyThrows
-    private String toJson(Object object) {
-        return objectMapper.writeValueAsString(object);
+        assertEquals(expectedRequestMethod, recordedRequest.getMethod());
+        assertEquals(expectedRequestBody, requestBody);
     }
-
-    private MultipartFile createMockMultipartFile(String name, String content) {
-        return new MockMultipartFile(name, name, "text/plain", content.getBytes());
-    }
-
-    @SneakyThrows
-    private <T> T fromJson(String json, TypeReference<T> typeReference) {
-        return objectMapper.readValue(json, typeReference);
-    }
-
 }

--- a/service-api/src/test/java/greencity/client/config/UserRemoteWebClientTest.java
+++ b/service-api/src/test/java/greencity/client/config/UserRemoteWebClientTest.java
@@ -50,7 +50,7 @@ class UserRemoteWebClientTest {
     @Test
     void uploadFileTest() {
         String expectedUrl = "upload-file-url";
-        String expectedRequestPath = "/files/single";
+        String expectedRequestPath = "/files";
         String expectedRequestMethod = HttpMethod.POST.name();
 
         mockWebServer.enqueue(new MockResponse()

--- a/service/src/main/java/greencity/scheduler/StorageCleanupScheduler.java
+++ b/service/src/main/java/greencity/scheduler/StorageCleanupScheduler.java
@@ -1,0 +1,17 @@
+package greencity.scheduler;
+
+import greencity.service.files.StorageCleanupService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StorageCleanupScheduler {
+    private final StorageCleanupService storageCleanupService;
+
+    @Scheduled(cron = "0 0 3 ? * SAT")
+    public void scheduleStorageCleanup() {
+        storageCleanupService.cleanUp();
+    }
+}

--- a/service/src/main/java/greencity/service/files/FileServiceImpl.java
+++ b/service/src/main/java/greencity/service/files/FileServiceImpl.java
@@ -1,14 +1,12 @@
 package greencity.service.files;
 
 import greencity.client.config.UserRemoteWebClient;
-import greencity.dto.files.CleanupFilesDto;
 import greencity.dto.files.DeleteFileDto;
 import greencity.dto.files.UploadFileDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/service/src/main/java/greencity/service/files/FileServiceImpl.java
+++ b/service/src/main/java/greencity/service/files/FileServiceImpl.java
@@ -13,7 +13,6 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class FileServiceImpl implements FileService {
-    private final FileStorageFacade fileStorageFacade;
     private final UserRemoteWebClient userRemoteWebClient;
     @Value("UBS")
     private String owner;
@@ -36,16 +35,5 @@ public class FileServiceImpl implements FileService {
             .build();
 
         userRemoteWebClient.deleteFile(deleteFileDto);
-    }
-
-    @Override
-    public void cleanUp() {
-        List<String> filePaths = fileStorageFacade.getFilePaths();
-        CleanupFilesDto cleanupFilesDto = CleanupFilesDto.builder()
-            .paths(filePaths)
-            .owner(owner)
-            .build();
-
-        userRemoteWebClient.cleanUp(cleanupFilesDto);
     }
 }

--- a/service/src/main/java/greencity/service/files/FileServiceImpl.java
+++ b/service/src/main/java/greencity/service/files/FileServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class FileServiceImpl implements FileService {
-    private final FileStorageFacadeImpl fileStorageFacade;
+    private final FileStorageFacade fileStorageFacade;
     private final UserRemoteWebClient userRemoteWebClient;
     @Value("UBS")
     private String owner;

--- a/service/src/main/java/greencity/service/files/FileServiceImpl.java
+++ b/service/src/main/java/greencity/service/files/FileServiceImpl.java
@@ -1,0 +1,51 @@
+package greencity.service.files;
+
+import greencity.client.config.UserRemoteWebClient;
+import greencity.dto.files.CleanupFilesDto;
+import greencity.dto.files.DeleteFileDto;
+import greencity.dto.files.UploadFileDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FileServiceImpl implements FileService {
+    private final FileStorageFacadeImpl fileStorageFacade;
+    private final UserRemoteWebClient userRemoteWebClient;
+    @Value("UBS")
+    private String owner;
+
+    @Override
+    public String uploadFile(MultipartFile file) {
+        UploadFileDto fileDto = UploadFileDto.builder()
+            .file(file)
+            .owner(owner)
+            .build();
+
+        return userRemoteWebClient.uploadFile(fileDto);
+    }
+
+    @Override
+    public void deleteFile(String path) {
+        DeleteFileDto deleteFileDto = DeleteFileDto.builder()
+            .path(path)
+            .owner(owner)
+            .build();
+
+        userRemoteWebClient.deleteFile(deleteFileDto);
+    }
+
+    @Override
+    public void cleanUp() {
+        List<String> filePaths = fileStorageFacade.getFilePaths();
+        CleanupFilesDto cleanupFilesDto = CleanupFilesDto.builder()
+            .paths(filePaths)
+            .owner(owner)
+            .build();
+
+        userRemoteWebClient.cleanUp(cleanupFilesDto);
+    }
+}

--- a/service/src/main/java/greencity/service/files/FileStorageFacade.java
+++ b/service/src/main/java/greencity/service/files/FileStorageFacade.java
@@ -1,0 +1,39 @@
+package greencity.service.files;
+
+import greencity.repository.EmployeeRepository;
+import greencity.repository.MessageAssetRepository;
+import greencity.repository.OrderRepository;
+import greencity.repository.PaymentRepository;
+import greencity.repository.ViolationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class FileStorageFacade {
+    private final PaymentRepository paymentRepository;
+    private final ViolationRepository violationRepository;
+    private final EmployeeRepository employeeRepository;
+    private final OrderRepository orderRepository;
+    private final MessageAssetRepository messageAssetRepository;
+
+    public List<String> getFilePaths() {
+        List<String> filePaths = new ArrayList<>();
+
+        filePaths.addAll(paymentRepository.findDistinctImagePaths());
+        filePaths.addAll(violationRepository.findDistinctImagePaths());
+        filePaths.addAll(employeeRepository.findDistinctImagePaths());
+        filePaths.addAll(messageAssetRepository.findDistinctImagePaths());
+        filePaths.addAll(orderRepository.findImagePaths()
+            .stream()
+            .filter(Objects::nonNull)
+            .flatMap(List::stream)
+            .distinct()
+            .toList());
+
+        return filePaths.stream().distinct().toList();
+    }
+}

--- a/service/src/main/java/greencity/service/files/StorageCleanupServiceImpl.java
+++ b/service/src/main/java/greencity/service/files/StorageCleanupServiceImpl.java
@@ -3,11 +3,13 @@ package greencity.service.files;
 import greencity.client.config.UserRemoteWebClient;
 import greencity.dto.files.CleanupFilesDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import java.util.List;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class StorageCleanupServiceImpl implements StorageCleanupService {
     private final FileStorageFacade fileStorageFacade;
@@ -23,6 +25,7 @@ public class StorageCleanupServiceImpl implements StorageCleanupService {
             .owner(owner)
             .build();
 
+        log.info("Starting storage cleanup with {} files to process", filePaths.size());
         userRemoteWebClient.cleanUp(cleanupFilesDto);
     }
 }

--- a/service/src/main/java/greencity/service/files/StorageCleanupServiceImpl.java
+++ b/service/src/main/java/greencity/service/files/StorageCleanupServiceImpl.java
@@ -1,0 +1,28 @@
+package greencity.service.files;
+
+import greencity.client.config.UserRemoteWebClient;
+import greencity.dto.files.CleanupFilesDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StorageCleanupServiceImpl implements StorageCleanupService {
+    private final FileStorageFacade fileStorageFacade;
+    private final UserRemoteWebClient userRemoteWebClient;
+    @Value("UBS")
+    private String owner;
+
+    @Override
+    public void cleanUp() {
+        List<String> filePaths = fileStorageFacade.getFilePaths();
+        CleanupFilesDto cleanupFilesDto = CleanupFilesDto.builder()
+            .paths(filePaths)
+            .owner(owner)
+            .build();
+
+        userRemoteWebClient.cleanUp(cleanupFilesDto);
+    }
+}

--- a/service/src/main/java/greencity/service/ubs/PaymentServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/PaymentServiceImpl.java
@@ -13,7 +13,6 @@ import static greencity.constant.ErrorMessage.PAYMENT_NOT_FOUND;
 import static greencity.constant.ErrorMessage.REFUND_CONFLICT_MONEY_AND_BONUSES;
 import static greencity.service.ubs.UBSManagementServiceImpl.FORMAT_DATE;
 import static java.util.Objects.isNull;
-import greencity.client.config.UserRemoteWebClient;
 import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
 import greencity.constant.OrderHistory;
@@ -44,6 +43,7 @@ import greencity.repository.PaymentRepository;
 import greencity.repository.RefundRepository;
 import greencity.repository.TariffsInfoRepository;
 import greencity.repository.UserRepository;
+import greencity.service.files.FileService;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -51,7 +51,6 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -75,7 +74,7 @@ public class PaymentServiceImpl implements PaymentService {
     private final PaymentRepository paymentRepository;
     private final EmployeeRepository employeeRepository;
     private final EventService eventService;
-    private final UserRemoteWebClient userRemoteWebClient;
+    private final FileService fileService;
     private final OrderRepository orderRepository;
     private final NotificationService notificationService;
     private final OrderBagService orderBagService;
@@ -143,7 +142,7 @@ public class PaymentServiceImpl implements PaymentService {
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Payment not found"));
         if (payment.getImagePath() != null) {
             try {
-                userRemoteWebClient.deleteFile(payment.getImagePath());
+                fileService.deleteFile(payment.getImagePath());
             } catch (WebClientRequestException | WebClientResponseException e) {
                 log.warn(AppConstant.USER_SERVICE_UNAVAILABLE_LOG, e.getMessage());
             }
@@ -403,7 +402,7 @@ public class PaymentServiceImpl implements PaymentService {
         if (requestDto.getImagePath().isEmpty()) {
             if (updatePayment.getImagePath() != null) {
                 try {
-                    userRemoteWebClient.deleteFile(updatePayment.getImagePath());
+                    fileService.deleteFile(updatePayment.getImagePath());
                 } catch (WebClientRequestException | WebClientResponseException e) {
                     log.warn(AppConstant.USER_SERVICE_UNAVAILABLE_LOG, e.getMessage());
                 }
@@ -412,7 +411,7 @@ public class PaymentServiceImpl implements PaymentService {
         }
         if (image != null) {
             try {
-                updatePayment.setImagePath(userRemoteWebClient.uploadFile(image));
+                updatePayment.setImagePath(fileService.uploadFile(image));
             } catch (WebClientRequestException | WebClientResponseException e) {
                 log.warn(AppConstant.USER_SERVICE_UNAVAILABLE_LOG, e.getMessage());
             }
@@ -448,7 +447,7 @@ public class PaymentServiceImpl implements PaymentService {
             .build();
         if (image != null) {
             try {
-                payment.setImagePath(userRemoteWebClient.uploadFile(image));
+                payment.setImagePath(fileService.uploadFile(image));
             } catch (WebClientRequestException | WebClientResponseException e) {
                 log.warn(AppConstant.USER_SERVICE_UNAVAILABLE_LOG, e.getMessage());
             }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -2,7 +2,6 @@ package greencity.service.ubs;
 
 import com.netflix.hystrix.exception.HystrixRuntimeException;
 import greencity.client.UserRemoteClient;
-import greencity.client.config.UserRemoteWebClient;
 import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
 import greencity.dto.employee.EmployeeWithTariffsIdDto;
@@ -34,6 +33,7 @@ import greencity.repository.ReceivingStationRepository;
 import greencity.repository.UserRepository;
 import greencity.repository.TariffsInfoRepository;
 import greencity.repository.EmployeeOrderPositionRepository;
+import greencity.service.files.FileService;
 import greencity.service.phone.UAPhoneNumberUtil;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -65,7 +65,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
     private final ReceivingStationRepository stationRepository;
     private final TariffsInfoRepository tariffsInfoRepository;
     private final UserRemoteClient userRemoteClient;
-    private final UserRemoteWebClient userRemoteWebClient;
+    private final FileService fileService;
     private final ModelMapper modelMapper;
     private final EmployeeCriteriaRepository employeeCriteriaRepository;
     private final EmployeeOrderPositionRepository employeeOrderPositionRepository;
@@ -103,7 +103,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
         employee.setEmployeeStatus(EmployeeStatus.ACTIVE);
         if (image != null) {
             try {
-                employee.setImagePath(userRemoteWebClient.uploadFile(image));
+                employee.setImagePath(fileService.uploadFile(image));
             } catch (WebClientRequestException | WebClientResponseException e) {
                 log.warn(AppConstant.USER_SERVICE_UNAVAILABLE_LOG, e.getMessage());
             }
@@ -285,13 +285,13 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
         if (image != null) {
             String imageUrlToDelete = upEmployee.getImagePath();
             try {
-                updatedEmployee.setImagePath(userRemoteWebClient.uploadFile(image));
+                updatedEmployee.setImagePath(fileService.uploadFile(image));
             } catch (WebClientRequestException | WebClientResponseException e) {
                 log.warn(AppConstant.USER_SERVICE_UNAVAILABLE_LOG, e.getMessage());
             }
             if (!imageUrlToDelete.equals(defaultImagePath)) {
                 try {
-                    userRemoteWebClient.deleteFile(imageUrlToDelete);
+                    fileService.deleteFile(imageUrlToDelete);
                 } catch (WebClientRequestException | WebClientResponseException e) {
                     log.warn(AppConstant.USER_SERVICE_UNAVAILABLE_LOG, e.getMessage());
                 }
@@ -374,7 +374,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
             .orElseThrow(() -> new NotFoundException(ErrorMessage.EMPLOYEE_NOT_FOUND + id));
         if (!employee.getImagePath().equals(defaultImagePath)) {
             try {
-                userRemoteWebClient.deleteFile(employee.getImagePath());
+                fileService.deleteFile(employee.getImagePath());
             } catch (WebClientRequestException | WebClientResponseException e) {
                 log.warn(AppConstant.USER_SERVICE_UNAVAILABLE_LOG, e.getMessage());
             }

--- a/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementServiceImpl.java
@@ -13,7 +13,6 @@ import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toList;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import greencity.client.UserRemoteClient;
-import greencity.client.config.UserRemoteWebClient;
 import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
 import greencity.constant.OrderHistory;
@@ -99,6 +98,7 @@ import greencity.repository.UserNotificationRepository;
 import greencity.repository.UserRepository;
 import greencity.repository.CityRepository;
 import greencity.repository.DistrictRepository;
+import greencity.service.files.FileService;
 import greencity.service.notification.NotificationServiceImpl;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigDecimal;
@@ -150,7 +150,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     private final EmployeeRepository employeeRepository;
     private final ReceivingStationRepository receivingStationRepository;
     private final NotificationServiceImpl notificationService;
-    private final UserRemoteWebClient userRemoteWebClient;
+    private final FileService fileService;
     private final OrderStatusTranslationRepository orderStatusTranslationRepository;
     private final PositionRepository positionRepository;
     private final EmployeeOrderPositionRepository employeeOrderPositionRepository;
@@ -1140,7 +1140,7 @@ public class UBSManagementServiceImpl implements UBSManagementService {
     private String processImage(MultipartFile image) {
         if (image != null) {
             try {
-                return userRemoteWebClient.uploadFile(image);
+                return fileService.uploadFile(image);
             } catch (WebClientRequestException | WebClientResponseException e) {
                 log.warn("User service is unavailable: {}", e.getMessage());
             }

--- a/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
@@ -1,6 +1,5 @@
 package greencity.service.ubs;
 
-import greencity.client.config.UserRemoteWebClient;
 import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
 import greencity.constant.OrderHistory;
@@ -26,6 +25,7 @@ import greencity.repository.OrderRepository;
 import greencity.repository.UserRepository;
 import greencity.repository.UserViolationsTableRepo;
 import greencity.repository.ViolationRepository;
+import greencity.service.files.FileService;
 import greencity.service.notification.NotificationServiceImpl;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,7 +64,7 @@ public class ViolationServiceImpl implements ViolationService {
 
     private EventService eventService;
     private NotificationServiceImpl notificationService;
-    private UserRemoteWebClient userRemoteWebClient;
+    private FileService fileService;
 
     @Override
     public UserViolationsWithUserName getAllViolations(Pageable page, Long userId, String columnName,
@@ -246,7 +246,7 @@ public class ViolationServiceImpl implements ViolationService {
             List<String> images = add.getImagesToDelete();
             for (String image : images) {
                 try {
-                    userRemoteWebClient.deleteFile(image);
+                    fileService.deleteFile(image);
                 } catch (WebClientRequestException | WebClientResponseException e) {
                     log.warn(AppConstant.USER_SERVICE_UNAVAILABLE_LOG, e.getMessage());
                 }
@@ -268,7 +268,7 @@ public class ViolationServiceImpl implements ViolationService {
     private void setImages(MultipartFile[] multipartFiles, List<String> images) {
         for (MultipartFile multipartFile : multipartFiles) {
             try {
-                images.add(userRemoteWebClient.uploadFile(multipartFile));
+                images.add(fileService.uploadFile(multipartFile));
             } catch (WebClientRequestException | WebClientResponseException e) {
                 log.warn(AppConstant.USER_SERVICE_UNAVAILABLE_LOG, e.getMessage());
             }

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
@@ -1,7 +1,6 @@
 package greencity.ubstelegrambot.service;
 
 import greencity.client.UserRemoteClient;
-import greencity.client.config.UserRemoteWebClient;
 import greencity.constant.ErrorMessage;
 import greencity.constant.TelegramBotConstants;
 import greencity.dto.order.OrdersDataForUserDto;
@@ -36,6 +35,7 @@ import greencity.repository.TelegramChatRepository;
 import greencity.repository.TelegramManagerRepository;
 import greencity.repository.TelegramMessageRepository;
 import greencity.repository.UserRepository;
+import greencity.service.files.FileService;
 import greencity.service.ubs.TelegramService;
 import greencity.service.ubs.TelegramUpdateProcessor;
 import greencity.service.ubs.UBSClientService;
@@ -79,7 +79,7 @@ public class TelegramServiceImpl implements TelegramService {
     private final TelegramMessageRepository telegramMessageRepository;
     private final TelegramManagerRepository telegramManagerRepository;
     private final TelegramChatRepository telegramChatRepository;
-    private final UserRemoteWebClient userRemoteWebClient;
+    private final FileService fileService;
     private final UserRemoteClient userRemoteClient;
     private final UBSClientService ubsClientService;
     private final TelegramExecutor executor;
@@ -191,7 +191,7 @@ public class TelegramServiceImpl implements TelegramService {
         List<MessageAsset> assets = new ArrayList<>();
         for (MultipartFile img : images) {
             validateFileSize(img);
-            String url = userRemoteWebClient.uploadFile(img);
+            String url = fileService.uploadFile(img);
             assets.add(MessageAsset.builder()
                 .url(url)
                 .fileName(img.getOriginalFilename())
@@ -736,7 +736,7 @@ public class TelegramServiceImpl implements TelegramService {
     private String uploadFile(MultipartFile file) {
         String url = "";
         try {
-            url = userRemoteWebClient.uploadFile(file);
+            url = fileService.uploadFile(file);
         } catch (WebClientRequestException | WebClientResponseException e) {
             log.warn("User service is unavailable: {}", e.getMessage());
         }

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -1,6 +1,5 @@
 package greencity.ubstelegrambot.service;
 
-import greencity.client.config.UserRemoteWebClient;
 import greencity.constant.TelegramBotConstants;
 import greencity.dto.telegram.MessageAssetDto;
 import greencity.dto.telegram.TelegramMessageDto;
@@ -17,6 +16,7 @@ import greencity.producers.TelegramChatProducer;
 import greencity.repository.MessageAssetRepository;
 import greencity.repository.TelegramChatRepository;
 import greencity.repository.TelegramMessageRepository;
+import greencity.service.files.FileService;
 import greencity.service.ubs.TelegramNotificationService;
 import greencity.service.ubs.TelegramSupportService;
 import greencity.ubstelegrambot.messages.MessageFactory;
@@ -52,7 +52,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class TelegramSupportServiceImpl implements TelegramSupportService {
     private final TelegramChatRepository telegramChatRepository;
-    private final UserRemoteWebClient userRemoteWebClient;
+    private final FileService fileService;
     private final TelegramMessageRepository telegramMessageRepository;
     private final MessageAssetRepository messageAssetRepository;
     private final TelegramExecutor telegramExecutor;
@@ -450,7 +450,7 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
     private String uploadFile(MultipartFile file) {
         String url = "";
         try {
-            url = userRemoteWebClient.uploadFile(file);
+            url = fileService.uploadFile(file);
         } catch (WebClientRequestException | WebClientResponseException e) {
             log.warn("User service is unavailable: {}", e.getMessage());
         }

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -235,6 +235,8 @@ public class ModelUtils {
     public static final String TEST_AGREEMENT_TEXT_UK = "Текст угоди українською";
     public static final String TEST_AGREEMENT_TEXT_EN = "Agreement text in English";
     public static final Order TEST_ORDER = createOrder();
+    public static final String TEST_OWNER = "Test owner";
+    public static final String TEST_FILE = "test_image.png";
     public static final OrderAddressDtoResponse TEST_ORDER_ADDRESS_DTO_RESPONSE = createOrderAddressDtoResponse();
     public static final OrderAddressExportDetailsDtoUpdate TEST_ORDER_ADDRESS_DTO_UPDATE =
         createOrderAddressDtoUpdate();
@@ -307,6 +309,7 @@ public class ModelUtils {
 
     public static final String KYIV_REGION_EN = "Kyiv Oblast";
     public static final String KYIV_REGION_UK = "Київська область";
+    public static final List<String> FILE_LIST = getFileList();
 
     public static EmployeeFilterView getEmployeeFilterView() {
         return getEmployeeFilterViewWithPassedIds(1L, 5L, 10L);
@@ -5994,5 +5997,9 @@ public class ModelUtils {
             false,
             true,
             true);
+    }
+
+    public static List<String> getFileList() {
+        return List.of(TEST_FILE, "file.pdf", "test.txt");
     }
 }

--- a/service/src/test/java/greencity/service/files/FileServiceImplTest.java
+++ b/service/src/test/java/greencity/service/files/FileServiceImplTest.java
@@ -22,7 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
-public class FileServiceImplTest {
+class FileServiceImplTest {
     @Mock
     UserRemoteWebClient userRemoteWebClient;
     @InjectMocks

--- a/service/src/test/java/greencity/service/files/FileServiceImplTest.java
+++ b/service/src/test/java/greencity/service/files/FileServiceImplTest.java
@@ -1,0 +1,89 @@
+package greencity.service.files;
+
+import static greencity.ModelUtils.FILE_LIST;
+import static greencity.ModelUtils.TEST_FILE;
+import static greencity.ModelUtils.TEST_OWNER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import greencity.client.config.UserRemoteWebClient;
+import greencity.dto.files.CleanupFilesDto;
+import greencity.dto.files.DeleteFileDto;
+import greencity.dto.files.UploadFileDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+public class FileServiceImplTest {
+    @Mock
+    FileStorageFacade fileStorageFacade;
+    @Mock
+    UserRemoteWebClient userRemoteWebClient;
+    @InjectMocks
+    private FileServiceImpl fileService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(fileService, "owner", TEST_OWNER);
+    }
+
+    @Test
+    void uploadFileTest() {
+        MultipartFile file = mock(MultipartFile.class);
+        ArgumentCaptor<UploadFileDto> captor = ArgumentCaptor.forClass(UploadFileDto.class);
+
+        when(userRemoteWebClient.uploadFile(any(UploadFileDto.class)))
+            .thenReturn(TEST_FILE);
+
+        String result = fileService.uploadFile(file);
+
+        assertEquals(TEST_FILE, result);
+
+        verify(userRemoteWebClient).uploadFile(captor.capture());
+        UploadFileDto uploadFileDto = captor.getValue();
+
+        assertEquals(file, uploadFileDto.getFile());
+        assertEquals(TEST_OWNER, uploadFileDto.getOwner());
+    }
+
+    @Test
+    void deleteFileTest() {
+        ArgumentCaptor<DeleteFileDto> captor = ArgumentCaptor.forClass(DeleteFileDto.class);
+
+        doNothing().when(userRemoteWebClient).deleteFile(any(DeleteFileDto.class));
+
+        fileService.deleteFile(TEST_FILE);
+
+        verify(userRemoteWebClient).deleteFile(captor.capture());
+        DeleteFileDto deleteFileDto = captor.getValue();
+
+        assertEquals(TEST_FILE, deleteFileDto.getPath());
+        assertEquals(TEST_OWNER, deleteFileDto.getOwner());
+    }
+
+    @Test
+    void cleanUpTest() {
+        ArgumentCaptor<CleanupFilesDto> captor = ArgumentCaptor.forClass(CleanupFilesDto.class);
+
+        doNothing().when(userRemoteWebClient).cleanUp(any(CleanupFilesDto.class));
+        when(fileStorageFacade.getFilePaths()).thenReturn(FILE_LIST);
+
+        fileService.cleanUp();
+
+        verify(userRemoteWebClient).cleanUp(captor.capture());
+        CleanupFilesDto cleanupFilesDto = captor.getValue();
+
+        assertEquals(FILE_LIST, cleanupFilesDto.getPaths());
+        assertEquals(TEST_OWNER, cleanupFilesDto.getOwner());
+    }
+}

--- a/service/src/test/java/greencity/service/files/FileServiceImplTest.java
+++ b/service/src/test/java/greencity/service/files/FileServiceImplTest.java
@@ -1,6 +1,5 @@
 package greencity.service.files;
 
-import static greencity.ModelUtils.FILE_LIST;
 import static greencity.ModelUtils.TEST_FILE;
 import static greencity.ModelUtils.TEST_OWNER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -10,7 +9,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import greencity.client.config.UserRemoteWebClient;
-import greencity.dto.files.CleanupFilesDto;
 import greencity.dto.files.DeleteFileDto;
 import greencity.dto.files.UploadFileDto;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,8 +23,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 public class FileServiceImplTest {
-    @Mock
-    FileStorageFacade fileStorageFacade;
     @Mock
     UserRemoteWebClient userRemoteWebClient;
     @InjectMocks
@@ -69,21 +65,5 @@ public class FileServiceImplTest {
 
         assertEquals(TEST_FILE, deleteFileDto.getPath());
         assertEquals(TEST_OWNER, deleteFileDto.getOwner());
-    }
-
-    @Test
-    void cleanUpTest() {
-        ArgumentCaptor<CleanupFilesDto> captor = ArgumentCaptor.forClass(CleanupFilesDto.class);
-
-        doNothing().when(userRemoteWebClient).cleanUp(any(CleanupFilesDto.class));
-        when(fileStorageFacade.getFilePaths()).thenReturn(FILE_LIST);
-
-        fileService.cleanUp();
-
-        verify(userRemoteWebClient).cleanUp(captor.capture());
-        CleanupFilesDto cleanupFilesDto = captor.getValue();
-
-        assertEquals(FILE_LIST, cleanupFilesDto.getPaths());
-        assertEquals(TEST_OWNER, cleanupFilesDto.getOwner());
     }
 }

--- a/service/src/test/java/greencity/service/files/FileStorageFacadeTest.java
+++ b/service/src/test/java/greencity/service/files/FileStorageFacadeTest.java
@@ -7,19 +7,16 @@ import greencity.repository.MessageAssetRepository;
 import greencity.repository.OrderRepository;
 import greencity.repository.PaymentRepository;
 import greencity.repository.ViolationRepository;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
-public class FileStorageFacadeTest {
+class FileStorageFacadeTest {
     @Mock
     private PaymentRepository paymentRepository;
     @Mock

--- a/service/src/test/java/greencity/service/files/FileStorageFacadeTest.java
+++ b/service/src/test/java/greencity/service/files/FileStorageFacadeTest.java
@@ -1,0 +1,53 @@
+package greencity.service.files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import greencity.repository.EmployeeRepository;
+import greencity.repository.MessageAssetRepository;
+import greencity.repository.OrderRepository;
+import greencity.repository.PaymentRepository;
+import greencity.repository.ViolationRepository;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+public class FileStorageFacadeTest {
+    @Mock
+    private PaymentRepository paymentRepository;
+    @Mock
+    private ViolationRepository violationRepository;
+    @Mock
+    private EmployeeRepository employeeRepository;
+    @Mock
+    private OrderRepository orderRepository;
+    @Mock
+    private MessageAssetRepository messageAssetRepository;
+    @InjectMocks
+    private FileStorageFacade fileStorageFacade;
+
+    @Test
+    void getFilePathsTest(){
+        when(paymentRepository.findDistinctImagePaths()).thenReturn(List.of("payment1.png", "payment2.png"));
+        when(violationRepository.findDistinctImagePaths()).thenReturn(List.of("violation1.png", "violation1.png"));
+        when(employeeRepository.findDistinctImagePaths()).thenReturn(Arrays.asList("employee1.png", "employee2.png"));
+        when(orderRepository.findImagePaths()).thenReturn(Arrays.asList(
+                List.of("order1.png", "order2.png"),
+                null,
+                List.of("order2.png")));
+        when(messageAssetRepository.findDistinctImagePaths()).thenReturn(List.of("message1.png", "message1.png"));
+
+        List<String> filePaths = fileStorageFacade.getFilePaths();
+
+        assertThat(filePaths).containsExactlyInAnyOrder("payment1.png", "payment2.png",
+                "violation1.png", "employee1.png", "employee2.png",
+                "order1.png", "order2.png", "message1.png");
+    }
+}

--- a/service/src/test/java/greencity/service/files/StorageCleanupServiceImplTest.java
+++ b/service/src/test/java/greencity/service/files/StorageCleanupServiceImplTest.java
@@ -1,0 +1,50 @@
+package greencity.service.files;
+
+import static greencity.ModelUtils.FILE_LIST;
+import static greencity.ModelUtils.TEST_OWNER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import greencity.client.config.UserRemoteWebClient;
+import greencity.dto.files.CleanupFilesDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(SpringExtension.class)
+public class StorageCleanupServiceImplTest {
+    @Mock
+    FileStorageFacade fileStorageFacade;
+    @Mock
+    UserRemoteWebClient userRemoteWebClient;
+    @InjectMocks
+    private StorageCleanupServiceImpl storageCleanupServiceImpl;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(storageCleanupServiceImpl, "owner", TEST_OWNER);
+    }
+
+    @Test
+    void cleanUpTest() {
+        ArgumentCaptor<CleanupFilesDto> captor = ArgumentCaptor.forClass(CleanupFilesDto.class);
+
+        doNothing().when(userRemoteWebClient).cleanUp(any(CleanupFilesDto.class));
+        when(fileStorageFacade.getFilePaths()).thenReturn(FILE_LIST);
+
+        storageCleanupServiceImpl.cleanUp();
+
+        verify(userRemoteWebClient).cleanUp(captor.capture());
+        CleanupFilesDto cleanupFilesDto = captor.getValue();
+
+        assertEquals(FILE_LIST, cleanupFilesDto.getPaths());
+        assertEquals(TEST_OWNER, cleanupFilesDto.getOwner());
+    }
+}

--- a/service/src/test/java/greencity/service/files/StorageCleanupServiceImplTest.java
+++ b/service/src/test/java/greencity/service/files/StorageCleanupServiceImplTest.java
@@ -19,7 +19,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(SpringExtension.class)
-public class StorageCleanupServiceImplTest {
+class StorageCleanupServiceImplTest {
     @Mock
     FileStorageFacade fileStorageFacade;
     @Mock

--- a/service/src/test/java/greencity/service/ubs/PaymentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/PaymentServiceImplTest.java
@@ -45,7 +45,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import greencity.ModelUtils;
-import greencity.client.config.UserRemoteWebClient;
 import greencity.constant.ErrorMessage;
 import greencity.constant.OrderHistory;
 import greencity.dto.payment.ManualPaymentRequestDto;
@@ -71,6 +70,7 @@ import greencity.repository.PaymentRepository;
 import greencity.repository.RefundRepository;
 import greencity.repository.TariffsInfoRepository;
 import greencity.repository.UserRepository;
+import greencity.service.files.FileService;
 import greencity.service.notification.NotificationServiceImpl;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
@@ -88,7 +88,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -115,7 +114,7 @@ class PaymentServiceImplTest {
     @Mock
     RefundRepository refundRepository;
     @Mock
-    private UserRemoteWebClient userRemoteWebClient;
+    private FileService fileService;
     @Mock
     private ModelMapper modelMapper;
     @Mock
@@ -123,7 +122,7 @@ class PaymentServiceImplTest {
     @Mock
     private EmployeeRepository employeeRepository;
     @Mock
-    private NotificationServiceImpl notificationService;
+    private NotificationService notificationService;
     @Mock
     private EventService eventService;
     @Mock
@@ -208,7 +207,7 @@ class PaymentServiceImplTest {
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(paymentRepository.findById(1L)).thenReturn(Optional.of(getManualPayment()));
         doNothing().when(paymentRepository).deletePaymentById(1L);
-        doNothing().when(userRemoteWebClient).deleteFile("");
+        doNothing().when(fileService).deleteFile("");
         doNothing().when(eventService).save(OrderHistory.DELETE_PAYMENT_MANUALLY_UK + getManualPayment().getPaymentId(),
             employee.getFirstName() + "  " + employee.getLastName(),
             getOrder());
@@ -227,7 +226,7 @@ class PaymentServiceImplTest {
         when(paymentRepository.findById(1L)).thenReturn(Optional.of(getManualPayment()));
         doNothing().when(paymentRepository).deletePaymentById(1L);
         doThrow(webClientRequestException)
-            .when(userRemoteWebClient).deleteFile(anyString());
+            .when(fileService).deleteFile(anyString());
         doNothing().when(eventService).save(OrderHistory.DELETE_PAYMENT_MANUALLY_UK + getManualPayment().getPaymentId(),
             employee.getFirstName() + "  " + employee.getLastName(),
             getOrder());
@@ -251,7 +250,7 @@ class PaymentServiceImplTest {
         verify(employeeRepository).findByUuid("abc");
         verify(paymentRepository).findById(1L);
         verify(paymentRepository).deletePaymentById(1L);
-        verify(userRemoteWebClient).deleteFile(payment.getImagePath());
+        verify(fileService).deleteFile(payment.getImagePath());
         verify(eventService).save(OrderHistory.DELETE_PAYMENT_MANUALLY_UK + payment.getPaymentId(),
             employee.getFirstName() + "  " + employee.getLastName(), payment.getOrder());
 
@@ -273,7 +272,7 @@ class PaymentServiceImplTest {
         verify(employeeRepository).findByUuid("abc");
         verify(paymentRepository).findById(1L);
         verify(paymentRepository).deletePaymentById(1L);
-        verify(userRemoteWebClient, times(0)).deleteFile(payment.getImagePath());
+        verify(fileService, times(0)).deleteFile(payment.getImagePath());
         verify(eventService).save(OrderHistory.DELETE_PAYMENT_MANUALLY_UK + payment.getPaymentId(),
             employee.getFirstName() + "  " + employee.getLastName(), payment.getOrder());
     }
@@ -309,7 +308,7 @@ class PaymentServiceImplTest {
         verify(paymentRepository, times(1)).findById(1L);
         verify(paymentRepository, times(1)).save(any());
         verify(eventService, times(2)).save(any(), any(), any());
-        verify(userRemoteWebClient, times(0)).deleteFile(null);
+        verify(fileService, times(0)).deleteFile(null);
     }
 
     @Test
@@ -324,7 +323,7 @@ class PaymentServiceImplTest {
             "", "application/json", "random Bytes".getBytes());
         when(paymentRepository.findById(1L)).thenReturn(Optional.of(getManualPayment()));
         when(paymentRepository.save(any())).thenReturn(getManualPayment());
-        when(userRemoteWebClient.uploadFile(file)).thenReturn("path");
+        when(fileService.uploadFile(file)).thenReturn("path");
         doNothing().when(eventService).save(OrderHistory.UPDATE_PAYMENT_MANUALLY_UK + 1, "Yuriy" + "  " + "Gerasum",
             getOrder());
         paymentServiceImpl.updateManualPayment(1L, getManualPaymentRequestDto(), file, "abc");
@@ -387,7 +386,7 @@ class PaymentServiceImplTest {
             "", "application/json", "random Bytes".getBytes());
         when(paymentRepository.findById(1L)).thenReturn(Optional.of(getManualPayment()));
         when(paymentRepository.save(any())).thenReturn(getManualPayment());
-        when(userRemoteWebClient.uploadFile(any()))
+        when(fileService.uploadFile(any()))
             .thenThrow(webClientRequestException);
         paymentServiceImpl.updateManualPayment(1L, requestDto, file, "abc");
         List<String> warns = logCaptor.getWarnLogs();
@@ -409,7 +408,7 @@ class PaymentServiceImplTest {
         when(paymentRepository.findById(1L)).thenReturn(Optional.of(getManualPayment()));
         when(paymentRepository.save(any())).thenReturn(getManualPayment());
         doThrow(webClientRequestException)
-            .when(userRemoteWebClient).deleteFile(anyString());
+            .when(fileService).deleteFile(anyString());
         paymentServiceImpl.updateManualPayment(1L, requestDto, file, "abc");
         List<String> warns = logCaptor.getWarnLogs();
         assertTrue(warns.getFirst().contains("User service is unavailable: null"));
@@ -471,7 +470,7 @@ class PaymentServiceImplTest {
             .thenReturn(Optional.of(tariffsInfo));
         when(orderRepository.getOrderDetails(1L)).thenReturn(Optional.of(order));
         when(paymentRepository.save(any())).thenReturn(payment);
-        when(userRemoteWebClient.uploadFile(any()))
+        when(fileService.uploadFile(any()))
             .thenThrow(webClientRequestException);
         doNothing().when(eventService).save(anyString(), anyString(), any(Order.class));
 

--- a/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import com.netflix.hystrix.exception.HystrixRuntimeException;
 import greencity.client.UserRemoteClient;
-import greencity.client.config.UserRemoteWebClient;
 import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
 import greencity.dto.employee.EmployeeWithTariffsDto;
@@ -53,6 +52,7 @@ import greencity.repository.EmployeeCriteriaRepository;
 import greencity.repository.EmployeeRepository;
 import greencity.repository.PositionRepository;
 import greencity.repository.TariffsInfoRepository;
+import greencity.service.files.FileService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -78,7 +78,7 @@ class UBSManagementEmployeeServiceImplTest {
     @Mock
     private TariffsInfoRepository tariffsInfoRepository;
     @Mock
-    private UserRemoteWebClient userRemoteWebClient;
+    private FileService fileService;
     @Mock
     private UserRemoteClient userRemoteClient;
     @Mock
@@ -124,7 +124,7 @@ class UBSManagementEmployeeServiceImplTest {
         when(tariffsInfoRepository.findById(1L)).thenReturn(Optional.of(getTariffInfo()));
         when(positionRepository.findByIdIn(any())).thenReturn(Set.of(getPosition()));
         when(positionRepository.existsById(any())).thenReturn(true);
-        when(userRemoteWebClient.uploadFile(file)).thenThrow(webClientRequestException);
+        when(fileService.uploadFile(file)).thenThrow(webClientRequestException);
         employeeService.save(dto, file);
 
         List<String> warns = logCaptor.getWarnLogs();
@@ -272,13 +272,13 @@ class UBSManagementEmployeeServiceImplTest {
         when(positionRepository.existsById(position.getId())).thenReturn(true);
         when(tariffsInfoRepository.findById(1L)).thenReturn(Optional.of(getTariffInfo()));
         when(repository.save(any())).thenReturn(employee);
-        doNothing().when(userRemoteWebClient).deleteFile(retrievedEmployee.getImagePath());
+        doNothing().when(fileService).deleteFile(retrievedEmployee.getImagePath());
         when(repository.findById(anyLong())).thenReturn(Optional.of(retrievedEmployee));
         employeeService.update(dto, file);
 
         verify(modelMapper, times(2)).map(any(), any());
         verify(repository).save(any());
-        verify(userRemoteWebClient).deleteFile(retrievedEmployee.getImagePath());
+        verify(fileService).deleteFile(retrievedEmployee.getImagePath());
         verify(positionRepository, atLeastOnce()).existsById(position.getId());
         verify(repository, times(2)).findById(anyLong());
     }
@@ -330,7 +330,7 @@ class UBSManagementEmployeeServiceImplTest {
         when(positionRepository.existsById(position.getId())).thenReturn(true);
         when(positionRepository.findByIdIn(any())).thenReturn(Set.of(getPosition()));
         when(repository.findById(anyLong())).thenReturn(Optional.of(employee));
-        doThrow(webClientRequestException).when(userRemoteWebClient).deleteFile(anyString());
+        doThrow(webClientRequestException).when(fileService).deleteFile(anyString());
         employeeService.update(dto, file);
 
         List<String> warns = logCaptor.getWarnLogs();
@@ -351,7 +351,7 @@ class UBSManagementEmployeeServiceImplTest {
         when(positionRepository.findByIdIn(any())).thenReturn(Set.of(getPosition()));
         when(positionRepository.existsById(position.getId())).thenReturn(true);
         when(repository.findById(anyLong())).thenReturn(Optional.of(employee));
-        when(userRemoteWebClient.uploadFile(file)).thenThrow(webClientRequestException);
+        when(fileService.uploadFile(file)).thenThrow(webClientRequestException);
 
         employeeService.update(dto, file);
         List<String> warns = logCaptor.getWarnLogs();
@@ -564,7 +564,7 @@ class UBSManagementEmployeeServiceImplTest {
         employeeService.deleteEmployeeImage(anyLong());
 
         verify(repository, times(1)).findById(anyLong());
-        verify(userRemoteWebClient, times(1)).deleteFile("path");
+        verify(fileService, times(1)).deleteFile("path");
         verify(repository, times(1)).save(employee);
     }
 
@@ -574,7 +574,7 @@ class UBSManagementEmployeeServiceImplTest {
         Employee employee = getEmployee();
         employee.setImagePath("path");
         when(repository.findById(anyLong())).thenReturn(Optional.of(employee));
-        doThrow(webClientRequestException).when(userRemoteWebClient).deleteFile("path");
+        doThrow(webClientRequestException).when(fileService).deleteFile("path");
 
         employeeService.deleteEmployeeImage(anyLong());
 

--- a/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementServiceImplTest.java
@@ -3,7 +3,6 @@ package greencity.service.ubs;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import greencity.ModelUtils;
 import greencity.client.UserRemoteClient;
-import greencity.client.config.UserRemoteWebClient;
 import greencity.constant.OrderHistory;
 import greencity.dto.bag.AdditionalBagInfoDto;
 import greencity.dto.bag.BagInfoDto;
@@ -67,6 +66,7 @@ import greencity.repository.UserNotificationRepository;
 import greencity.repository.UserRepository;
 import greencity.repository.CityRepository;
 import greencity.repository.DistrictRepository;
+import greencity.service.files.FileService;
 import greencity.service.notification.NotificationServiceImpl;
 import java.util.HashMap;
 import org.junit.jupiter.api.Assertions;
@@ -130,7 +130,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class UBSManagementServiceImplTest {
     @Mock
-    private UserRemoteWebClient userRemoteWebClient;
+    private FileService fileService;
     @Mock(strictness = Mock.Strictness.LENIENT)
     OrderRepository orderRepository;
     @Mock

--- a/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import greencity.ModelUtils;
-import greencity.client.config.UserRemoteWebClient;
 import greencity.constant.ErrorMessage;
 import greencity.constant.OrderHistory;
 import greencity.dto.violation.AddingViolationsToUserDto;
@@ -35,6 +34,7 @@ import greencity.repository.OrderRepository;
 import greencity.repository.UserRepository;
 import greencity.repository.UserViolationsTableRepo;
 import greencity.repository.ViolationRepository;
+import greencity.service.files.FileService;
 import greencity.service.notification.NotificationServiceImpl;
 import java.util.Arrays;
 import java.util.List;
@@ -75,7 +75,7 @@ class ViolationServiceImplTest {
     @Mock
     WebClientRequestException webClientRequestException;
     @Mock
-    private UserRemoteWebClient userRemoteWebClient;
+    private FileService fileService;
     @Mock
     private EventService eventService;
     @Mock
@@ -213,7 +213,7 @@ class ViolationServiceImplTest {
         if (updateViolationToUserDto.getImagesToDelete() != null) {
             List<String> images = updateViolationToUserDto.getImagesToDelete();
             for (String image : images) {
-                doNothing().when(userRemoteWebClient).deleteFile(image);
+                doNothing().when(fileService).deleteFile(image);
                 violationImages.remove(image);
             }
         }
@@ -239,7 +239,7 @@ class ViolationServiceImplTest {
         if (updateViolationToUserDto.getImagesToDelete() != null) {
             List<String> images = updateViolationToUserDto.getImagesToDelete();
             for (String image : images) {
-                doThrow(webClientRequestException).when(userRemoteWebClient).deleteFile(image);
+                doThrow(webClientRequestException).when(fileService).deleteFile(image);
                 violationImages.remove(image);
             }
         }
@@ -262,11 +262,11 @@ class ViolationServiceImplTest {
         if (updateViolationToUserDto.getImagesToDelete() != null) {
             List<String> images = updateViolationToUserDto.getImagesToDelete();
             for (String image : images) {
-                doNothing().when(userRemoteWebClient).deleteFile(image);
+                doNothing().when(fileService).deleteFile(image);
                 violationImages.remove(image);
             }
         }
-        when(userRemoteWebClient.uploadFile(any()))
+        when(fileService.uploadFile(any()))
             .thenThrow(webClientRequestException);
 
         violationService.updateUserViolation(updateViolationToUserDto, new MultipartFile[2], "abc");

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
@@ -1,7 +1,6 @@
 package greencity.ubstelegrambot;
 
 import greencity.client.UserRemoteClient;
-import greencity.client.config.UserRemoteWebClient;
 import greencity.dto.order.OrdersDataForUserDto;
 import greencity.dto.pageble.PageableDto;
 import greencity.dto.telegram.ChatDto;
@@ -32,6 +31,7 @@ import greencity.repository.TelegramChatRepository;
 import greencity.repository.TelegramManagerRepository;
 import greencity.repository.TelegramMessageRepository;
 import greencity.repository.UserRepository;
+import greencity.service.files.FileService;
 import greencity.service.ubs.TelegramUpdateProcessor;
 import greencity.service.ubs.UBSClientService;
 import greencity.ubstelegrambot.messages.MessageFactory;
@@ -104,7 +104,7 @@ class TelegramServiceTest {
     private TelegramChatRepository telegramChatRepository;
 
     @Mock
-    private UserRemoteWebClient userRemoteWebClient;
+    private FileService fileService;
 
     @Mock
     private TelegramMessageRepository telegramMessageRepository;
@@ -158,7 +158,7 @@ class TelegramServiceTest {
             telegramMessageRepository,
             telegramManagerRepository,
             telegramChatRepository,
-            userRemoteWebClient,
+            fileService,
             userRemoteClient,
             ubsClientService,
             executor,
@@ -205,7 +205,7 @@ class TelegramServiceTest {
             () -> telegramService.sendMessageToUser(request, new MultipartFile[] {file}));
 
         verify(telegramChatRepository).findById(1L);
-        verifyNoInteractions(userRemoteWebClient);
+        verifyNoInteractions(fileService);
         verifyNoInteractions(executor);
     }
 
@@ -228,11 +228,11 @@ class TelegramServiceTest {
         when(file.getSize()).thenReturn(2048L);
         when(file.getContentType()).thenReturn("image/png");
         when(file.getInputStream()).thenReturn(bais);
-        when(userRemoteWebClient.uploadFile(file)).thenReturn("http://image");
+        when(fileService.uploadFile(file)).thenReturn("http://image");
 
         telegramService.sendMessageToUser(request, new MultipartFile[] {file});
 
-        verify(userRemoteWebClient).uploadFile(file);
+        verify(fileService).uploadFile(file);
         verify(executor).executeSendFile(any(SendDocument.class));
         verify(telegramMessageRepository).save(any(TelegramMessage.class));
         verify(telegramChatRepository).save(any(TelegramChat.class));
@@ -257,11 +257,11 @@ class TelegramServiceTest {
         when(file.getSize()).thenReturn(2048L);
         when(file.getContentType()).thenReturn("image/png");
         when(file.getInputStream()).thenReturn(bais);
-        when(userRemoteWebClient.uploadFile(file)).thenReturn("http://image");
+        when(fileService.uploadFile(file)).thenReturn("http://image");
 
         telegramService.sendMessageToUser(request, new MultipartFile[] {file});
 
-        verify(userRemoteWebClient).uploadFile(file);
+        verify(fileService).uploadFile(file);
         verify(executor).executeSendPhoto(any(SendPhoto.class));
         verify(telegramMessageRepository).save(any(TelegramMessage.class));
         verify(telegramChatRepository).save(any(TelegramChat.class));
@@ -1205,7 +1205,7 @@ class TelegramServiceTest {
         assertEquals("File size exceeds Telegram bot limit (50MB)", exception.getMessage());
 
         verify(telegramChatRepository).findById(1L);
-        verifyNoInteractions(userRemoteWebClient);
+        verifyNoInteractions(fileService);
         verifyNoInteractions(executor);
         verify(telegramMessageRepository, never()).save(any());
     }
@@ -1546,11 +1546,11 @@ class TelegramServiceTest {
         sentDoc.setMessageId(999);
         when(executor.executeSendFile(any(SendDocument.class))).thenReturn(sentDoc);
 
-        when(userRemoteWebClient.uploadFile(nonImageFile)).thenReturn("http://fakeurl");
+        when(fileService.uploadFile(nonImageFile)).thenReturn("http://fakeurl");
 
         telegramService.sendMessageToUser(request, new MultipartFile[] {nonImageFile});
 
-        verify(userRemoteWebClient).uploadFile(nonImageFile);
+        verify(fileService).uploadFile(nonImageFile);
         verify(executor).executeSendFile(any(SendDocument.class));
 
         ArgumentCaptor<TelegramMessage> messageCaptor = ArgumentCaptor.forClass(TelegramMessage.class);
@@ -1607,7 +1607,7 @@ class TelegramServiceTest {
         when(file.getSize()).thenReturn(1024L);
         when(file.getContentType()).thenReturn("application/octet-stream");
 
-        when(userRemoteWebClient.uploadFile(file)).thenReturn("http://fakeurl");
+        when(fileService.uploadFile(file)).thenReturn("http://fakeurl");
 
         Message fakeMessage = new Message();
         fakeMessage.setMessageId(123);
@@ -1615,7 +1615,7 @@ class TelegramServiceTest {
 
         telegramService.sendMessageToUser(request, new MultipartFile[] {file});
 
-        verify(userRemoteWebClient).uploadFile(file);
+        verify(fileService).uploadFile(file);
         verify(executor).executeSendFile(any(SendDocument.class));
         verify(telegramMessageRepository).save(any());
         verify(messageAssetRepository).save(any());

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramSupportServiceTest.java
@@ -1,6 +1,5 @@
 package greencity.ubstelegrambot;
 
-import greencity.client.config.UserRemoteWebClient;
 import greencity.constant.TelegramBotConstants;
 import greencity.dto.telegram.TelegramMessageDto;
 import greencity.entity.telegram.MessageAsset;
@@ -12,6 +11,7 @@ import greencity.producers.TelegramChatProducer;
 import greencity.repository.MessageAssetRepository;
 import greencity.repository.TelegramChatRepository;
 import greencity.repository.TelegramMessageRepository;
+import greencity.service.files.FileService;
 import greencity.service.ubs.TelegramNotificationService;
 import greencity.ubstelegrambot.messages.MessageFactory;
 import greencity.ubstelegrambot.messages.MessageProvider;
@@ -84,7 +84,7 @@ class TelegramSupportServiceTest {
     private TelegramMessageRepository telegramMessageRepository;
 
     @Mock
-    private UserRemoteWebClient userRemoteWebClient;
+    private FileService fileService;
 
     @Mock
     private TelegramExecutor telegramExecutor;
@@ -367,12 +367,12 @@ class TelegramSupportServiceTest {
         when(telegramMessageRepository.findByMediaGroupId(mediaGroupId)).thenReturn(Optional.of(telegramMessage));
         when(telegramExecutor.executeGetFile(any(GetFile.class))).thenReturn(file);
         when(telegramUtils.fileToByteArray(file)).thenReturn(new byte[] {1, 2, 3});
-        when(userRemoteWebClient.uploadFile(any(MultipartFile.class))).thenReturn("azureFileUrl");
+        when(fileService.uploadFile(any(MultipartFile.class))).thenReturn("azureFileUrl");
 
         SendMessage result = telegramSupportService.processSupportMessage(message, TelegramBotConstants.UK);
 
         assertNull(result);
-        verify(userRemoteWebClient).uploadFile(any(MultipartFile.class));
+        verify(fileService).uploadFile(any(MultipartFile.class));
         verify(messageAssetRepository).save(any(MessageAsset.class));
         verify(telegramMessageRepository).findByMediaGroupId(mediaGroupId);
 
@@ -460,7 +460,7 @@ class TelegramSupportServiceTest {
         when(telegramExecutor.executeGetFile(any(GetFile.class))).thenReturn(file);
         when(file.getFilePath()).thenReturn("/path/to/file.pdf");
         when(telegramUtils.fileToByteArray(file)).thenReturn(new byte[] {1, 2, 3});
-        when(userRemoteWebClient.uploadFile(any())).thenReturn("https://azure.com/file");
+        when(fileService.uploadFile(any())).thenReturn("https://azure.com/file");
 
         TelegramChat chat = TelegramChat.builder()
             .id(1L)
@@ -473,7 +473,7 @@ class TelegramSupportServiceTest {
         SendMessage result = telegramSupportService.processSupportMessage(message, TelegramBotConstants.UK);
 
         assertEquals(MessageProvider.get(TelegramBotConstants.UK, "message.sent.to.manager"), result.getText());
-        verify(userRemoteWebClient).uploadFile(any());
+        verify(fileService).uploadFile(any());
         verify(messageAssetRepository).save(any());
 
         verify(telegramMessageRepository).save(any(TelegramMessage.class));
@@ -539,7 +539,7 @@ class TelegramSupportServiceTest {
         when(file.getFilePath()).thenReturn("/path/to/file.pdf");
 
         when(telegramUtils.fileToByteArray(file)).thenReturn(new byte[] {1, 2, 3});
-        when(userRemoteWebClient.uploadFile(any())).thenReturn("https://azure.com/file");
+        when(fileService.uploadFile(any())).thenReturn("https://azure.com/file");
 
         TelegramChat chat = TelegramChat.builder()
             .id(1L)
@@ -556,7 +556,7 @@ class TelegramSupportServiceTest {
         verify(telegramMessageRepository).save(any(TelegramMessage.class));
         verify(telegramChatProducer).notifyNewMessage(any(TelegramMessageDto.class), anyLong());
         verify(telegramNotificationService).notifyManagerAboutNewMessagesFromUser(any(), any(), eq(chat.getId()));
-        verify(userRemoteWebClient).uploadFile(any(MultipartFile.class));
+        verify(fileService).uploadFile(any(MultipartFile.class));
         verify(messageAssetRepository).save(any(MessageAsset.class));
 
     }
@@ -595,7 +595,7 @@ class TelegramSupportServiceTest {
         when(telegramExecutor.executeGetFile(any(GetFile.class))).thenReturn(file);
         when(file.getFilePath()).thenReturn("/path/photo.jpeg");
         when(telegramUtils.fileToByteArray(file)).thenReturn(new byte[] {1, 2, 3});
-        when(userRemoteWebClient.uploadFile(any(MultipartFile.class))).thenReturn("https://azure.com/photo");
+        when(fileService.uploadFile(any(MultipartFile.class))).thenReturn("https://azure.com/photo");
 
         ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
         SendMessage result = telegramSupportService.processSupportMessage(message, TelegramBotConstants.UK);
@@ -609,7 +609,7 @@ class TelegramSupportServiceTest {
             eq(chatDbId));
         assertEquals("Image content (1 images) + text", contentCaptor.getValue());
 
-        verify(userRemoteWebClient).uploadFile(any(MultipartFile.class));
+        verify(fileService).uploadFile(any(MultipartFile.class));
         verify(messageAssetRepository).save(any(MessageAsset.class));
     }
 
@@ -666,7 +666,7 @@ class TelegramSupportServiceTest {
         tgFile.setFilePath("files/sticker.webp");
         when(telegramExecutor.executeGetFile(any())).thenReturn(tgFile);
         when(telegramUtils.fileToByteArray(any())).thenReturn("bytes".getBytes());
-        when(userRemoteWebClient.uploadFile(any())).thenReturn("http://cdn/sticker.webp");
+        when(fileService.uploadFile(any())).thenReturn("http://cdn/sticker.webp");
 
         SendMessage result = telegramSupportService.processSupportMessage(message, "en");
 
@@ -728,7 +728,7 @@ class TelegramSupportServiceTest {
         tgFile.setFilePath("files/clip.mp4");
         when(telegramExecutor.executeGetFile(any())).thenReturn(tgFile);
         when(telegramUtils.fileToByteArray(any())).thenReturn("video".getBytes());
-        when(userRemoteWebClient.uploadFile(any())).thenReturn("http://cdn/clip.mp4");
+        when(fileService.uploadFile(any())).thenReturn("http://cdn/clip.mp4");
 
         SendMessage result = telegramSupportService.processSupportMessage(message, "en");
 
@@ -789,7 +789,7 @@ class TelegramSupportServiceTest {
         telegramFile.setFilePath("video/file.mp4");
         when(telegramExecutor.executeGetFile(any(GetFile.class))).thenReturn(telegramFile);
         when(telegramUtils.fileToByteArray(any(File.class))).thenReturn(new byte[] {1, 2, 3});
-        when(userRemoteWebClient.uploadFile(any(MultipartFile.class))).thenReturn("http://file-url");
+        when(fileService.uploadFile(any(MultipartFile.class))).thenReturn("http://file-url");
 
         // when
         SendMessage result = telegramSupportService.processSupportMessage(message, "en");


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link :clipboard:
[#9145](https://github.com/ita-social-projects/GreenCity/issues/9145)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Weekly automated storage cleanup runs every Saturday at 03:00 to free space.

- Improvements
  - Centralized file service used across modules for consistent uploads/deletes.
  - Aggregation and deduplication of stored image paths from multiple sources to reduce duplicates.
  - New DTOs and cleanup workflow to support bulk cleanup operations.

- Tests
  - Expanded unit tests for file operations, aggregation, and cleanup flows to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->