### PR TITLE
Bugfix #1797 modified telegram notifications endpoints for access with a USER role

### DIFF
--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -297,8 +297,7 @@ public class SecurityConfig {
                     UBS_LINK + "/personal-data",
                     UBS_LINK + "/details-for-existing-order/{orderId}",
                     UBS_LINK + "/orders/{id}/tariff",
-                    TELEGRAM_LINK + "/notifications"
-                )
+                    TELEGRAM_LINK + "/notifications")
                 .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.GET,
                     TELEGRAM_LINK + "/**",

--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -254,6 +254,7 @@ public class SecurityConfig {
                     "/notifications/updateTemplateForSITE")
                 .hasAnyRole(ADMIN)
                 .requestMatchers(HttpMethod.PUT,
+                    TELEGRAM_LINK + "/notifications",
                     UBS_LINK + "/update-recipients-data")
                 .hasAnyRole(ADMIN, UBS_EMPLOYEE, USER)
                 .requestMatchers(HttpMethod.HEAD,
@@ -295,7 +296,9 @@ public class SecurityConfig {
                     UBS_LINK + "/order-details-for-tariff",
                     UBS_LINK + "/personal-data",
                     UBS_LINK + "/details-for-existing-order/{orderId}",
-                    UBS_LINK + "/orders/{id}/tariff")
+                    UBS_LINK + "/orders/{id}/tariff",
+                    TELEGRAM_LINK + "/notifications"
+                )
                 .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.GET,
                     TELEGRAM_LINK + "/**",

--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -27,22 +27,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import java.util.Arrays;
 import java.util.List;
-import static greencity.constant.AppConstant.ADMIN;
-import static greencity.constant.AppConstant.ADMIN_EMPL_LINK;
-import static greencity.constant.AppConstant.ADMIN_LINK;
-import static greencity.constant.AppConstant.COMMIT_INFO;
-import static greencity.constant.AppConstant.EXPORT_SETTINGS_LINKS;
-import static greencity.constant.AppConstant.LOGS_LINKS;
-import static greencity.constant.AppConstant.SUPER_ADMIN_LINK;
-import static greencity.constant.AppConstant.TELEGRAM_LINK;
-import static greencity.constant.AppConstant.UBS_CLIENT_LINK;
-import static greencity.constant.AppConstant.UBS_EMPLOYEE;
-import static greencity.constant.AppConstant.UBS_EXPORT;
-import static greencity.constant.AppConstant.UBS_LINK;
-import static greencity.constant.AppConstant.UBS_LINK_USERPROFILE;
-import static greencity.constant.AppConstant.UBS_MANAG_LINK;
-import static greencity.constant.AppConstant.USER;
-import static greencity.constant.AppConstant.USER_AGREEMENT_LINK;
+import static greencity.constant.AppConstant.*;
 import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
@@ -254,7 +239,7 @@ public class SecurityConfig {
                     "/notifications/updateTemplateForSITE")
                 .hasAnyRole(ADMIN)
                 .requestMatchers(HttpMethod.PUT,
-                    TELEGRAM_LINK + "/notifications",
+                    TELEGRAM_LINK + NOTIFICATIONS_LINK,
                     UBS_LINK + "/update-recipients-data")
                 .hasAnyRole(ADMIN, UBS_EMPLOYEE, USER)
                 .requestMatchers(HttpMethod.HEAD,
@@ -297,7 +282,7 @@ public class SecurityConfig {
                     UBS_LINK + "/personal-data",
                     UBS_LINK + "/details-for-existing-order/{orderId}",
                     UBS_LINK + "/orders/{id}/tariff",
-                    TELEGRAM_LINK + "/notifications")
+                    TELEGRAM_LINK + NOTIFICATIONS_LINK)
                 .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.GET,
                     TELEGRAM_LINK + "/**",

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -94,7 +94,6 @@ hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=20000
 ribbon.ConnectTimeout=20000
 ribbon.ReadTimeout=20000
 
-
 greencity.authorization.googleApiKey=${GOOGLE_API_KEY}
 
 # Swagger configuration

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -89,7 +89,7 @@ feign.hystrix.enabled=true
 hystrix.command.default.execution.isolation.strategy=SEMAPHORE
 hystrix.shareSecurityContext=true
 
-# change default hystrix timeout to 10 seconds
+# change a default hystrix timeout to 10 seconds
 hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=20000
 ribbon.ConnectTimeout=20000
 ribbon.ReadTimeout=20000

--- a/service-api/src/main/java/greencity/constant/AppConstant.java
+++ b/service-api/src/main/java/greencity/constant/AppConstant.java
@@ -17,6 +17,7 @@ public class AppConstant {
     public static final String UBS_MANAG_LINK = "/ubs/management";
     public static final String UBS_CLIENT_LINK = "/ubs/client";
     public static final String ADMIN_LINK = "/admin";
+    public static final String NOTIFICATIONS_LINK = "/notifications";
     public static final String ADMIN_EMPL_LINK = "/admin/ubs-employee";
     public static final String SUPER_ADMIN_LINK = "/ubs/superAdmin";
     public static final String USER_AGREEMENT_LINK = "/user-agreement";


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Links 📋
- <a href="https://github.com/ita-social-projects/GreenCityUBS/issues/1797">#1797</a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telegram notifications are now available to authorized users. Access to view and manage notifications is restricted to users with ADMIN, UBS_EMPLOYEE, or USER roles; notification endpoints have been aligned with existing order-related access rules so authorized users can send, update, or view notifications where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->