### PR TITLE
Added reason for profile deletion

### DIFF
--- a/core/src/main/java/greencity/controller/UserProfileController.java
+++ b/core/src/main/java/greencity/controller/UserProfileController.java
@@ -170,7 +170,7 @@ public class UserProfileController {
     })
     @DeleteMapping("/user/delete")
     public ResponseEntity<Object> deleteUser(@Parameter(hidden = true) @CurrentUserUuid String uuid,
-        @RequestBody UserDeletionReasonDto reason) {
+        @RequestBody @Valid UserDeletionReasonDto reason) {
         userService.deleteUserByUuid(uuid, reason);
         return ResponseEntity.ok().build();
     }

--- a/core/src/main/java/greencity/controller/UserProfileController.java
+++ b/core/src/main/java/greencity/controller/UserProfileController.java
@@ -2,6 +2,8 @@ package greencity.controller;
 
 import greencity.annotations.CurrentUserUuid;
 import greencity.constants.HttpStatuses;
+import greencity.dto.user.UserDeactivationReasonDto;
+import greencity.dto.user.UserDeletionReasonDto;
 import greencity.dto.user.UserProfileCreateDto;
 import greencity.dto.user.UserProfileDto;
 import greencity.dto.user.UserProfileUpdateDto;
@@ -168,8 +170,9 @@ public class UserProfileController {
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })
     @DeleteMapping("/user/delete")
-    public ResponseEntity<Object> deleteUser(@Parameter(hidden = true) @CurrentUserUuid String uuid) {
-        userService.deleteUserByUuid(uuid);
+    public ResponseEntity<Object> deleteUser(@Parameter(hidden = true) @CurrentUserUuid String uuid,
+        @RequestBody UserDeletionReasonDto dto) {
+        userService.deleteUserByUuid(uuid, dto);
         return ResponseEntity.ok().build();
     }
 

--- a/core/src/main/java/greencity/controller/UserProfileController.java
+++ b/core/src/main/java/greencity/controller/UserProfileController.java
@@ -2,7 +2,6 @@ package greencity.controller;
 
 import greencity.annotations.CurrentUserUuid;
 import greencity.constants.HttpStatuses;
-import greencity.dto.user.UserDeactivationReasonDto;
 import greencity.dto.user.UserDeletionReasonDto;
 import greencity.dto.user.UserProfileCreateDto;
 import greencity.dto.user.UserProfileDto;
@@ -171,8 +170,8 @@ public class UserProfileController {
     })
     @DeleteMapping("/user/delete")
     public ResponseEntity<Object> deleteUser(@Parameter(hidden = true) @CurrentUserUuid String uuid,
-        @RequestBody UserDeletionReasonDto dto) {
-        userService.deleteUserByUuid(uuid, dto);
+        @RequestBody UserDeletionReasonDto reason) {
+        userService.deleteUserByUuid(uuid, reason);
         return ResponseEntity.ok().build();
     }
 

--- a/core/src/test/java/greencity/controller/UserProfileControllerTest.java
+++ b/core/src/test/java/greencity/controller/UserProfileControllerTest.java
@@ -16,6 +16,7 @@ import greencity.configuration.SecurityConfig;
 import greencity.constant.AppConstant;
 import greencity.converters.UserArgumentResolver;
 import greencity.dto.address.AddressDto;
+import greencity.dto.user.UserDeletionReasonDto;
 import greencity.dto.user.UserProfileDto;
 import greencity.enums.UserStatus;
 import greencity.exception.handler.CustomExceptionHandler;
@@ -166,15 +167,20 @@ class UserProfileControllerTest {
     @Test
     void deleteUserTest() throws Exception {
         String uuid = "uuid";
+        UserDeletionReasonDto dto = UserDeletionReasonDto.builder()
+            .reason("reason")
+            .build();
 
         when(userRepository.findUuidByRecipientEmail(principal.getName()))
             .thenReturn(Optional.of("uuid"));
 
         mockMvc.perform(delete(AppConstant.UBS_LINK_USERPROFILE + "/user/delete")
-            .principal(principal))
+            .principal(principal)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(dto)))
             .andExpect(status().isOk());
 
