### PR TITLE
Fix/9175 add violation without photo

### DIFF
--- a/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/ViolationServiceImpl.java
@@ -112,7 +112,7 @@ public class ViolationServiceImpl implements ViolationService {
         if (violationRepository.findActiveViolationByOrderId(order.getId()).isEmpty()) {
             User user = order.getUser();
             Violation violation = violationBuilder(add, order, user);
-            if (multipartFiles.length > 0) {
+            if (multipartFiles != null && multipartFiles.length > 0) {
                 List<String> images = new LinkedList<>();
                 setImages(multipartFiles, images);
                 violation.setImages(images);

--- a/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/ViolationServiceImplTest.java
@@ -373,6 +373,31 @@ class ViolationServiceImplTest {
     }
 
     @Test
+    void testAddUserViolationWithNullMultipartFiles() {
+        Employee employee = ModelUtils.getEmployee();
+        User user = ModelUtils.getTestUser();
+        Order order = user.getOrders().getFirst();
+        order.setOrderStatus(OrderStatus.DONE);
+        order.setUser(user);
+        TariffsInfo tariffsInfo = ModelUtils.getTariffInfo();
+        order.setTariffsInfo(tariffsInfo);
+        AddingViolationsToUserDto add = ModelUtils.getAddingViolationsToUserDto();
+
+        when(orderRepository.findById(anyLong())).thenReturn(Optional.of(order));
+        when(employeeRepository.findByEmail(anyString())).thenReturn(Optional.of(employee));
+        when(employeeRepository.findTariffsInfoForEmployee(anyLong())).thenReturn(Arrays.asList(1L, 2L));
+
+        violationService.addUserViolation(add, null, employee.getEmail());
+
+        verify(orderRepository, times(2)).findById(anyLong());
+        verify(employeeRepository).findTariffsInfoForEmployee(anyLong());
+        verify(violationRepository).save(any(Violation.class));
+        verify(userRepository).save(user);
+        verify(eventService).saveEvent(OrderHistory.ADD_VIOLATION_UK, employee.getEmail(), order);
+        verify(notificationService).notifyAddViolation(order.getId());
+    }
+
+    @Test
     void testUpdateViolationWhenImagesIsNotEmpty() {
         Employee employee = ModelUtils.getEmployee();
         User user = ModelUtils.getTestUser();


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#9146](https://github.com/ita-social-projects/GreenCity/issues/9146)

## Changed
- Added a null check to prevent potential NullPointerException when no files are provided, allowing violations to be created without attached images.
- Added unit test to cover null case for multipartFiles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved an issue where submitting a violation without attachments could cause an error. The system now safely handles submissions with no images, ensuring the violation is saved and processed correctly for a smoother reporting experience.

- Tests
  - Added test coverage for violation submissions without attachments to ensure consistent behavior and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->