### PR TITLE
Bugfix #9209 added project name value to sign in the remote request

### DIFF
--- a/service-api/src/main/java/greencity/dto/TestersSignInRequest.java
+++ b/service-api/src/main/java/greencity/dto/TestersSignInRequest.java
@@ -1,4 +1,4 @@
 package greencity.dto;
 
-public record TestersSignInRequest(String email, String password, String secretKey) {
+public record TestersSignInRequest(String email, String password, String secretKey, String projectName) {
 }

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramLoginServiceImpl.java
@@ -77,7 +77,7 @@ public class TelegramLoginServiceImpl implements TelegramLoginService {
         }
 
         try {
-            var response = userRemoteClient.signIn(new TestersSignInRequest(login, password, secretToken));
+            var response = userRemoteClient.signIn(new TestersSignInRequest(login, password, secretToken, "PICKUP"));
 
             var responseBody = response.getBody();
             String name = (responseBody != null && responseBody.name() != null) ? responseBody.name() : USERNAME;


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link
[#9209](https://github.com/ita-social-projects/GreenCity/issues/9209)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal authentication handling to support project-based identification in sign-in requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->