### PR TITLE
Fix #9126 - Add updatedAt to TelegramMessageDto

### DIFF
--- a/service-api/src/main/java/greencity/dto/telegram/TelegramMessageDto.java
+++ b/service-api/src/main/java/greencity/dto/telegram/TelegramMessageDto.java
@@ -18,6 +18,8 @@ public class TelegramMessageDto {
 
     private Instant sendAt;
 
+    private Instant updatedAt;
+
     private String text;
 
     private Boolean fromManager;

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
@@ -348,6 +348,7 @@ public class TelegramServiceImpl implements TelegramService {
                 return new TelegramMessageDto(
                     message.getId(),
                     message.getSendAt(),
+                    message.getUpdatedAt(),
                     message.getText(),
                     message.getFromManager(),
                     message.getStatus(),
@@ -439,7 +440,8 @@ public class TelegramServiceImpl implements TelegramService {
             TelegramMessageDto lastMessage = TelegramMessageDto.builder()
                 .id(message.getId())
                 .text(message.getText())
-                .sendAt(!isUpdated ? message.getSendAt() : message.getUpdatedAt())
+                .sendAt(message.getSendAt())
+                .updatedAt(message.getUpdatedAt())
                 .fromManager(message.getFromManager())
                 .deliveryStatus(message.getStatus())
                 .assets(assetDtos)

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
@@ -148,13 +148,15 @@ public class TelegramServiceImpl implements TelegramService {
         SendMessage sendMessage = MessageFactory.buildMessage(chat.getChatId(), request.getText());
         Message sentMessage = executor.executeSendMessage(sendMessage);
 
+        Instant currentTime = Instant.now();
+
         TelegramMessage textMessage = TelegramMessage.builder()
             .chat(chat)
             .text(request.getText())
             .fromManager(true)
             .status(MessageDeliveryStatus.SENT)
-            .sendAt(Instant.now())
-            .updatedAt(Instant.now())
+            .sendAt(currentTime)
+            .updatedAt(currentTime)
             .messageViewingStatus(MessageViewingStatus.READ)
             .telegramMessageId(sentMessage != null ? sentMessage.getMessageId() : null)
             .build();
@@ -166,13 +168,14 @@ public class TelegramServiceImpl implements TelegramService {
 
     private void handleImageMessages(TelegramChat chat, CreateTelegramMessageRequest request,
         List<MultipartFile> images) {
+        Instant currentTime = Instant.now();
         TelegramMessage imageMessage = TelegramMessage.builder()
             .chat(chat)
             .text(request.getText())
             .fromManager(true)
             .status(MessageDeliveryStatus.SENT)
-            .sendAt(Instant.now())
-            .updatedAt(Instant.now())
+            .sendAt(currentTime)
+            .updatedAt(currentTime)
             .messageViewingStatus(MessageViewingStatus.READ)
             .build();
 
@@ -245,13 +248,14 @@ public class TelegramServiceImpl implements TelegramService {
             validateFileSize(file);
 
             String caption = images.isEmpty() ? request.getText() : null;
+            Instant currentTime = Instant.now();
             TelegramMessage fileMessage = TelegramMessage.builder()
                 .chat(chat)
                 .fromManager(true)
                 .text(caption)
                 .status(MessageDeliveryStatus.SENT)
-                .sendAt(Instant.now())
-                .updatedAt(Instant.now())
+                .sendAt(currentTime)
+                .updatedAt(currentTime)
                 .messageViewingStatus(MessageViewingStatus.READ)
                 .build();
 

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -172,14 +172,15 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
 
         String messageText = Optional.ofNullable(message.getText())
             .orElse(message.getCaption());
+        Instant currentTime = Instant.now();
 
         TelegramMessage telegramMessage = TelegramMessage.builder()
             .chat(chat)
             .fromManager(false)
             .mediaGroupId(mediaGroupId)
             .status(MessageDeliveryStatus.SENT)
-            .sendAt(Instant.now())
-            .updatedAt(Instant.now())
+            .sendAt(currentTime)
+            .updatedAt(currentTime)
             .text(messageText)
             .messageViewingStatus(MessageViewingStatus.UNREAD)
             .telegramMessageId(message.getMessageId())

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramSupportServiceImpl.java
@@ -411,6 +411,7 @@ public class TelegramSupportServiceImpl implements TelegramSupportService {
         TelegramMessageDto telegramMessageDto = TelegramMessageDto.builder()
             .id(telegramMessage.getId())
             .sendAt(telegramMessage.getSendAt())
+            .updatedAt(telegramMessage.getUpdatedAt())
             .text(telegramMessage.getText())
             .fromManager(telegramMessage.getFromManager())
             .deliveryStatus(telegramMessage.getStatus())

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
@@ -1,7 +1,6 @@
 package greencity.ubstelegrambot;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -50,7 +49,6 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -388,31 +386,28 @@ class TelegramServiceTest {
     }
 
     @Test
-    void handleDefaultUpdate_CallbackStartsWithSetLanguage_ReturnsLanguageSwitcherProcessor() throws Exception {
-        // Arrange
+    void handleDefaultUpdate_CallbackStartsWithSetLanguage_ReturnsLanguageSwitcherProcessor() {
         Update update = mock(Update.class);
         CallbackQuery callbackQuery = mock(CallbackQuery.class);
         org.telegram.telegrambots.meta.api.objects.User mocked =
             mock(org.telegram.telegrambots.meta.api.objects.User.class);
+        SendMessage expected = new SendMessage("123", "test");
 
         when(update.hasCallbackQuery()).thenReturn(true);
         when(update.getCallbackQuery()).thenReturn(callbackQuery);
         when(callbackQuery.getData()).thenReturn("set_language_en");
         when(callbackQuery.getFrom()).thenReturn(mocked);
         when(mocked.getId()).thenReturn(123L);
-
         when(telegramChatRepository.findByChatId("123")).thenReturn(Optional.of(TelegramChat.builder()
             .chatStateUpdatedAt(Instant.now())
             .build()));
+        when(updateProcessor.process(update)).thenReturn(expected);
 
-        Method method = TelegramServiceImpl.class.getDeclaredMethod("handleDefaultUpdate", Update.class);
-        method.setAccessible(true);
+        telegramService.processUpdate(update);
 
-        // Act
-        TelegramUpdateProcessor result = (TelegramUpdateProcessor) method.invoke(telegramService, update);
-
-        // Assert
-        assertEquals(updateProcessor, result);
+        verify(updateProcessor).process(update);
+        verify(executor).executeCommand(expected);
+        verifyNoMoreInteractions(executor);
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link :clipboard:
[#9126](https://github.com/ita-social-projects/GreenCity/issues/9126)
Related to PR [#1844](https://github.com/ita-social-projects/GreenCityUBS/pull/1844)

## Summary Of Changes :fire:
* Added `updatedAt` field to `TelegramMessageDto`.
* Refactored TelegramServiceTest to stop relying on reflection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit message "updated at" timestamp across Telegram messages and APIs, and exposed it alongside the send timestamp so clients see both.

* **Bug Fixes / Improvements**
  * Ensured send and updated timestamps are produced consistently (single timestamp per message event).

* **Tests**
  * Updated tests to reflect and validate the new timestamp behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->