### PR TITLE
Bugfix #9193 - Alternate email not updated

### DIFF
--- a/service/src/main/java/greencity/service/ubs/payment/ProcessPaymentServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/payment/ProcessPaymentServiceImpl.java
@@ -106,7 +106,7 @@ public class ProcessPaymentServiceImpl implements ProcessPaymentService {
         order = getOrder(orderId);
         long sumToPayInCoins = getLastPayment(order).getAmount();
 
-        formAndSaveUser(currentUser, dto.getPointsToUse(), order);
+        formAndSaveUser(currentUser, dto.getPointsToUse(), order, dto.getPersonalData().getEmail());
         saveOrderEvent(OrderHistory.ORDER_FORMED_UK, OrderHistory.CLIENT_UK, order);
 
         PaymentSystemResponse paymentSystemResponse =
@@ -136,7 +136,7 @@ public class ProcessPaymentServiceImpl implements ProcessPaymentService {
         order = getOrder(orderId);
         long sumToPayInCoins = getLastPayment(order).getAmount();
 
-        formAndSaveUser(currentUser, dto.getPointsToUse(), order);
+        formAndSaveUser(currentUser, dto.getPointsToUse(), order, dto.getPersonalData().getEmail());
         saveOrderEvent(OrderHistory.ORDER_STATUS_UPDATED_UK, OrderHistory.CLIENT_UK, order);
 
         PaymentSystemResponse paymentSystemResponse =
@@ -355,7 +355,7 @@ public class ProcessPaymentServiceImpl implements ProcessPaymentService {
         return userData;
     }
 
-    private void formAndSaveUser(User currentUser, int pointsToUse, Order order) {
+    private void formAndSaveUser(User currentUser, int pointsToUse, Order order, String email) {
         currentUser.getOrders().add(order);
         if (pointsToUse != 0) {
             currentUser.setCurrentPoints(currentUser.getCurrentPoints() - pointsToUse);
@@ -366,6 +366,9 @@ public class ProcessPaymentServiceImpl implements ProcessPaymentService {
                 .order(order)
                 .reason(BonusReason.DEBIT_PAYMENT)
                 .build());
+        }
+        if (!currentUser.getRecipientEmail().equals(email)) {
+            currentUser.setAlternateEmail(email);
         }
         userRepository.save(currentUser);
     }

--- a/service/src/test/java/greencity/service/ubs/payment/ProcessPaymentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/payment/ProcessPaymentServiceImplTest.java
@@ -51,6 +51,7 @@ import greencity.entity.order.Certificate;
 import greencity.entity.order.Order;
 import greencity.entity.order.Payment;
 import greencity.entity.user.User;
+import greencity.entity.user.ubs.OrderAddress;
 import greencity.entity.user.ubs.UBSuser;
 import greencity.enums.CertificateStatus;
 import greencity.enums.OrderPaymentStatus;
@@ -225,6 +226,44 @@ class ProcessPaymentServiceImplTest {
 
         assertThrows(AddressNotWithinLocationAreaException.class,
             () -> service.processNewOrder(dto, "uuid"));
+    }
+
+    @Test
+    void processNewOrder_shouldUpdateAlternateEmail_whenEmailDiffers() {
+        String oldEmail = "old@mail.com";
+        String newEmail = "new@mail.com";
+        OrderResponseDto dto = getOrderResponseDto(false);
+        dto.getPersonalData().setEmail(newEmail);
+        Order order = getOrder();
+        UBSuser ubsUser = getUBSuser();
+        PaymentSystemResponse response = getPaymentSystemResponse();
+        OrderAddressDto addressDto = getOrderAddressDto();
+        OrderAddress orderAddress = getOrderAddress();
+        User user = getUser();
+        user.setOrders(new ArrayList<>(List.of(order)));
+        user.setRecipientEmail(oldEmail);
+
+        when(addressService.checkIfAddressMatchLocationArea(dto.getLocationId(), dto.getAddressId()))
+            .thenReturn(true);
+        when(addressService.formAndSaveOrderAddress(dto.getAddressId(), dto.getLocationId(), user.getId()))
+            .thenReturn(addressDto);
+        when(orderAddressRepository.findById(addressDto.getId())).thenReturn(Optional.of(orderAddress));
+        when(modelMapper.map(dto, Order.class)).thenReturn(order);
+        when(userRepository.findByUuid("uuid")).thenReturn(user);
+        when(modelMapper.map(dto.getPersonalData(), UBSuser.class)).thenReturn(ubsUser);
+        when(orderService.formAndSaveOrderRequest(dto, order.getId(), user.getId(), null))
+            .thenReturn(order.getId());
+        when(orderRepository.save(order)).thenReturn(order);
+        when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
+        when(ubsUserRepository.save(ubsUser)).thenReturn(ubsUser);
+        when(userRepository.save(user)).thenReturn(user);
+        when(wayForPayService.getPaymentRequestDto(order.getId(), "")).thenReturn(response);
+        doNothing().when(eventService).save(anyString(), anyString(), anyLong());
+        doNothing().when(notificationService).notifyCreatedOrder(order.getId());
+
+        service.processNewOrder(dto, "uuid");
+
+        assertEquals(newEmail, user.getAlternateEmail());
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link :clipboard:
[#9193](https://github.com/ita-social-projects/GreenCity/issues/9193)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment processing now captures and stores alternate email addresses when a different email is provided during order placement.

* **Tests**
  * Added test coverage for alternate email update functionality during order processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->