### PR TITLE
fix BigOrderTableRepositoryTest

### DIFF
--- a/core/src/test/java/greencity/IntegrationTestBase.java
+++ b/core/src/test/java/greencity/IntegrationTestBase.java
@@ -1,10 +1,11 @@
 package greencity;
 
 import greencity.initializer.PostgresInitializer;
+import jakarta.transaction.Transactional;
+import java.util.TimeZone;
 import org.junit.jupiter.api.BeforeAll;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import jakarta.transaction.Transactional;
 
 @ActiveProfiles("test")
 @ContextConfiguration(initializers = {
@@ -15,6 +16,7 @@ public abstract class IntegrationTestBase {
 
     @BeforeAll
     static void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Kyiv"));
         PostgresInitializer.postgreSQLContainer.start();
     }
 }

--- a/core/src/test/java/greencity/IntegrationTestBase.java
+++ b/core/src/test/java/greencity/IntegrationTestBase.java
@@ -1,11 +1,11 @@
 package greencity;
 
 import greencity.initializer.PostgresInitializer;
-import jakarta.transaction.Transactional;
 import java.util.TimeZone;
 import org.junit.jupiter.api.BeforeAll;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 @ActiveProfiles("test")
 @ContextConfiguration(initializers = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized the integration test environment by setting a default time zone (Europe/Kyiv) before the database container starts. This improves consistency of date/time handling, reduces flaky outcomes across CI and local runs, and enhances test repeatability. Also aligned test transactional behavior with framework conventions. No impact on application runtime; changes affect test execution stability and developer experience only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->