### PR TITLE
Feature #9045 - Unread notifications in header

### DIFF
--- a/core/src/main/java/greencity/controller/WebSocketController.java
+++ b/core/src/main/java/greencity/controller/WebSocketController.java
@@ -16,14 +16,16 @@ public class WebSocketController {
     /**
      * Handles client subscriptions to the "/app/unread" destination.
      *
-     * <p>When a client subscribes, this method triggers the notifier service to
+     * <p>
+     * When a client subscribes, this method triggers the notifier service to
      * calculate and broadcast the current unread message count to all subscribers
      * via the WebSocket message broker.
+     * </p>
      */
     @AsyncListener(
-            operation = @AsyncOperation(
-                    channelName = "/app/unread",
-                    description = "Subscription endpoint that triggers initial unread message count broadcast"))
+        operation = @AsyncOperation(
+            channelName = "/app/unread",
+            description = "Subscription endpoint that triggers initial unread message count broadcast"))
     @StompAsyncOperationBinding
     @SubscribeMapping("/unread")
     public void onSubscribe() {

--- a/core/src/main/java/greencity/controller/WebSocketController.java
+++ b/core/src/main/java/greencity/controller/WebSocketController.java
@@ -1,0 +1,32 @@
+package greencity.controller;
+
+import greencity.service.ubs.TelegramUnreadCountNotifier;
+import io.github.springwolf.bindings.stomp.annotations.StompAsyncOperationBinding;
+import io.github.springwolf.core.asyncapi.annotations.AsyncListener;
+import io.github.springwolf.core.asyncapi.annotations.AsyncOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.annotation.SubscribeMapping;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class WebSocketController {
+    private final TelegramUnreadCountNotifier telegramUnreadCountNotifier;
+
+    /**
+     * Handles client subscriptions to the "/app/unread" destination.
+     *
+     * <p>When a client subscribes, this method triggers the notifier service to
+     * calculate and broadcast the current unread message count to all subscribers
+     * via the WebSocket message broker.
+     */
+    @AsyncListener(
+            operation = @AsyncOperation(
+                    channelName = "/app/unread",
+                    description = "Subscription endpoint that triggers initial unread message count broadcast"))
+    @StompAsyncOperationBinding
+    @SubscribeMapping("/unread")
+    public void onSubscribe() {
+        telegramUnreadCountNotifier.notifyUnreadCount();
+    }
+}

--- a/core/src/test/java/greencity/controller/WebSocketControllerTest.java
+++ b/core/src/test/java/greencity/controller/WebSocketControllerTest.java
@@ -1,0 +1,26 @@
+package greencity.controller;
+
+import static org.mockito.Mockito.verify;
+import greencity.service.ubs.TelegramUnreadCountNotifier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WebSocketControllerTest {
+
+    @Mock
+    private TelegramUnreadCountNotifier telegramUnreadCountNotifier;
+
+    @InjectMocks
+    private WebSocketController controller;
+
+    @Test
+    void onSubscribe_invokesNotifier() {
+        controller.onSubscribe();
+
+        verify(telegramUnreadCountNotifier).notifyUnreadCount();
+    }
+}

--- a/dao/src/main/java/greencity/repository/TelegramMessageRepository.java
+++ b/dao/src/main/java/greencity/repository/TelegramMessageRepository.java
@@ -2,6 +2,7 @@ package greencity.repository;
 
 import greencity.entity.telegram.TelegramChat;
 import greencity.entity.telegram.TelegramMessage;
+import greencity.enums.MessageViewingStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -49,4 +50,15 @@ public interface TelegramMessageRepository extends JpaRepository<TelegramMessage
      *         this chat, otherwise empty
      */
     Optional<TelegramMessage> findByChatAndTelegramMessageId(TelegramChat telegramChat, Integer messageId);
+
+    /**
+     * Returns the number of {@link TelegramMessage} entities that have the
+     * specified {@link MessageViewingStatus}.
+     *
+     * @param messageViewingStatus the status to filter by (e.g.
+     *                             {@link MessageViewingStatus#UNREAD})
+     * @return the number of messages with the given status (returns {@code 0} if
+     *         none match)
+     */
+    Long countByMessageViewingStatus(MessageViewingStatus messageViewingStatus);
 }

