### PR TITLE
Fix QR-code redirect to WayForPay payment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 21
+          distribution: ''
 
 #       - name: Set up Go
 #         uses: actions/setup-go@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 21
-          distribution: ''
+          distribution: 'temurin'
 
 #       - name: Set up Go
 #         uses: actions/setup-go@v3

--- a/core/src/main/java/greencity/configuration/SecurityConfig.java
+++ b/core/src/main/java/greencity/configuration/SecurityConfig.java
@@ -113,6 +113,7 @@ public class SecurityConfig {
                     UBS_LINK + "/districts-for-kyiv",
                     UBS_LINK + "/order-details-for-tariff",
                     UBS_LINK + "/activeTariffsInfo",
+                    UBS_LINK + "/redirect/{orderId}",
                     COMMIT_INFO,
                     SUPER_ADMIN_LINK + "/settingsText")
                 .permitAll()

--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -45,6 +45,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import java.io.IOException;
+import java.net.URI;
 import java.security.Principal;
 import java.util.List;
 import java.util.Locale;
@@ -584,5 +585,16 @@ public class OrderController {
     @GetMapping("/activeTariffsInfo")
     public ResponseEntity<List<GetActiveTariffInfoDto>> activeTariffsInfo() {
         return ResponseEntity.status(HttpStatus.OK).body(tariffService.getTariffsInfo());
+    }
+
+    @Operation(summary = "Redirect to WayForPay from QR-code for payment.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK, content = @Content),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
+    })
+    @GetMapping("/redirect/{orderId}")
+    public ResponseEntity<Void> redirectToWayForPay(@PathVariable Long orderId) {
+        return ResponseEntity.status(HttpStatus.FOUND)
+            .location(URI.create(processPaymentService.formedLink(orderId))).build();
     }
 }

--- a/core/src/main/resources/application-test.properties
+++ b/core/src/main/resources/application-test.properties
@@ -30,6 +30,7 @@ greencity.wayforpay.login=fake-login
 greencity.wayforpay.secret=fake-secret
 greencity.redirect.green-city-client=fake-green-city-client
 greencity.redirect.user-server-address=fake-user-server-address
+greencity.redirect.ubs-server-address =fake-ubs-server-address
 greencity.authorization.service-email=fake-service-email
 redirect.confirm-page=fake-confirm-page
 

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -36,6 +36,7 @@ spring.jpa.properties.hibernate.default_batch_fetch_size=10
 
 #RestTemplate
 greencity.redirect.user-server-address=${GREENCITYUSER_SERVER_ADDRESS}
+greencity.redirect.ubs-server-address = ${GREENCITY_UBS_SERVER_ADDRESS}
 
 #WebClient
 webclient.connection-timeout-millis=${WEBCLIENT_CONNECTION_TIMEOUT}

--- a/core/src/test/java/greencity/controller/OrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/OrderControllerTest.java
@@ -13,9 +13,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import greencity.ModelUtils;
 import greencity.configuration.SecurityConfig;