-        verify(userService).deleteUserByUuid(uuid);
+        verify(userService).deleteUserByUuid(uuid, dto);
     }
 
     @Test

--- a/service-api/src/main/java/greencity/dto/user/UserDeletionReasonDto.java
+++ b/service-api/src/main/java/greencity/dto/user/UserDeletionReasonDto.java
@@ -9,9 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 @Builder
-public class UserDeactivationReasonDto {
-    private String email;
-    private String name;
+public class UserDeletionReasonDto {
     private String reason;
-    private String lang;
 }

--- a/service-api/src/main/java/greencity/dto/user/UserDeletionReasonDto.java
+++ b/service-api/src/main/java/greencity/dto/user/UserDeletionReasonDto.java
@@ -1,5 +1,6 @@
 package greencity.dto.user;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,5 +11,6 @@ import lombok.NoArgsConstructor;
 @Data
 @Builder
 public class UserDeletionReasonDto {
+    @NotBlank
     private String reason;
 }

--- a/service-api/src/main/java/greencity/service/ubs/user/UserService.java
+++ b/service-api/src/main/java/greencity/service/ubs/user/UserService.java
@@ -4,7 +4,6 @@ import greencity.dto.customer.UbsCustomersDto;
 import greencity.dto.customer.UbsCustomersDtoUpdate;
 import greencity.dto.employee.UserEmployeeAuthorityDto;
 import greencity.dto.position.PositionAuthoritiesDto;
-import greencity.dto.user.UserDeactivationReasonDto;
 import greencity.dto.user.UserDeletionReasonDto;
 import greencity.dto.user.UserInfoDto;
 import greencity.dto.user.UserPointDto;
@@ -111,10 +110,10 @@ public interface UserService {
     /**
      * Method to delete a user by uuid, setting their status to DELETED.
      *
-     * @param uuid {@link String} user's uuid.
-     * @param dto  {@link UserDeletionReasonDto} reason for deletion
+     * @param uuid   {@link String} user's uuid.
+     * @param reason {@link UserDeletionReasonDto} reason for deletion
      */
-    void deleteUserByUuid(String uuid, UserDeletionReasonDto dto);
+    void deleteUserByUuid(String uuid, UserDeletionReasonDto reason);
 
     /**
      * Method that change user status.

--- a/service-api/src/main/java/greencity/service/ubs/user/UserService.java
+++ b/service-api/src/main/java/greencity/service/ubs/user/UserService.java
@@ -4,6 +4,8 @@ import greencity.dto.customer.UbsCustomersDto;
 import greencity.dto.customer.UbsCustomersDtoUpdate;
 import greencity.dto.employee.UserEmployeeAuthorityDto;
 import greencity.dto.position.PositionAuthoritiesDto;
+import greencity.dto.user.UserDeactivationReasonDto;
+import greencity.dto.user.UserDeletionReasonDto;
 import greencity.dto.user.UserInfoDto;
 import greencity.dto.user.UserPointDto;
 import greencity.dto.user.UserProfileCreateDto;
@@ -110,8 +112,9 @@ public interface UserService {
      * Method to delete a user by uuid, setting their status to DELETED.
      *
      * @param uuid {@link String} user's uuid.
+     * @param dto  {@link UserDeletionReasonDto} reason for deletion
      */
-    void deleteUserByUuid(String uuid);
+    void deleteUserByUuid(String uuid, UserDeletionReasonDto dto);
 
     /**
      * Method that change user status.

--- a/service/src/main/java/greencity/service/ubs/user/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/user/UserServiceImpl.java
@@ -305,7 +305,7 @@ public class UserServiceImpl implements UserService {
      */
     @org.springframework.transaction.annotation.Transactional
     @Override
-    public void deleteUserByUuid(String uuid, UserDeletionReasonDto dto) {
+    public void deleteUserByUuid(String uuid, UserDeletionReasonDto reason) {
         User user = userRepository.findUserByUuid(uuid)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_UUID + uuid));
 
@@ -315,7 +315,7 @@ public class UserServiceImpl implements UserService {
         }
 
         String lang = userRemoteClient.findUserLanguageByUuid(user.getUuid());
-        saveAndSendDeactivationReason(user, dto.getReason(), lang);
+        saveAndSendDeactivationReason(user, reason.getReason(), lang);
 
         user.setStatus(UserStatus.DELETED);
         userRepository.save(user);

--- a/service/src/main/java/greencity/service/ubs/user/UserServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/user/UserServiceImpl.java
@@ -21,6 +21,7 @@ import greencity.dto.order.OrderAddressDtoRequest;
 import greencity.dto.position.PositionAuthoritiesDto;
 import greencity.dto.user.UserActivationDto;
 import greencity.dto.user.UserDeactivationReasonDto;
+import greencity.dto.user.UserDeletionReasonDto;
 import greencity.dto.user.UserExternalDto;
 import greencity.dto.user.UserInfoDto;
 import greencity.dto.user.UserPointDto;
@@ -304,7 +305,7 @@ public class UserServiceImpl implements UserService {
      */
     @org.springframework.transaction.annotation.Transactional
     @Override
-    public void deleteUserByUuid(String uuid) {
+    public void deleteUserByUuid(String uuid, UserDeletionReasonDto dto) {
         User user = userRepository.findUserByUuid(uuid)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_UUID + uuid));
 
@@ -312,6 +313,9 @@ public class UserServiceImpl implements UserService {
             || user.getStatus() == UserStatus.BLOCKED) {
             throw new ForbiddenException(ErrorMessage.FORBIDDEN_USER_DELETION);
         }
+
+        String lang = userRemoteClient.findUserLanguageByUuid(user.getUuid());
+        saveAndSendDeactivationReason(user, dto.getReason(), lang);
 
         user.setStatus(UserStatus.DELETED);
         userRepository.save(user);
@@ -329,10 +333,10 @@ public class UserServiceImpl implements UserService {
             throw new UserStatusUpdateException(ErrorMessage.USER_CANNOT_DEACTIVATE_YOURSELF);
         }
 
-        UserExternalDto currentUserDto = userRemoteClient.findByUuid(currentUserUuid);
         String lang = userRemoteClient.findUserLanguageByUuid(targetUser.getUuid());
         switch (status) {
             case DEACTIVATED -> {
+                UserExternalDto currentUserDto = userRemoteClient.findByUuid(currentUserUuid);
                 UserExternalDto targetUserDto = userRemoteClient.findByUuid(targetUser.getUuid());
                 if (targetUserDto.getRole().equals(Role.ROLE_ADMIN)) {
                     throw new UserStatusUpdateException(ErrorMessage.ADMIN_CANNOT_DEACTIVATE_OTHER_ADMIN);
@@ -340,19 +344,7 @@ public class UserServiceImpl implements UserService {
 
                 String reason = String.format("Deactivated by %s[%s] admin.", currentUserDto.getName(),
                     currentUserDto.getUuid());
-                userDeactivationRepo.save(UserDeactivationReason.builder()
-                    .dateTimeOfDeactivation(LocalDateTime.now())
-                    .reason(reason)
-                    .user(targetUser)
-                    .build());
-
-                UserDeactivationReasonDto notification = UserDeactivationReasonDto.builder()
-                    .deactivationReason(reason)
-                    .email(targetUser.getRecipientEmail())
-                    .name(targetUser.getRecipientName())
-                    .lang(lang)
-                    .build();
-                userRemoteClient.sendReasonOfDeactivation(notification);
+                saveAndSendDeactivationReason(targetUser, reason, lang);
             }
             case ACTIVATED -> {
                 UserActivationDto notification = UserActivationDto.builder()
@@ -393,6 +385,21 @@ public class UserServiceImpl implements UserService {
     @Override
     public long getActivatedUsersAmount() {
         return userRepository.countAllByStatus(UserStatus.ACTIVATED);
+    }
+
+    private void saveAndSendDeactivationReason(User user, String reason, String lang) {
+        userDeactivationRepo.save(UserDeactivationReason.builder()
+            .dateTimeOfDeactivation(LocalDateTime.now())
+            .reason(reason)
+            .user(user)
+            .build());
+
+        userRemoteClient.sendReasonOfDeactivation(UserDeactivationReasonDto.builder()
+            .reason(reason)
+            .email(user.getRecipientEmail())
+            .name(user.getRecipientName())
+            .lang(lang)
+            .build());
     }
 
     private List<String> filterReasons(String lang, String reasons) {

--- a/service/src/test/java/greencity/service/ubs/user/UserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/user/UserServiceImplTest.java
@@ -50,6 +50,7 @@ import greencity.dto.position.PositionAuthoritiesDto;
 import greencity.dto.user.PasswordStatusDto;
 import greencity.dto.user.UserActivationDto;
 import greencity.dto.user.UserDeactivationReasonDto;
+import greencity.dto.user.UserDeletionReasonDto;
 import greencity.dto.user.UserExternalDto;
 import greencity.dto.user.UserInfoDto;
 import greencity.dto.user.UserProfileCreateDto;
@@ -645,9 +646,13 @@ class UserServiceImplTest {
     void deleteUserByUuid_ShouldSetStatusToDeleted_WhenUserIsActivated() {
         String uuid = "test-uuid-123";
         testUser.setStatus(UserStatus.ACTIVATED);
+        UserDeletionReasonDto dto = UserDeletionReasonDto.builder()
+            .reason("test reason")
+            .build();
+
         when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.of(testUser));
 
-        userService.deleteUserByUuid(uuid);
+        userService.deleteUserByUuid(uuid, dto);
 
         assertEquals(UserStatus.DELETED, testUser.getStatus());
         verify(userRepository).save(testUser);
@@ -657,10 +662,14 @@ class UserServiceImplTest {
     void deleteUserByUuid_ShouldThrowForbiddenException_WhenUserIsDeactivated() {
         String uuid = "test-uuid-123";
         testUser.setStatus(UserStatus.DEACTIVATED);
+        UserDeletionReasonDto dto = UserDeletionReasonDto.builder()
+            .reason("test reason")
+            .build();
+
         when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.of(testUser));
 
         ForbiddenException exception = assertThrows(ForbiddenException.class,
-            () -> userService.deleteUserByUuid(uuid));
+            () -> userService.deleteUserByUuid(uuid, dto));
 
         assertEquals(ErrorMessage.FORBIDDEN_USER_DELETION, exception.getMessage());
         verify(userRepository, never()).save(any());
@@ -670,10 +679,14 @@ class UserServiceImplTest {
     void deleteUserByUuid_ShouldThrowForbiddenException_WhenUserIsBlocked() {
         String uuid = "test-uuid-123";
         testUser.setStatus(UserStatus.BLOCKED);
+        UserDeletionReasonDto dto = UserDeletionReasonDto.builder()
+            .reason("test reason")
+            .build();
+
         when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.of(testUser));
 
         ForbiddenException exception = assertThrows(ForbiddenException.class,
-            () -> userService.deleteUserByUuid(uuid));
+            () -> userService.deleteUserByUuid(uuid, dto));
 
         assertEquals(ErrorMessage.FORBIDDEN_USER_DELETION, exception.getMessage());
         verify(userRepository, never()).save(any());
@@ -682,10 +695,14 @@ class UserServiceImplTest {
     @Test
     void deleteUserByUuid_ShouldThrowNotFoundException_WhenUserNotExists() {
         String uuid = "non-existent-uuid";
+        UserDeletionReasonDto dto = UserDeletionReasonDto.builder()
+            .reason("test reason")
+            .build();
+
         when(userRepository.findUserByUuid(uuid)).thenReturn(Optional.empty());
 
         NotFoundException exception = assertThrows(NotFoundException.class,
-            () -> userService.deleteUserByUuid(uuid));
+            () -> userService.deleteUserByUuid(uuid, dto));
 
         assertEquals(ErrorMessage.USER_NOT_FOUND_BY_UUID + uuid, exception.getMessage());
         verify(userRepository, never()).save(any());


### PR DESCRIPTION
## Changed
- added dto with reason of deactivation user profile when user deletes his profile;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account deletion now accepts and records a user-provided reason and includes it in related notifications.
  * Delete account endpoint now requires a request body containing the deletion reason.

* **Refactor**
  * Standardized reason field naming across user status flows: deactivation/deletion DTOs use the field name "reason".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->