### PR TITLE
Remove 404 status from get /ubs/personal-data endpoint

### DIFF
--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -167,8 +167,7 @@ public class OrderController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
             content = @Content(schema = @Schema(implementation = PersonalDataDto.class))),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED, content = @Content)
     })
     @GetMapping("/personal-data")
     public ResponseEntity<PersonalDataDto> getUBSUsers(


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#9180](https://github.com/ita-social-projects/GreenCity/issues/9180)

## Changed
Removed the invalid 404 Not Found response from the Swagger documentation for the GET /ubs/personal-data endpoint, since this status cannot occur for an authorized user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation for the certificate availability check endpoint to reflect only 200 (OK) and 401 (UNAUTHORIZED) responses, removing the previously listed 404 (NOT_FOUND).
  * Aligns documented responses with actual behavior to improve accuracy for integrators and API consumers.
  * No changes to endpoint behavior, request/response payloads, or method signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->