--- a/service-api/src/main/java/greencity/dto/telegram/UnreadMessagesDto.java
+++ b/service-api/src/main/java/greencity/dto/telegram/UnreadMessagesDto.java
@@ -1,0 +1,14 @@
+package greencity.dto.telegram;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UnreadMessagesDto {
+    Long unreadMessagesCount;
+}

--- a/service-api/src/main/java/greencity/service/ubs/TelegramUnreadCountNotifier.java
+++ b/service-api/src/main/java/greencity/service/ubs/TelegramUnreadCountNotifier.java
@@ -1,0 +1,11 @@
+package greencity.service.ubs;
+
+import greencity.enums.MessageViewingStatus;
+
+public interface TelegramUnreadCountNotifier {
+    /**
+     * Counts messages with {@link MessageViewingStatus#UNREAD} and publishes the
+     * total.
+     */
+    void notifyUnreadCount();
+}

--- a/service/src/main/java/greencity/producers/TelegramChatProducer.java
+++ b/service/src/main/java/greencity/producers/TelegramChatProducer.java
@@ -50,7 +50,21 @@ public class TelegramChatProducer {
         messagingTemplate.convertAndSend("/topic/chats", chatDto);
     }
 
-    public void notifyUnreadMessages(UnreadMessagesDto unreadMessagesDto) {
+    /**
+     * Sends a notification about the count of unread messages for users.
+     * <p>
+     * This event is published to clients subscribed to the <b>/topic/unread</b> destination.
+     * It can be used to update the unread message counters in the user interface.
+     * </p>
+     *
+     * @param unreadMessagesDto the DTO containing unread message counts for users, must not be {@code null}
+     */
+    @AsyncPublisher(
+            operation = @AsyncOperation(
+                    channelName = "/topic/unread",
+                    description = "Subscription for unread message count updates"))
+    @StompAsyncOperationBinding
+    public void notifyUnreadMessages(@Payload UnreadMessagesDto unreadMessagesDto) {
         messagingTemplate.convertAndSend("/topic/unread", unreadMessagesDto);
     }
 }