@@ -440,5 +439,16 @@ class OrderControllerTest {
             .andExpect(content().json(new ObjectMapper().writeValueAsString(listOfTariffs)));
 
         verify(tariffService).getTariffsInfo();
+    }
+
+    @Test
+    void redirectToWayForPay_ShouldReturnFoundAndLocationHeader() throws Exception {
+        when(processPaymentService.formedLink(1L)).thenReturn("test-link");
+
+        mockMvc.perform(get(ubsLink + "/redirect/" + 1L))
+            .andExpect(status().isFound())
+            .andExpect(header().string("Location", "test-link"));
+
+        verify(processPaymentService).formedLink(1L);
     }
 }

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -224,6 +224,7 @@ public class ErrorMessage {
     public static final String SIGN_IN_TOKEN_NOT_FOUND = "SignIn token key not set";
     public static final String ORDER_LOCK_DURATION_MINUTES_NOT_FOUND = "OrderLockDuration property is empty";
     public static final String USER_SERVER_ADDRESS_NOT_FOUND = "The redirect user server address is empty";
+    public static final String UBS_SERVER_ADDRESS_NOT_FOUND = "The redirect ubs server address is empty";
     public static final String WEB_CLIENT_CONNECTION_TIMEOUT_NOT_FOUND = "The webclient connection timeout is empty";
     public static final String WEB_CLIENT_RESPONSE_TIMEOUT_NOT_FOUND = "The webclient response timeout is empty";
     public static final String TELEGRAM_BOT_NAME_NOT_FOUND = "The greencity bots name is empty";

--- a/service-api/src/main/java/greencity/dto/order/OrdersDataForUserDto.java
+++ b/service-api/src/main/java/greencity/dto/order/OrdersDataForUserDto.java
@@ -20,7 +20,6 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode
-
 public class OrdersDataForUserDto {
     private Long id;
     private LocalDateTime dateForm;

--- a/service-api/src/main/java/greencity/properties/RemoteWebClientProperties.java
+++ b/service-api/src/main/java/greencity/properties/RemoteWebClientProperties.java
@@ -24,6 +24,7 @@ public class RemoteWebClientProperties {
     @PostConstruct
     public void validateProperties() {
         getGreenCityUserAddress();
+        getGreenCityUbsAddress();
         getWebClientConnectTimeout();
         getWebClientResponseTimeout();
         log.info("All Remote Web Client properties validated successfully.");
@@ -34,6 +35,15 @@ public class RemoteWebClientProperties {
         if (!StringUtils.hasText(address)) {
             log.error(ErrorMessage.USER_SERVER_ADDRESS_NOT_FOUND);
             throw new IllegalStateException(ErrorMessage.USER_SERVER_ADDRESS_NOT_FOUND);
+        }
+        return address;
+    }
+
+    public String getGreenCityUbsAddress() {
+        String address = environment.getProperty("greencity.redirect.ubs-server-address");
+        if (!StringUtils.hasText(address)) {
+            log.error(ErrorMessage.UBS_SERVER_ADDRESS_NOT_FOUND);
+            throw new IllegalStateException(ErrorMessage.UBS_SERVER_ADDRESS_NOT_FOUND);
         }
         return address;
     }

--- a/service-api/src/main/java/greencity/service/ubs/payment/ProcessPaymentService.java
+++ b/service-api/src/main/java/greencity/service/ubs/payment/ProcessPaymentService.java
@@ -48,12 +48,11 @@ public interface ProcessPaymentService {
      * redirect URL from the WayForPay response. - Schedules a payment expiry job
      * for the generated link.
      *
-     * @param orderId         the {order id for which the payment link is generated
-     * @param sumToPayInCoins the amount to be paid in coins
+     * @param orderId the {order id for which the payment link is generated
      * @return the checkout URL where the client should be redirected to complete
      *         payment
      */
-    String formedLink(Long orderId, long sumToPayInCoins);
+    String formedLink(Long orderId);
 
     /**
      * Forms a payment link for redirecting the user to WayForPay checkout, using

--- a/service-api/src/test/java/greencity/properties/RemoteWebClientPropertiesTest.java
+++ b/service-api/src/test/java/greencity/properties/RemoteWebClientPropertiesTest.java
@@ -56,6 +56,29 @@ class RemoteWebClientPropertiesTest {
     }
 
     @Test
+    void getGreenCityUbsAddress_shouldReturnValue() {
+        when(environment.getProperty("greencity.redirect.ubs-server-address"))
+            .thenReturn("https://greencity.com/ubs");
+
+        String result = remoteWebClientProperties.getGreenCityUbsAddress();
+
+        assertEquals("https://greencity.com/ubs", result);
+        verify(environment).getProperty("greencity.redirect.ubs-server-address");
+    }
+
+    @Test
+    void getGreenCityUbsAddress_shouldLogErrorIfEmpty() {
+        when(environment.getProperty("greencity.redirect.ubs-server-address"))
+            .thenReturn("");
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> remoteWebClientProperties.getGreenCityUbsAddress());
+
+        assertEquals(ErrorMessage.UBS_SERVER_ADDRESS_NOT_FOUND, exception.getMessage());
+        assertTrue(logCaptor.getErrorLogs().contains(ErrorMessage.UBS_SERVER_ADDRESS_NOT_FOUND));
+    }
+
+    @Test
     void getWebClientConnectTimeout_shouldReturnValue() {
         when(environment.getProperty("webclient.connection-timeout-millis", Integer.class))
             .thenReturn(5000);
@@ -105,6 +128,8 @@ class RemoteWebClientPropertiesTest {
     void validateProperties_shouldLogInfo_whenAllPropertiesValid() {
         when(environment.getProperty("greencity.redirect.user-server-address"))
             .thenReturn("user-url");
+        when(environment.getProperty("greencity.redirect.ubs-server-address"))
+            .thenReturn("ubs-url");
         when(environment.getProperty("webclient.connection-timeout-millis", Integer.class))
             .thenReturn(2);
         when(environment.getProperty("webclient.response-timeout-millis", Integer.class))
@@ -121,6 +146,8 @@ class RemoteWebClientPropertiesTest {
     void validateProperties_shouldThrowException_whenAnyPropertyInvalid() {
         when(environment.getProperty("greencity.redirect.user-server-address"))
             .thenReturn("user-url");
+        when(environment.getProperty("greencity.redirect.ubs-server-address"))
+            .thenReturn("ubs-url");
         when(environment.getProperty("webclient.connection-timeout-millis", Integer.class))
             .thenReturn(null);
         when(environment.getProperty("webclient.response-timeout-millis", Integer.class))

--- a/service/src/main/java/greencity/service/ubs/payment/ProcessPaymentServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/payment/ProcessPaymentServiceImpl.java
@@ -175,10 +175,11 @@ public class ProcessPaymentServiceImpl implements ProcessPaymentService {
 
     @Override
     @Transactional
-    public String formedLink(Long orderId, long sumToPayInCoins) {
+    public String formedLink(Long orderId) {
         Order order = getOrder(orderId);
         validateOrderPaymentProcessingStatus(order);
         incrementCounter(order);
+        long sumToPayInCoins = order.getSumTotalAmountWithoutDiscounts();
         PaymentWayForPayRequestDto paymentWayForPayRequestDto =
             wayForPayService.formPaymentRequestForWayForPay(order.getId(), sumToPayInCoins);
         paymentWayForPayRequestDto

--- a/service/src/main/java/greencity/service/ubs/pdf/exporter/OrdersDataPdfFileExporterImpl.java
+++ b/service/src/main/java/greencity/service/ubs/pdf/exporter/OrdersDataPdfFileExporterImpl.java
@@ -36,9 +36,9 @@ import greencity.dto.order.OrdersDataForUserDto;
 import greencity.entity.order.Order;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.exporting.pdf.PdfFileExportingException;
+import greencity.properties.RemoteWebClientProperties;
 import greencity.repository.OrderRepository;
 import greencity.service.ubs.file.export.FileExporter;
-import greencity.service.ubs.payment.ProcessPaymentService;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -49,13 +49,14 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class OrdersDataPdfFileExporterImpl implements FileExporter<OrdersDataForUserDto> {
     private static final String DEFAULT_FONT_NAME = "Comic Sans MS";
     private static final Color DEFAULT_CELL_BACKGROUND_COLOR = Color.WHITE;
@@ -67,8 +68,8 @@ public class OrdersDataPdfFileExporterImpl implements FileExporter<OrdersDataFor
     private static final int DEFAULT_SPACING_VALUE = 10;
     private static final float[] ORDER_DETAILS_TABLE_COLUMN_WIDTH = new float[] {50, 95, 100, 100, 80, 100, 80};
     private static final float[] ORDER_CONTENT_TABLE_COLUMN_WIDTH = new float[] {125, 120, 120, 120, 120};
-    private final ProcessPaymentService processPaymentService;
     private final OrderRepository orderRepository;
+    private final RemoteWebClientProperties remoteWebClientProperties;
 
     /**
      * {@inheritDoc}
@@ -278,17 +279,13 @@ public class OrdersDataPdfFileExporterImpl implements FileExporter<OrdersDataFor
                 return;
             }
 
-            String paymentLink = order.getPaymentLink();
-            if (paymentLink == null || paymentLink.isBlank()) {
-                paymentLink = processPaymentService.formedLink(order.getId(), sumInCoins);
-            }
+            String backendQrUrl = UriComponentsBuilder
+                .fromPath(remoteWebClientProperties.getGreenCityUbsAddress())
+                .path("ubs/redirect/{orderId}")
+                .buildAndExpand(order.getId())
+                .toUriString();
 
-            if (paymentLink == null || paymentLink.isBlank()) {
-                addQrCodeMessage(document, PdfQrCodeText.LINK_NOT_GENERATED, locale);
-                return;
-            }
-
-            addQrCodeWithText(document, paymentLink, locale);
+            addQrCodeWithText(document, backendQrUrl, locale);
         } catch (Exception e) {
             log.warn("Cannot add QR code to PDF for order {}: {}", orderDetails.getId(), e.getMessage(), e);
             addQrCodeMessage(document, PdfQrCodeText.LINK_NOT_GENERATED, locale);

--- a/service/src/test/java/greencity/service/ubs/payment/ProcessPaymentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/payment/ProcessPaymentServiceImplTest.java
@@ -789,4 +789,25 @@ class ProcessPaymentServiceImplTest {
 
         assertEquals(invoiceUrl, result);
     }
+
+    @Test
+    void formedLinkForQRCodeTest() {
+        String invoiceUrl = "https://pay.example.com/invoice/TEST123";
+        Order order = getOrderCount();
+        order.setPayment(List.of(getPayment()));
+        order.setPaymentLink(" ");
+        order.setSumTotalAmountWithoutDiscounts(400L);
+        PaymentWayForPayRequestDto payRequestDto = new PaymentWayForPayRequestDto();
+
+        when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
+        when(wayForPayClient.getCheckOutResponse(any()))
+            .thenReturn("{\"invoiceUrl\":\"https://pay.example.com/invoice/TEST123\"}");
+        when(wayForPayService.formPaymentRequestForWayForPay(anyLong(), anyLong()))
+            .thenReturn(payRequestDto);
+        when(wayForPayService.getLinkFromWayForPayCheckoutResponse(anyString())).thenReturn(invoiceUrl);
+
+        String result = service.formedLink(order.getId());
+
+        assertEquals(invoiceUrl, result);
+    }
 }

--- a/service/src/test/java/greencity/service/ubs/pdf/exporter/OrdersDataPdfFileExporterImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/pdf/exporter/OrdersDataPdfFileExporterImplTest.java
@@ -1,29 +1,28 @@
 package greencity.service.ubs.pdf.exporter;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.pdf.PdfPTable;
 import com.lowagie.text.pdf.PdfReader;
 import com.lowagie.text.pdf.parser.PdfTextExtractor;
 import greencity.ModelUtils;
 import greencity.constant.AppConstant;
+import greencity.entity.order.Order;
 import greencity.enums.pdf.PdfQrCodeText;
 import greencity.dto.order.OrdersDataForUserDto;
 import greencity.exceptions.exporting.pdf.PdfFileExportingException;
 import greencity.repository.OrderRepository;
 import greencity.service.ubs.payment.ProcessPaymentService;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.Locale;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -38,6 +37,13 @@ class OrdersDataPdfFileExporterImplTest {
 
     @InjectMocks
     private OrdersDataPdfFileExporterImpl pdfFileExporter;
+
+    private void invokeAddQrCode(OrdersDataForUserDto dto, Document document, Locale locale) throws Exception {
+        Method m = OrdersDataPdfFileExporterImpl.class
+            .getDeclaredMethod("addQrCode", OrdersDataForUserDto.class, Document.class, Locale.class);
+        m.setAccessible(true);
+        m.invoke(pdfFileExporter, dto, document, locale);
+    }
 
     @Test
     void exportValidEnPdf() throws IOException {
@@ -121,5 +127,36 @@ class OrdersDataPdfFileExporterImplTest {
         byte[] pdf = pdfFileExporter.export(dto, Locale.of("uk"));
         var text = new PdfTextExtractor(new PdfReader(pdf)).getTextFromPage(1, true);
         assertTrue(text.contains(PdfQrCodeText.getByLocale(PdfQrCodeText.ALREADY_PAID, Locale.of("uk"))));
+    }
+
+    @Test
+    void addQrCode_whenSumIsZeroOrNegative_shouldShowAlreadyPaidMessage() throws Exception {
+        long orderId = 1L;
+        Locale locale = Locale.UK;
+
+        OrdersDataForUserDto orderDetails = mock(OrdersDataForUserDto.class);
+        when(orderDetails.getId()).thenReturn(orderId);
+        when(orderDetails.getAmountBeforePayment()).thenReturn(0.0); // => sumInCoins = 0
+
+        Order order = new Order();
+        order.setId(orderId);
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
+
+        Document document = mock(Document.class);
+
+        invokeAddQrCode(orderDetails, document, locale);
+
+        ArgumentCaptor<Paragraph> paragraphCaptor = ArgumentCaptor.forClass(Paragraph.class);
+        verify(document, times(1)).add(paragraphCaptor.capture());
+
+        Paragraph paragraph = paragraphCaptor.getValue();
+        String actualText = paragraph.getContent().trim();
+
+        String expectedText =
+            PdfQrCodeText.getByLocale(PdfQrCodeText.ALREADY_PAID, locale);
+
+        assertEquals(expectedText, actualText);
+
+        verify(document, never()).add(isA(PdfPTable.class));
     }
 }

--- a/service/src/test/java/greencity/service/ubs/pdf/exporter/OrdersDataPdfFileExporterImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/pdf/exporter/OrdersDataPdfFileExporterImplTest.java
@@ -122,34 +122,4 @@ class OrdersDataPdfFileExporterImplTest {
         var text = new PdfTextExtractor(new PdfReader(pdf)).getTextFromPage(1, true);
         assertTrue(text.contains(PdfQrCodeText.getByLocale(PdfQrCodeText.ALREADY_PAID, Locale.of("uk"))));
     }
-
-    @Test
-    void exportWhenLinkBlankShowsLinkNotGenerated() throws Exception {
-        var dto = ModelUtils.getOrdersDataForUserDto();
-        dto.setAmountBeforePayment(10.0);
-        when(orderRepository.findById(anyLong()))
-            .thenReturn(Optional.of(mock(greencity.entity.order.Order.class)));
-        when(processPaymentService.formedLink(any(), anyLong())).thenReturn("   ");
-
-        byte[] pdf = pdfFileExporter.export(dto, Locale.ENGLISH);
-        var text = new PdfTextExtractor(new PdfReader(pdf)).getTextFromPage(1, true);
-
-        assertTrue(text.contains(PdfQrCodeText.getByLocale(PdfQrCodeText.LINK_NOT_GENERATED, Locale.ENGLISH)));
-    }
-
-    @Test
-    void export_whenLinkPresent_addsQrHint_andCallsFormedLink() throws Exception {
-        OrdersDataForUserDto dto = ModelUtils.getOrdersDataForUserDto();
-        dto.setAmountBeforePayment(10.00);
-        when(orderRepository.findById(anyLong()))
-            .thenReturn(Optional.of(mock(greencity.entity.order.Order.class)));
-        String url = "https://pay.example.com/invoice/TEST123";
-        when(processPaymentService.formedLink(any(), anyLong())).thenReturn(url);
-        Locale locale = Locale.ENGLISH;
-        byte[] pdf = pdfFileExporter.export(dto, locale);
-        String pageText = new PdfTextExtractor(new PdfReader(pdf)).getTextFromPage(1, true);
-        String expectedHint = PdfQrCodeText.getByLocale(PdfQrCodeText.QR_CODE_HINT, locale);
-        assertTrue(pageText.contains(expectedHint));
-        verify(processPaymentService).formedLink(any(), anyLong());
-    }
 }

--- a/service/src/test/java/greencity/service/ubs/pdf/exporter/OrdersDataPdfFileExporterImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/pdf/exporter/OrdersDataPdfFileExporterImplTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.lowagie.text.Document;
+import com.lowagie.text.Image;
 import com.lowagie.text.Paragraph;
 import com.lowagie.text.pdf.PdfPTable;
 import com.lowagie.text.pdf.PdfReader;
@@ -14,8 +15,10 @@ import greencity.entity.order.Order;
 import greencity.enums.pdf.PdfQrCodeText;
 import greencity.dto.order.OrdersDataForUserDto;
 import greencity.exceptions.exporting.pdf.PdfFileExportingException;
+import greencity.properties.RemoteWebClientProperties;
 import greencity.repository.OrderRepository;
 import greencity.service.ubs.payment.ProcessPaymentService;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Locale;
@@ -25,7 +28,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @ExtendWith(MockitoExtension.class)
 class OrdersDataPdfFileExporterImplTest {
@@ -34,6 +39,9 @@ class OrdersDataPdfFileExporterImplTest {
 
     @Mock
     private OrderRepository orderRepository;
+
+    @Mock
+    private RemoteWebClientProperties remoteWebClientProperties;
 
     @InjectMocks
     private OrdersDataPdfFileExporterImpl pdfFileExporter;
@@ -158,5 +166,59 @@ class OrdersDataPdfFileExporterImplTest {
         assertEquals(expectedText, actualText);
 
         verify(document, never()).add(isA(PdfPTable.class));
+    }
+
+    @Test
+    void addQrCode_whenSumPositive_shouldGenerateQrAndAddTable() throws Exception {
+        long orderId = 2L;
+        Locale locale = Locale.ENGLISH;
+
+        OrdersDataForUserDto orderDetails = mock(OrdersDataForUserDto.class);
+        when(orderDetails.getId()).thenReturn(orderId);
+        when(orderDetails.getAmountBeforePayment()).thenReturn(123.45); // > 0
+
+        Order order = new Order();
+        order.setId(orderId);
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
+
+        when(remoteWebClientProperties.getGreenCityUbsAddress()).thenReturn("/");
+
+        Document document = mock(Document.class);
+
+        BufferedImage fakeQrImage = new BufferedImage(150, 150, BufferedImage.TYPE_INT_RGB);
+        Image fakePdfImage = mock(Image.class);
+
+        try (MockedStatic<QrCodeGenerator> qrCodeGenMock = mockStatic(QrCodeGenerator.class);
+            MockedStatic<PdfImageUtil> pdfImageUtilMock = mockStatic(PdfImageUtil.class)) {
+
+            qrCodeGenMock
+                .when(() -> QrCodeGenerator.generateQrCodeImage(anyString(), eq(150), eq(150)))
+                .thenReturn(fakeQrImage);
+
+            pdfImageUtilMock
+                .when(() -> PdfImageUtil.convertBufferedImageToImage(fakeQrImage))
+                .thenReturn(fakePdfImage);
+
+            invokeAddQrCode(orderDetails, document, locale);
+
+            verify(document, atLeastOnce()).add(isA(PdfPTable.class));
+
+            ArgumentCaptor<String> linkCaptor = ArgumentCaptor.forClass(String.class);
+
+            qrCodeGenMock.verify(
+                () -> QrCodeGenerator.generateQrCodeImage(linkCaptor.capture(), eq(150), eq(150)));
+
+            String actualLink = linkCaptor.getValue();
+
+            String expectedLink = UriComponentsBuilder
+                .fromPath("/")
+                .path("ubs/redirect/{orderId}")
+                .buildAndExpand(orderId)
+                .toUriString();
+
+            assertEquals(expectedLink, actualLink);
+
+            verify(document, never()).add(isA(Paragraph.class));
+        }
     }
 }


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋

## Changed
- changed logic for creating QR-code in PDF file and redirect to WayForPay service;
- added additional logic for processing payment flow;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public order redirect endpoint (GET /ubs/redirect/{orderId}) returning a 302 redirect.

* **Refactor**
  * QR codes in exported order PDFs now point to a backend redirect URL instead of external payment-link generation.
  * Simplified payment link generation signatures and flow.

* **Configuration**
  * Introduced a configurable UBS server address property validated at startup.

* **Tests**
  * Expanded tests for UBS property handling, redirect behavior, and QR/payment-link scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->