### PR TITLE
Fix/9281 Giving employee access only to their own tariffs

### DIFF
--- a/core/src/main/java/greencity/controller/ManagementEmployeeController.java
+++ b/core/src/main/java/greencity/controller/ManagementEmployeeController.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Positive;
+import java.security.Principal;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -298,8 +299,8 @@ public class ManagementEmployeeController {
     })
     @PreAuthorize("@preAuthorizer.hasAuthority('SEE_TARIFFS', authentication)")
     @GetMapping("/getTariffs")
-    public ResponseEntity<List<GetTariffInfoForEmployeeDto>> getTariffInfoForEmployee() {
-        return ResponseEntity.status(HttpStatus.OK).body(employeeService.getTariffsForEmployee());
+    public ResponseEntity<List<GetTariffInfoForEmployeeDto>> getTariffInfoForEmployee(Principal principal) {
+        return ResponseEntity.status(HttpStatus.OK).body(employeeService.getTariffsForEmployee(principal.getName()));
     }
 
     /**

--- a/core/src/test/java/greencity/controller/ManagementEmployeeControllerTest.java
+++ b/core/src/test/java/greencity/controller/ManagementEmployeeControllerTest.java
@@ -254,9 +254,12 @@ class ManagementEmployeeControllerTest {
 
     @Test
     void getTariffInfoForEmployeeTest() throws Exception {
+        Principal mockPrincipal = mock(Principal.class);
+        when(mockPrincipal.getName()).thenReturn("testmail@gmail.com");
+
         mockMvc.perform(get(UBS_LINK + GET_ALL_TARIFFS)
-            .principal(principal)).andExpect(status().isOk());
-        verify(service, times(1)).getTariffsForEmployee();
+            .principal(mockPrincipal)).andExpect(status().isOk());
+        verify(service, times(1)).getTariffsForEmployee(mockPrincipal.getName());
     }
 
     @Test

--- a/dao/src/main/java/greencity/repository/TariffsInfoRepository.java
+++ b/dao/src/main/java/greencity/repository/TariffsInfoRepository.java
@@ -208,4 +208,7 @@ public interface TariffsInfoRepository extends JpaRepository<TariffsInfo, Long>,
 
     @Query("SELECT t FROM TariffsInfo t WHERE t.tariffStatus = 'ACTIVE'")
     List<TariffsInfo> findAllActiveTariffsInfo();
+
+    @Query("SELECT t.tariffsInfo FROM TariffsInfoRecievingEmployee t WHERE t.employee.id = :employeeId")
+    List<TariffsInfo> findByEmployeeId(@Param("employeeId") Long employeeId);
 }

--- a/service-api/src/main/java/greencity/service/ubs/UBSManagementEmployeeService.java
+++ b/service-api/src/main/java/greencity/service/ubs/UBSManagementEmployeeService.java
@@ -98,7 +98,7 @@ public interface UBSManagementEmployeeService {
      * @return list of GetTariffInfoForEmployeeDto.
      * @author Nikita Korzh.
      */
-    List<GetTariffInfoForEmployeeDto> getTariffsForEmployee();
+    List<GetTariffInfoForEmployeeDto> getTariffsForEmployee(String email);
 
     /**
      * Method to get a list of employees associated with a specific tariff.

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -38,7 +38,6 @@ import greencity.repository.TariffsInfoRepository;
 import greencity.repository.EmployeeOrderPositionRepository;
 import greencity.service.phone.UAPhoneNumberUtil;
 import greencity.service.ubs.user.UserService;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
@@ -449,7 +448,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
     @Override
     public List<GetTariffInfoForEmployeeDto> getTariffsForEmployee(String email) {
         Employee employee = employeeRepository.findByEmail(email)
-            .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.EMPLOYEE_NOT_FOUND_BY_EMAIL + email));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.EMPLOYEE_NOT_FOUND_BY_EMAIL + email));
 
         List<TariffsInfo> tariffs = tariffsInfoRepository.findByEmployeeId(employee.getId());
         return tariffs

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -38,6 +38,7 @@ import greencity.repository.TariffsInfoRepository;
 import greencity.repository.EmployeeOrderPositionRepository;
 import greencity.service.phone.UAPhoneNumberUtil;
 import greencity.service.ubs.user.UserService;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
@@ -446,8 +447,11 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
      * {@inheritDoc}
      */
     @Override
-    public List<GetTariffInfoForEmployeeDto> getTariffsForEmployee() {
-        List<TariffsInfo> tariffs = tariffsInfoRepository.findAll();
+    public List<GetTariffInfoForEmployeeDto> getTariffsForEmployee(String email) {
+        Employee employee = employeeRepository.findByEmail(email)
+             .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.EMPLOYEE_NOT_FOUND_BY_EMAIL + email));
+
+        List<TariffsInfo> tariffs = tariffsInfoRepository.findByEmployeeId(employee.getId());
         return tariffs
             .stream()
             .map(tariffsInfo -> modelMapper.map(tariffsInfo, GetTariffInfoForEmployeeDto.class))

--- a/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/UBSManagementEmployeeServiceImpl.java
@@ -449,7 +449,7 @@ public class UBSManagementEmployeeServiceImpl implements UBSManagementEmployeeSe
     @Override
     public List<GetTariffInfoForEmployeeDto> getTariffsForEmployee(String email) {
         Employee employee = employeeRepository.findByEmail(email)
-             .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.EMPLOYEE_NOT_FOUND_BY_EMAIL + email));
+            .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.EMPLOYEE_NOT_FOUND_BY_EMAIL + email));
 
         List<TariffsInfo> tariffs = tariffsInfoRepository.findByEmployeeId(employee.getId());
         return tariffs