--- a/service/src/main/java/greencity/producers/TelegramChatProducer.java
+++ b/service/src/main/java/greencity/producers/TelegramChatProducer.java
@@ -53,16 +53,18 @@ public class TelegramChatProducer {
     /**
      * Sends a notification about the count of unread messages for users.
      * <p>
-     * This event is published to clients subscribed to the <b>/topic/unread</b> destination.
-     * It can be used to update the unread message counters in the user interface.
+     * This event is published to clients subscribed to the <b>/topic/unread</b>
+     * destination. It can be used to update the unread message counters in the user
+     * interface.
      * </p>
      *
-     * @param unreadMessagesDto the DTO containing unread message counts for users, must not be {@code null}
+     * @param unreadMessagesDto the DTO containing unread message counts for users,
+     *                          must not be {@code null}
      */
     @AsyncPublisher(
-            operation = @AsyncOperation(
-                    channelName = "/topic/unread",
-                    description = "Subscription for unread message count updates"))
+        operation = @AsyncOperation(
+            channelName = "/topic/unread",
+            description = "Subscription for unread message count updates"))
     @StompAsyncOperationBinding
     public void notifyUnreadMessages(@Payload UnreadMessagesDto unreadMessagesDto) {
         messagingTemplate.convertAndSend("/topic/unread", unreadMessagesDto);

--- a/service/src/main/java/greencity/producers/TelegramChatProducer.java
+++ b/service/src/main/java/greencity/producers/TelegramChatProducer.java
@@ -2,6 +2,7 @@ package greencity.producers;
 
 import greencity.dto.telegram.TelegramMessageDto;
 import greencity.dto.telegram.ChatDto;
+import greencity.dto.telegram.UnreadMessagesDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -47,5 +48,9 @@ public class TelegramChatProducer {
     public void notifyNewChat(ChatDto chatDto) {
         log.debug("Publish to /topic/chats");
         messagingTemplate.convertAndSend("/topic/chats", chatDto);
+    }
+
+    public void notifyUnreadMessages(UnreadMessagesDto unreadMessagesDto) {
+        messagingTemplate.convertAndSend("/topic/unread", unreadMessagesDto);
     }
 }

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramMessageStatusHandler.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramMessageStatusHandler.java
@@ -1,0 +1,36 @@
+package greencity.ubstelegrambot.service;
+
+import greencity.dto.telegram.MarkMessagesAsReadRequestDto;
+import greencity.entity.telegram.TelegramChat;
+import greencity.entity.telegram.TelegramMessage;
+import greencity.enums.MessageViewingStatus;
+import greencity.repository.TelegramMessageRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class TelegramMessageStatusHandler {
+    private final TelegramMessageRepository telegramMessageRepository;
+
+    @Transactional
+    public void markMessagesAsRead(MarkMessagesAsReadRequestDto request) {
+        List<TelegramMessage> messages = telegramMessageRepository.findAllById(request.getMessagesIds());
+
+        for (TelegramMessage message : messages) {
+            if (message.getMessageViewingStatus() == MessageViewingStatus.UNREAD) {
+                message.setMessageViewingStatus(MessageViewingStatus.READ);
+
+                TelegramChat chat = message.getChat();
+                int currentUnread = chat.getUnreadMessagesCount();
+                if (currentUnread > 0) {
+                    chat.setUnreadMessagesCount(currentUnread - 1);
+                }
+            }
+        }
+
+        telegramMessageRepository.saveAll(messages);
+    }
+}

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramServiceImpl.java
@@ -40,6 +40,7 @@ import greencity.repository.TelegramManagerRepository;
 import greencity.repository.TelegramMessageRepository;
 import greencity.repository.UserRepository;
 import greencity.service.ubs.TelegramService;
+import greencity.service.ubs.TelegramUnreadCountNotifier;
 import greencity.service.ubs.TelegramUpdateProcessor;
 import greencity.service.ubs.order.OrderService;
 import greencity.specification.ChatSpecifications;
@@ -92,6 +93,8 @@ public class TelegramServiceImpl implements TelegramService {
     private final TelegramChatProducer telegramChatProducer;
     private final TelegramUtils telegramUtils;
     private final MessageAssetRepository messageAssetRepository;
+    private final TelegramMessageStatusHandler telegramMessageStatusHandler;
+    private final TelegramUnreadCountNotifier telegramUnreadCountNotifier;
     private final Map<String, TelegramUpdateProcessor> telegramUpdateProcessorMap;
 
     /**
@@ -508,23 +511,10 @@ public class TelegramServiceImpl implements TelegramService {
      * {@inheritDoc}
      */
     @Override
-    @Transactional
     public void markMessagesAsRead(MarkMessagesAsReadRequestDto request) {
-        List<TelegramMessage> messages = telegramMessageRepository.findAllById(request.getMessagesIds());
+        telegramMessageStatusHandler.markMessagesAsRead(request);
 
-        for (TelegramMessage message : messages) {
-            if (message.getMessageViewingStatus() == MessageViewingStatus.UNREAD) {
-                message.setMessageViewingStatus(MessageViewingStatus.READ);
-
-                TelegramChat chat = message.getChat();
-                int currentUnread = chat.getUnreadMessagesCount();
-                if (currentUnread > 0) {
-                    chat.setUnreadMessagesCount(currentUnread - 1);
-                }
-            }
-        }
-
-        telegramMessageRepository.saveAll(messages);
+        telegramUnreadCountNotifier.notifyUnreadCount();
     }
 
     /**
@@ -588,6 +578,8 @@ public class TelegramServiceImpl implements TelegramService {
         if (sendMessage != null) {
             executor.executeCommand(sendMessage);
         }
+
+        telegramUnreadCountNotifier.notifyUnreadCount();
     }
 
     @Override

--- a/service/src/main/java/greencity/ubstelegrambot/service/TelegramUnreadCountNotifierImpl.java
+++ b/service/src/main/java/greencity/ubstelegrambot/service/TelegramUnreadCountNotifierImpl.java
@@ -1,0 +1,27 @@
+package greencity.ubstelegrambot.service;
+
+import greencity.dto.telegram.UnreadMessagesDto;
+import greencity.enums.MessageViewingStatus;
+import greencity.producers.TelegramChatProducer;
+import greencity.repository.TelegramMessageRepository;
+import greencity.service.ubs.TelegramUnreadCountNotifier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TelegramUnreadCountNotifierImpl implements TelegramUnreadCountNotifier {
+    private final TelegramMessageRepository telegramMessageRepository;
+    private final TelegramChatProducer telegramChatProducer;
+
+    @Override
+    public void notifyUnreadCount() {
+        Long unreadCount = telegramMessageRepository.countByMessageViewingStatus(MessageViewingStatus.UNREAD);
+
+        UnreadMessagesDto unreadMessagesDto = UnreadMessagesDto.builder()
+            .unreadMessagesCount(unreadCount)
+            .build();
+
+        telegramChatProducer.notifyUnreadMessages(unreadMessagesDto);
+    }
+}

--- a/service/src/test/java/greencity/producers/TelegramChatProducerTest.java
+++ b/service/src/test/java/greencity/producers/TelegramChatProducerTest.java
@@ -1,14 +1,15 @@
 package greencity.producers;
 
+import static org.mockito.Mockito.verify;
 import greencity.dto.telegram.ChatDto;
 import greencity.dto.telegram.TelegramMessageDto;
+import greencity.dto.telegram.UnreadMessagesDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class TelegramChatProducerTest {
@@ -35,6 +36,15 @@ class TelegramChatProducerTest {
         telegramChatProducer.notifyNewChat(chatDto);
 
         verify(messagingTemplate).convertAndSend("/topic/chats", chatDto);
+    }
+
+    @Test
+    void testNotifyUnreadMessages_CorrectDestination_MessageSent() {
+        UnreadMessagesDto unreadMessagesDto = new UnreadMessagesDto();
+
+        telegramChatProducer.notifyUnreadMessages(unreadMessagesDto);
+
+        verify(messagingTemplate).convertAndSend("/topic/unread", unreadMessagesDto);
     }
 
 }

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramMessageStatusHandlerTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramMessageStatusHandlerTest.java
@@ -1,5 +1,8 @@
 package greencity.ubstelegrambot;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import greencity.dto.telegram.MarkMessagesAsReadRequestDto;
 import greencity.entity.telegram.TelegramChat;
 import greencity.entity.telegram.TelegramMessage;
@@ -11,11 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.util.List;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class TelegramMessageStatusHandlerTest {

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramMessageStatusHandlerTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramMessageStatusHandlerTest.java
@@ -1,0 +1,68 @@
+package greencity.ubstelegrambot;
+
+import greencity.dto.telegram.MarkMessagesAsReadRequestDto;
+import greencity.entity.telegram.TelegramChat;
+import greencity.entity.telegram.TelegramMessage;
+import greencity.enums.MessageViewingStatus;
+import greencity.repository.TelegramMessageRepository;
+import greencity.ubstelegrambot.service.TelegramMessageStatusHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TelegramMessageStatusHandlerTest {
+    @Mock
+    private TelegramMessageRepository telegramMessageRepository;
+    @InjectMocks
+    private TelegramMessageStatusHandler telegramMessageStatusHandler;
+
+    @Test
+    void testMarkMessagesAsRead_IdsSpecified_MessagesMarkedAsRead() {
+        List<Long> messageIds = List.of(1L, 2L);
+
+        TelegramChat chat1 = TelegramChat.builder()
+            .id(10L)
+            .unreadMessagesCount(1)
+            .build();
+
+        TelegramChat chat2 = TelegramChat.builder()
+            .id(20L)
+            .unreadMessagesCount(0)
+            .build();
+
+        TelegramMessage message1 = TelegramMessage.builder()
+            .id(1L)
+            .messageViewingStatus(MessageViewingStatus.UNREAD)
+            .chat(chat1)
+            .build();
+
+        TelegramMessage message2 = TelegramMessage.builder()
+            .id(2L)
+            .messageViewingStatus(MessageViewingStatus.READ)
+            .chat(chat2)
+            .build();
+
+        when(telegramMessageRepository.findAllById(messageIds))
+            .thenReturn(List.of(message1, message2));
+
+        telegramMessageStatusHandler.markMessagesAsRead(
+            MarkMessagesAsReadRequestDto.builder().messagesIds(messageIds).build());
+
+        verify(telegramMessageRepository).findAllById(messageIds);
+        verify(telegramMessageRepository).saveAll(List.of(message1, message2));
+
+        assertEquals(MessageViewingStatus.READ, message1.getMessageViewingStatus());
+        assertEquals(MessageViewingStatus.READ, message2.getMessageViewingStatus());
+
+        assertEquals(0, chat1.getUnreadMessagesCount());
+        assertEquals(0, chat2.getUnreadMessagesCount());
+    }
+}

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramServiceTest.java
@@ -27,7 +27,6 @@ import greencity.entity.user.User;
 import greencity.entity.user.employee.Employee;
 import greencity.enums.AssetType;
 import greencity.enums.MessageDeliveryStatus;
-import greencity.enums.MessageViewingStatus;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.bots.TelegramBotExecutionException;
 import greencity.exceptions.bots.UnsupportedTelegramAssetException;
@@ -39,10 +38,12 @@ import greencity.repository.TelegramChatRepository;
 import greencity.repository.TelegramManagerRepository;
 import greencity.repository.TelegramMessageRepository;
 import greencity.repository.UserRepository;
+import greencity.service.ubs.TelegramUnreadCountNotifier;
 import greencity.service.ubs.TelegramUpdateProcessor;
 import greencity.service.ubs.order.OrderService;
 import greencity.ubstelegrambot.messages.MessageFactory;
 import greencity.ubstelegrambot.service.TelegramExecutor;
+import greencity.ubstelegrambot.service.TelegramMessageStatusHandler;
 import greencity.ubstelegrambot.service.TelegramServiceImpl;
 import greencity.ubstelegrambot.service.TelegramUtils;
 import java.awt.image.BufferedImage;
@@ -132,6 +133,12 @@ class TelegramServiceTest {
     @Mock
     private TelegramUpdateProcessor updateProcessor;
 
+    @Mock
+    private TelegramMessageStatusHandler telegramMessageStatusHandler;
+
+    @Mock
+    private TelegramUnreadCountNotifier telegramUnreadCountNotifier;
+
     private TelegramServiceImpl telegramService;
 
     public Map<String, TelegramUpdateProcessor> telegramUpdateProcessorMap;
@@ -156,6 +163,8 @@ class TelegramServiceTest {
             telegramChatProducer,
             telegramUtils,
             messageAssetRepository,
+            telegramMessageStatusHandler,
+            telegramUnreadCountNotifier,
             telegramUpdateProcessorMap);
     }
 
@@ -1449,43 +1458,17 @@ class TelegramServiceTest {
     @Test
     void testMarkMessagesAsRead_IdsSpecified_MessagesMarkedAsRead() {
         List<Long> messageIds = List.of(1L, 2L);
-
-        TelegramChat chat1 = TelegramChat.builder()
-            .id(10L)
-            .unreadMessagesCount(1)
+        MarkMessagesAsReadRequestDto requestDto = MarkMessagesAsReadRequestDto.builder()
+            .messagesIds(messageIds)
             .build();
 
-        TelegramChat chat2 = TelegramChat.builder()
-            .id(20L)
-            .unreadMessagesCount(0)
-            .build();
+        doNothing().when(telegramMessageStatusHandler).markMessagesAsRead(requestDto);
+        doNothing().when(telegramUnreadCountNotifier).notifyUnreadCount();
 
-        TelegramMessage message1 = TelegramMessage.builder()
-            .id(1L)
-            .messageViewingStatus(MessageViewingStatus.UNREAD)
-            .chat(chat1)
-            .build();
+        telegramService.markMessagesAsRead(requestDto);
 
-        TelegramMessage message2 = TelegramMessage.builder()
-            .id(2L)
-            .messageViewingStatus(MessageViewingStatus.READ)
-            .chat(chat2)
-            .build();
-
-        when(telegramMessageRepository.findAllById(messageIds))
-            .thenReturn(List.of(message1, message2));
-
-        telegramService.markMessagesAsRead(
-            MarkMessagesAsReadRequestDto.builder().messagesIds(messageIds).build());
-
-        verify(telegramMessageRepository).findAllById(messageIds);
-        verify(telegramMessageRepository).saveAll(List.of(message1, message2));
-
-        assertEquals(MessageViewingStatus.READ, message1.getMessageViewingStatus());
-        assertEquals(MessageViewingStatus.READ, message2.getMessageViewingStatus());
-
-        assertEquals(0, chat1.getUnreadMessagesCount());
-        assertEquals(0, chat2.getUnreadMessagesCount());
+        verify(telegramMessageStatusHandler).markMessagesAsRead(requestDto);
+        verify(telegramUnreadCountNotifier).notifyUnreadCount();
     }
 
     @Test

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramUnreadCountNotifierTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramUnreadCountNotifierTest.java
@@ -1,0 +1,37 @@
+package greencity.ubstelegrambot;
+
+import greencity.enums.MessageViewingStatus;
+import greencity.producers.TelegramChatProducer;
+import greencity.repository.TelegramMessageRepository;
+import greencity.ubstelegrambot.service.TelegramUnreadCountNotifierImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TelegramUnreadCountNotifierTest {
+    @Mock
+    private TelegramMessageRepository telegramMessageRepository;
+    @Mock
+    private TelegramChatProducer telegramChatProducer;
+    @InjectMocks
+    private TelegramUnreadCountNotifierImpl telegramUnreadCountNotifier;
+
+    @Test
+    void testNotifyUnreadCount() {
+        when(telegramMessageRepository.countByMessageViewingStatus(MessageViewingStatus.UNREAD)).thenReturn(2L);
+        doNothing().when(telegramChatProducer).notifyUnreadMessages(any());
+
+        telegramUnreadCountNotifier.notifyUnreadCount();
+
+        verify(telegramChatProducer).notifyUnreadMessages(any());
+
+    }
+}

--- a/service/src/test/java/greencity/ubstelegrambot/TelegramUnreadCountNotifierTest.java
+++ b/service/src/test/java/greencity/ubstelegrambot/TelegramUnreadCountNotifierTest.java
@@ -1,5 +1,9 @@
 package greencity.ubstelegrambot;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import greencity.enums.MessageViewingStatus;
 import greencity.producers.TelegramChatProducer;
 import greencity.repository.TelegramMessageRepository;
@@ -9,11 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class TelegramUnreadCountNotifierTest {


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link :clipboard:
[#9045](https://github.com/ita-social-projects/GreenCity/issues/9045)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time unread-message count broadcasting to clients (subscription and topic publishing)
  * Flow to mark messages as read that updates message statuses and chat unread counts, with delegated handling
  * Automatic unread-count notification triggered after relevant operations

* **Tests**
  * Unit tests for message-status handling, unread-count notifier, WebSocket subscription, and producer notification delivery
<!-- end of auto-generated comment: release notes by coderabbit.ai -->