### PR TITLE
Update /bot_responses endpoint to include id and lang fields

### DIFF
--- a/dao/src/main/java/greencity/entity/telegram/BotResponseProjection.java
+++ b/dao/src/main/java/greencity/entity/telegram/BotResponseProjection.java
@@ -1,9 +1,11 @@
 package greencity.entity.telegram;
 
 public interface BotResponseProjection {
+    Long getId();
+
     String getMessageType();
 
-    String getMessageUk();
+    String getLang();
 
-    String getMessageEn();
+    String getText();
 }

--- a/dao/src/main/java/greencity/repository/TelegramBotMessageRepository.java
+++ b/dao/src/main/java/greencity/repository/TelegramBotMessageRepository.java
@@ -16,14 +16,14 @@ public interface TelegramBotMessageRepository extends JpaRepository<BotMessage, 
 
     @Query(value = """
         SELECT
+            t.id AS id,
             t.message_type AS messageType,
-            MAX(CASE WHEN t.lang = 'uk' THEN t.text END) AS messageUk,
-            MAX(CASE WHEN t.lang = 'en' THEN t.text END) AS messageEn
+            t.lang AS lang,
+            t.text AS text
         FROM bot_messages t
-        GROUP BY t.message_type
-        ORDER BY t.message_type
+        ORDER BY t.message_type, t.lang
         """,
-        countQuery = "SELECT COUNT(DISTINCT message_type) FROM bot_messages",
+        countQuery = "SELECT COUNT(*) FROM bot_messages",
         nativeQuery = true)
-    Page<BotResponseProjection> findAllPivot(Pageable pageable);
+    Page<BotResponseProjection> findAllWithLang(Pageable pageable);
 }

--- a/service-api/src/main/java/greencity/dto/telegram/BotResponse.java
+++ b/service-api/src/main/java/greencity/dto/telegram/BotResponse.java
@@ -10,7 +10,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class BotResponse {
+    private Long id;
     private String messageType;
-    private String messageUk;
-    private String messageEn;
+    private String lang;
+    private String text;
 }

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramBotResponseServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramBotResponseServiceImpl.java
@@ -28,12 +28,14 @@ public class TelegramBotResponseServiceImpl implements TelegramBotResponseServic
      */
     @Override
     public PageableDto<BotResponse> getAllBotResponses(Pageable pageable) {
-        Page<BotResponseProjection> botMessages = telegramBotMessageRepository.findAllPivot(pageable);
+        Page<BotResponseProjection> botMessages = telegramBotMessageRepository.findAllWithLang(pageable);
+
         List<BotResponse> responses = botMessages.stream()
             .map(e -> BotResponse.builder()
+                .id(e.getId())
                 .messageType(e.getMessageType())
-                .messageUk(e.getMessageUk())
-                .messageEn(e.getMessageEn())
+                .lang(e.getLang())
+                .text(e.getText())
                 .build())
             .toList();
 

--- a/service/src/test/java/greencity/ubstelegrambot/service/TelegramBotResponseServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/service/TelegramBotResponseServiceTest.java
@@ -46,7 +46,7 @@ class TelegramBotResponseServiceTest {
             pageable,
             2);
 
-        when(telegramBotMessageRepository.findAllPivot(pageable)).thenReturn(page);
+        when(telegramBotMessageRepository.findAllWithLang(pageable)).thenReturn(page);
 
         PageableDto<BotResponse> result = telegramBotResponseServiceImpl.getAllBotResponses(pageable);
 
@@ -61,7 +61,7 @@ class TelegramBotResponseServiceTest {
         Pageable pageable = PageRequest.of(0, 2);
         Page<BotResponseProjection> emptyPage = Page.empty(pageable);
 
-        when(telegramBotMessageRepository.findAllPivot(pageable)).thenReturn(emptyPage);
+        when(telegramBotMessageRepository.findAllWithLang(pageable)).thenReturn(emptyPage);
 
         PageableDto<BotResponse> result = telegramBotResponseServiceImpl.getAllBotResponses(pageable);
 


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋

## Changed
- Added id and lang to BotResponseProjection and BotResponse for frontend editing support; 
- Updated SQL query in TelegramBotMessageRepository;
- Removed grouping by message type to return individual language entries;
- Fix tests in TelegramBotResponseServiceTest class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Telegram bot response data structure with improved field organization
  * Restructured response fields for clearer data representation
  * Added unique identifier to bot responses
  * Renamed query method for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->