### PR TITLE
Fix after User Status Split

### DIFF
--- a/service/src/main/java/greencity/service/ubs/user/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/user/UserServiceImpl.java
@@ -173,6 +173,7 @@ public class UserServiceImpl implements UserService {
             .uuid(userProfileCreateDto.getUuid())
             .recipientEmail(userProfileCreateDto.getEmail())
             .recipientName(userProfileCreateDto.getName())
+            .status(UserStatus.ACTIVATED)
             .currentPoints(0)
             .violations(0)
             .dateOfRegistration(LocalDate.now()).build());

--- a/service/src/test/java/greencity/service/ubs/user/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/user/UserServiceImplTest.java
@@ -371,6 +371,7 @@ class UserServiceImplTest {
             .uuid(userProfileCreateDto.getUuid())
             .recipientEmail(userProfileCreateDto.getEmail())
             .recipientName(userProfileCreateDto.getName())
+            .status(UserStatus.ACTIVATED)
             .currentPoints(0)
             .violations(0)
             .dateOfRegistration(LocalDate.now()).build();


### PR DESCRIPTION
* added status initialization in createUserProfile method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - New UBS user accounts are now activated by default upon creation, enabling immediate access and streamlining onboarding.

- **Bug Fixes**
  - Removes issues caused by users remaining in a pending activation state, improving first-time login reliability and reducing onboarding friction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->