--- a/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/UBSManagementEmployeeServiceImplTest.java
@@ -597,16 +597,24 @@ class UBSManagementEmployeeServiceImplTest {
 
     @Test
     void getTariffsForEmployeeTest() {
+        String email = "test@example.com";
+
+        Employee employee = getEmployee();
+        employee.setEmail(email);
+        employee.setId(1L);
+
         TariffsInfo tariffsInfo = getTariffsInfo();
         GetTariffInfoForEmployeeDto dto = GetTariffInfoForEmployeeDto.builder().build();
 
+        when(repository.findByEmail(email)).thenReturn(Optional.of(employee));
         when(modelMapper.map(tariffsInfo, GetTariffInfoForEmployeeDto.class)).thenReturn(dto);
-        when(tariffsInfoRepository.findAll()).thenReturn(List.of(getTariffsInfo()));
+        when(tariffsInfoRepository.findByEmployeeId(employee.getId())).thenReturn(List.of(tariffsInfo));
 
-        List<GetTariffInfoForEmployeeDto> dtos = employeeService.getTariffsForEmployee();
+        List<GetTariffInfoForEmployeeDto> dtos = employeeService.getTariffsForEmployee(email);
         assertEquals(1, dtos.size());
-        verify(modelMapper, times(1)).map(any(), any());
-        verify(tariffsInfoRepository).findAll();
+        verify(repository, times(1)).findByEmail(email);
+        verify(tariffsInfoRepository, times(1)).findByEmployeeId(employee.getId());
+        verify(modelMapper, times(1)).map(tariffsInfo, GetTariffInfoForEmployeeDto.class);
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
[#9281](https://github.com/ita-social-projects/GreenCity/issues/9281)

## Changed
- Fixed an issue where employees could see all tariffs, including those they are not responsible for.
- Fixed related tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tariff lists now reliably show only tariffs for the currently authenticated employee (looked up by their account), preventing other users' or global tariffs from appearing.

* **Tests**
  * Updated tests to validate employee lookup and filtered tariff retrieval for a given employee, ensuring correct behavior per user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->