### PR TITLE
Fix/9294 change tariff endpoints

### DIFF
--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -86,14 +86,13 @@ public class OrderController {
     private final UserService userService;
 
     /**
-     * Controller returns all available bags by tariff and location ids.
+     * Controller returns all available bags by tariff id.
      *
-     * @param tariffId   - id of tariff.
-     * @param locationId - id of location.
+     * @param tariffId - id of tariff.
      * @return {@link UserPointsAndAllBagsDto}.
      * @author SafarovRenat
      */
-    @Operation(summary = "Get details for the given tariff and location")
+    @Operation(summary = "Get details for the given tariff")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
             content = @Content(schema = @Schema(implementation = UserPointsAndAllBagsDto.class))),
@@ -101,11 +100,10 @@ public class OrderController {
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })
     @GetMapping("/order-details-for-tariff")
-    public ResponseEntity<UserPointsAndAllBagsDto> getCurrentUserPointsByTariffAndLocationId(
-        @RequestParam Long tariffId,
-        @RequestParam Long locationId) {
+    public ResponseEntity<UserPointsAndAllBagsDto> getCurrentUserPointsByTariffId(
+        @RequestParam Long tariffId) {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(orderCheckoutService.getFirstPageDataByTariffAndLocationId(tariffId, locationId));
+            .body(orderCheckoutService.getFirstPageDataByTariff(tariffId));
     }
 
     /**

--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -449,7 +449,7 @@ public class OrderController {
     public ResponseEntity<TariffInfoByLocationDto> getInfoAboutTariff(
         @Positive @PathVariable Long tariffId) {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(tariffService.getTariffInfoForLocation(tariffId));
+            .body(tariffService.getTariffInfo(tariffId));
     }
 
     /**

--- a/core/src/main/java/greencity/controller/OrderController.java
+++ b/core/src/main/java/greencity/controller/OrderController.java
@@ -435,25 +435,23 @@ public class OrderController {
     }
 
     /**
-     * Controller for getting info about tariff for courier and location.
+     * Controller for getting info about tariff.
      *
-     * @param courierId  - id of courier
-     * @param locationId - id of location
+     * @param tariffId - id of tariff
      * @return {@link TariffInfoByLocationDto}
      * @author Anton Bondar
      */
-    @Operation(summary = "Get tariff for courier and location")
+    @Operation(summary = "Get tariff by tariff ID")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })
-    @GetMapping("/tariffinfo/{locationId}")
+    @GetMapping("/tariffinfo/{tariffId}")
     public ResponseEntity<TariffInfoByLocationDto> getInfoAboutTariff(
-        @Positive @RequestParam Long courierId,
-        @Positive @PathVariable Long locationId) {
+        @Positive @PathVariable Long tariffId) {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(tariffService.getTariffInfoForLocation(courierId, locationId));
+            .body(tariffService.getTariffInfoForLocation(tariffId));
     }
 
     /**

--- a/core/src/test/java/greencity/controller/OrderControllerTest.java
+++ b/core/src/test/java/greencity/controller/OrderControllerTest.java
@@ -128,7 +128,7 @@ class OrderControllerTest {
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
 
-        verify(orderCheckoutService).getFirstPageDataByTariffAndLocationId(1L, 1L);
+        verify(orderCheckoutService).getFirstPageDataByTariff(1L);
     }
 
     @Test

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -111,6 +111,7 @@ public class ErrorMessage {
     public static final String TARIFF_FOR_COURIER_AND_LOCATION_NOT_EXIST =
         "Could not find tariff for courier with id: %d and location with id: %d ";
     public static final String TARIFF_OR_LOCATION_IS_DEACTIVATED = "Tariff or location is deactivated.";
+    public static final String TARIFF_IS_DEACTIVATED = "Tariff is deactivated.";
     public static final String TARIFF_IS_ALREADY_EXISTS = "Tariff for such locations is already exists";
     public static final String TARIFF_WITH_SUCH_NAME_IS_ALREADY_EXISTS = "Tariff with such name is already exists";
     public static final String COULD_NOT_RETRIEVE_PASSWORD_STATUS = "Could not retrieve password status";

--- a/service-api/src/main/java/greencity/service/ubs/order/OrderCheckoutService.java
+++ b/service-api/src/main/java/greencity/service/ubs/order/OrderCheckoutService.java
@@ -7,12 +7,11 @@ public interface OrderCheckoutService {
     /**
      * Method returns all bags available for order.
      *
-     * @param tariffId   {@link Long} tariff id.
-     * @param locationId {@link Long} location id.
+     * @param tariffId {@link Long} tariff id.
      * @return {@link UserPointsAndAllBagsDto}.
      * @author Safarov Renat
      */
-    UserPointsAndAllBagsDto getFirstPageDataByTariffAndLocationId(Long tariffId, Long locationId);
+    UserPointsAndAllBagsDto getFirstPageDataByTariff(Long tariffId);
 
     /**
      * Methods returns all available for order bags and current user's bonus points.

--- a/service-api/src/main/java/greencity/service/ubs/tariff/TariffService.java
+++ b/service-api/src/main/java/greencity/service/ubs/tariff/TariffService.java
@@ -7,14 +7,13 @@ import java.util.List;
 
 public interface TariffService {
     /**
-     * Method for getting info about tariff by courier ID and location ID.
+     * Method for getting info about tariff by tariff ID.
      *
-     * @param courierId  - id of courier
-     * @param locationId - id of location
+     * @param tariffId The ID of the tariff.
      * @return {@link TariffInfoByLocationDto}
      * @author Anton Bondar
      */
-    TariffInfoByLocationDto getTariffInfoForLocation(Long courierId, Long locationId);
+    TariffInfoByLocationDto getTariffInfoForLocation(Long tariffId);
 
     /**
      * Method for getting info about tariff by order's id.

--- a/service-api/src/main/java/greencity/service/ubs/tariff/TariffService.java
+++ b/service-api/src/main/java/greencity/service/ubs/tariff/TariffService.java
@@ -13,7 +13,7 @@ public interface TariffService {
      * @return {@link TariffInfoByLocationDto}
      * @author Anton Bondar
      */
-    TariffInfoByLocationDto getTariffInfoForLocation(Long tariffId);
+    TariffInfoByLocationDto getTariffInfo(Long tariffId);
 
     /**
      * Method for getting info about tariff by order's id.

--- a/service/src/main/java/greencity/service/ubs/order/OrderCheckoutServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/order/OrderCheckoutServiceImpl.java
@@ -1,12 +1,5 @@
 package greencity.service.ubs.order;
 
-import static greencity.constant.ErrorMessage.LOCATION_DOESNT_FOUND_BY_ID;
-import static greencity.constant.ErrorMessage.LOCATION_IS_DEACTIVATED_FOR_TARIFF;
-import static greencity.constant.ErrorMessage.ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST;
-import static greencity.constant.ErrorMessage.TARIFF_FOR_LOCATION_NOT_EXIST;
-import static greencity.constant.ErrorMessage.TARIFF_NOT_FOUND;
-import static greencity.constant.ErrorMessage.TARIFF_OR_LOCATION_IS_DEACTIVATED;
-import static greencity.constant.ErrorMessage.USER_WITH_CURRENT_UUID_DOES_NOT_EXIST;
 import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
 import greencity.dto.bag.BagTranslationDto;
@@ -24,7 +17,6 @@ import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.http.AccessDeniedException;
 import greencity.repository.BagRepository;
-import greencity.repository.LocationRepository;
 import greencity.repository.OrderBagRepository;
 import greencity.repository.OrderRepository;
 import greencity.repository.TariffLocationRepository;
@@ -39,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
+import static greencity.constant.ErrorMessage.*;
 
 @Service
 @RequiredArgsConstructor
@@ -46,7 +39,6 @@ import org.springframework.stereotype.Service;
 public class OrderCheckoutServiceImpl implements OrderCheckoutService {
     private final TariffsInfoRepository tariffsInfoRepository;
     private final TariffLocationRepository tariffLocationRepository;
-    private final LocationRepository locationRepository;
     private final BagRepository bagRepository;
     private final UserRepository userRepository;
     private final OrderRepository orderRepository;
@@ -55,14 +47,13 @@ public class OrderCheckoutServiceImpl implements OrderCheckoutService {
     private final ModelMapper modelMapper;
 
     @Override
-    public UserPointsAndAllBagsDto getFirstPageDataByTariffAndLocationId(Long tariffId, Long locationId) {
+    public UserPointsAndAllBagsDto getFirstPageDataByTariff(Long tariffId) {
         TariffsInfo tariffsInfo = tariffsInfoRepository.findById(tariffId)
             .orElseThrow(() -> new NotFoundException(TARIFF_NOT_FOUND + tariffId));
 
-        Location location = locationRepository.findById(locationId)
-            .orElseThrow(() -> new NotFoundException(LOCATION_DOESNT_FOUND_BY_ID + locationId));
-
-        checkIfTariffIsAvailableForCurrentLocation(tariffsInfo, location);
+        if (tariffsInfo.getTariffStatus() == TariffStatus.DEACTIVATED) {
+            throw new BadRequestException(TARIFF_IS_DEACTIVATED);
+        }
 
         return getUserPointsAndAllBagsDtoByTariffIdAndUserPoints(tariffsInfo.getId(), 0);
     }

--- a/service/src/main/java/greencity/service/ubs/tariff/TariffServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/tariff/TariffServiceImpl.java
@@ -28,7 +28,7 @@ public class TariffServiceImpl implements TariffService {
     private final ModelMapper modelMapper;
 
     @Override
-    public TariffInfoByLocationDto getTariffInfoForLocation(Long tariffId) {
+    public TariffInfoByLocationDto getTariffInfo(Long tariffId) {
         TariffsInfo tariffsInfo = findTariffsInfoByTariffId(tariffId);
 
         return TariffInfoByLocationDto.builder()
@@ -84,8 +84,7 @@ public class TariffServiceImpl implements TariffService {
 
     private TariffsInfo findTariffsInfoByTariffId(Long tariffId) {
         return tariffsInfoRepository.findById(tariffId)
-            .orElseThrow(() -> new NotFoundException(
-                String.format(TARIFF_NOT_FOUND + tariffId)));
+            .orElseThrow(() -> new NotFoundException(TARIFF_NOT_FOUND + tariffId));
     }
 
     private String joinLocationNames(Set<TariffLocation> locations, boolean isUk) {

--- a/service/src/main/java/greencity/service/ubs/tariff/TariffServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/tariff/TariffServiceImpl.java
@@ -1,10 +1,5 @@
 package greencity.service.ubs.tariff;
 
-import static greencity.constant.ErrorMessage.COURIER_IS_NOT_FOUND_BY_ID;
-import static greencity.constant.ErrorMessage.LOCATION_DOESNT_FOUND_BY_ID;
-import static greencity.constant.ErrorMessage.TARIFF_FOR_COURIER_AND_LOCATION_NOT_EXIST;
-import static greencity.constant.ErrorMessage.TARIFF_FOR_ORDER_NOT_EXIST;
-import static greencity.constant.ErrorMessage.TARIFF_NOT_FOUND_BY_LOCATION_ID;
 import greencity.dto.TariffInfoByLocationDto;
 import greencity.dto.TariffsForLocationDto;
 import greencity.dto.tariff.GetActiveTariffInfoDto;
@@ -13,7 +8,6 @@ import greencity.entity.order.TariffLocation;
 import greencity.entity.order.TariffsInfo;
 import greencity.exceptions.NotFoundException;
 import greencity.repository.CourierRepository;
-import greencity.repository.LocationRepository;
 import greencity.repository.TariffsInfoRepository;
 import java.util.List;
 import java.util.Optional;
@@ -23,28 +17,24 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
+import static greencity.constant.ErrorMessage.*;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class TariffServiceImpl implements TariffService {
     private final CourierRepository courierRepository;
-    private final LocationRepository locationRepository;
     private final TariffsInfoRepository tariffsInfoRepository;
     private final ModelMapper modelMapper;
 
     @Override
-    public TariffInfoByLocationDto getTariffInfoForLocation(Long courierId, Long locationId) {
-        if (!courierRepository.existsCourierById(courierId)) {
-            throw new NotFoundException(COURIER_IS_NOT_FOUND_BY_ID + courierId);
-        }
-        if (!locationRepository.existsById(locationId)) {
-            throw new NotFoundException(LOCATION_DOESNT_FOUND_BY_ID + locationId);
-        }
+    public TariffInfoByLocationDto getTariffInfoForLocation(Long tariffId) {
+        TariffsInfo tariffsInfo = findTariffsInfoByTariffId(tariffId);
+
         return TariffInfoByLocationDto.builder()
             .orderIsPresent(true)
             .tariffsForLocationDto(modelMapper.map(
-                findTariffsInfoByCourierAndLocationId(courierId, locationId), TariffsForLocationDto.class))
+                tariffsInfo, TariffsForLocationDto.class))
             .build();
     }
 
@@ -92,11 +82,10 @@ public class TariffServiceImpl implements TariffService {
             .toList();
     }
 
-    private TariffsInfo findTariffsInfoByCourierAndLocationId(Long courierId, Long locationId) {
-        return tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(courierId, locationId)
-            .orElseThrow(
-                () -> new NotFoundException(
-                    String.format(TARIFF_FOR_COURIER_AND_LOCATION_NOT_EXIST, courierId, locationId)));
+    private TariffsInfo findTariffsInfoByTariffId(Long tariffId) {
+        return tariffsInfoRepository.findById(tariffId)
+            .orElseThrow(() -> new NotFoundException(
+                String.format(TARIFF_NOT_FOUND + tariffId)));
     }
 
     private String joinLocationNames(Set<TariffLocation> locations, boolean isUk) {

--- a/service/src/test/java/greencity/service/ubs/order/OrderCheckoutServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/order/OrderCheckoutServiceImplTest.java
@@ -1,9 +1,6 @@
 package greencity.service.ubs.order;
 
-import static greencity.constant.ErrorMessage.LOCATION_IS_DEACTIVATED_FOR_TARIFF;
-import static greencity.constant.ErrorMessage.ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST;
-import static greencity.constant.ErrorMessage.TARIFF_OR_LOCATION_IS_DEACTIVATED;
-import static greencity.constant.ErrorMessage.USER_WITH_CURRENT_UUID_DOES_NOT_EXIST;
+import static greencity.constant.ErrorMessage.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,13 +20,11 @@ import greencity.entity.user.Location;
 import greencity.entity.user.User;
 import greencity.entity.user.ubs.OrderAddress;
 import greencity.entity.user.ubs.UBSuser;
-import greencity.enums.LocationStatus;
 import greencity.enums.TariffStatus;
 import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.http.AccessDeniedException;
 import greencity.repository.BagRepository;
-import greencity.repository.LocationRepository;
 import greencity.repository.OrderBagRepository;
 import greencity.repository.OrderRepository;
 import greencity.repository.TariffLocationRepository;
@@ -57,8 +52,6 @@ class OrderCheckoutServiceImplTest {
     private TariffsInfoRepository tariffsInfoRepository;
     @Mock
     private TariffLocationRepository tariffLocationRepository;
-    @Mock
-    private LocationRepository locationRepository;
     @Mock
     private BagRepository bagRepository;
     @Mock
@@ -95,33 +88,25 @@ class OrderCheckoutServiceImplTest {
     }
 
     @Test
-    void getFirstPageDataByTariffAndLocationId_success() {
+    void getFirstPageDataByTariff_success() {
         when(tariffsInfoRepository.findById(1L)).thenReturn(Optional.of(tariffsInfo));
-        when(locationRepository.findById(10L)).thenReturn(Optional.of(location));
-        when(tariffLocationRepository.findTariffLocationByTariffsInfoAndLocation(tariffsInfo, location))
-            .thenReturn(Optional.of(TariffLocation.builder()
-                .id(1L)
-                .location(location)
-                .tariffsInfo(tariffsInfo)
-                .locationStatus(location.getLocationStatus())
-                .build()));
         when(bagRepository.findAllActiveBagsByTariffsInfoId(1L)).thenReturn(List.of(ModelUtils.getBag()));
 
         when(modelMapper.map(any(Bag.class), eq(BagTranslationDto.class)))
             .thenReturn(ModelUtils.getBagTranslationDto());
 
         UserPointsAndAllBagsDto result =
-            orderCheckoutService.getFirstPageDataByTariffAndLocationId(1L, 10L);
+            orderCheckoutService.getFirstPageDataByTariff(1L);
 
         assertThat(result.getBags()).hasSize(1);
     }
 
     @Test
-    void getFirstPageDataByTariffAndLocationId_tariffNotFound() {
+    void getFirstPageDataByTariff_tariffNotFound() {
         when(tariffsInfoRepository.findById(1L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() ->
-            orderCheckoutService.getFirstPageDataByTariffAndLocationId(1L, 10L))
+            orderCheckoutService.getFirstPageDataByTariff(1L))
             .isInstanceOf(NotFoundException.class);
     }
 
@@ -211,43 +196,14 @@ class OrderCheckoutServiceImplTest {
     }
 
     @Test
-    void getFirstPageDataByTariffAndLocationId_tariffOrLocationDeactivated() {
+    void getFirstPageDataByTariff_tariffOrLocationDeactivated() {
         tariffsInfo.setTariffStatus(TariffStatus.DEACTIVATED);
 
         when(tariffsInfoRepository.findById(1L)).thenReturn(Optional.of(tariffsInfo));
-        when(locationRepository.findById(10L)).thenReturn(Optional.of(location));
 
-        assertThatThrownBy(() -> orderCheckoutService.getFirstPageDataByTariffAndLocationId(1L, 10L))
+        assertThatThrownBy(() -> orderCheckoutService.getFirstPageDataByTariff(1L))
             .isInstanceOf(BadRequestException.class)
-            .hasMessageContaining(TARIFF_OR_LOCATION_IS_DEACTIVATED);
-    }
-
-    @Test
-    void getFirstPageDataByTariffAndLocationId_locationDeactivatedForTariff() {
-        when(tariffsInfoRepository.findById(1L)).thenReturn(Optional.of(tariffsInfo));
-        when(locationRepository.findById(10L)).thenReturn(Optional.of(location));
-        when(tariffLocationRepository.findTariffLocationByTariffsInfoAndLocation(tariffsInfo, location))
-            .thenReturn(Optional.of(TariffLocation.builder()
-                .id(1L)
-                .location(location)
-                .tariffsInfo(tariffsInfo)
-                .locationStatus(LocationStatus.ACTIVE)
-                .build()));
-
-        location.setLocationStatus(LocationStatus.ACTIVE);
-        tariffsInfo.setTariffStatus(TariffStatus.ACTIVE);
-        when(tariffLocationRepository.findTariffLocationByTariffsInfoAndLocation(tariffsInfo, location))
-            .thenReturn(Optional.of(TariffLocation.builder()
-                .id(1L)
-                .location(location)
-                .tariffsInfo(tariffsInfo)
-                .locationStatus(LocationStatus.DEACTIVATED)
-                .build()));
-
-        assertThatThrownBy(() ->
-            orderCheckoutService.getFirstPageDataByTariffAndLocationId(1L, 10L))
-            .isInstanceOf(BadRequestException.class)
-            .hasMessageContaining(LOCATION_IS_DEACTIVATED_FOR_TARIFF + 1L);
+            .hasMessageContaining(TARIFF_IS_DEACTIVATED);
     }
 
     @Test
@@ -264,38 +220,5 @@ class OrderCheckoutServiceImplTest {
         PersonalDataDto result = orderCheckoutService.getSecondPageData("uuid-123");
 
         assertThat(result.getEmail()).isNull();
-    }
-
-    @Test
-    void isTariffAvailableForCurrentLocation_success() {
-        when(tariffLocationRepository.findTariffLocationByTariffsInfoAndLocation(tariffsInfo, location))
-            .thenReturn(Optional.of(TariffLocation.builder()
-                .id(1L)
-                .tariffsInfo(tariffsInfo)
-                .location(location)
-                .locationStatus(LocationStatus.ACTIVE)
-                .build()));
-
-        when(tariffsInfoRepository.findById(1L)).thenReturn(Optional.of(tariffsInfo));
-        when(locationRepository.findById(10L)).thenReturn(Optional.of(location));
-        when(bagRepository.findAllActiveBagsByTariffsInfoId(1L)).thenReturn(List.of(ModelUtils.getBag()));
-        when(modelMapper.map(any(Bag.class), eq(BagTranslationDto.class))).thenReturn(ModelUtils.getBagTranslationDto());
-
-        UserPointsAndAllBagsDto result = orderCheckoutService.getFirstPageDataByTariffAndLocationId(1L, 10L);
-
-        assertThat(result.getBags()).isNotEmpty();
-    }
-
-    @Test
-    void getFirstPageDataByTariffAndLocationId_locationStatusDeactivated() {
-        tariffsInfo.setTariffStatus(TariffStatus.ACTIVE);
-        location.setLocationStatus(LocationStatus.DEACTIVATED);
-
-        when(tariffsInfoRepository.findById(1L)).thenReturn(Optional.of(tariffsInfo));
-        when(locationRepository.findById(10L)).thenReturn(Optional.of(location));
-
-        assertThatThrownBy(() -> orderCheckoutService.getFirstPageDataByTariffAndLocationId(1L, 10L))
-            .isInstanceOf(BadRequestException.class)
-            .hasMessageContaining(TARIFF_OR_LOCATION_IS_DEACTIVATED);
     }
 }

--- a/service/src/test/java/greencity/service/ubs/tariff/TariffServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/tariff/TariffServiceImplTest.java
@@ -20,7 +20,6 @@ import greencity.entity.order.TariffsInfo;
 import greencity.entity.user.Location;
 import greencity.exceptions.NotFoundException;
 import greencity.repository.CourierRepository;
-import greencity.repository.LocationRepository;
 import greencity.repository.TariffsInfoRepository;
 import java.util.List;
 import java.util.Optional;
@@ -37,8 +36,6 @@ class TariffServiceImplTest {
     @Mock
     private CourierRepository courierRepository;
     @Mock
-    private LocationRepository locationRepository;
-    @Mock
     private TariffsInfoRepository tariffsInfoRepository;
     @Mock
     private ModelMapper modelMapper;
@@ -48,57 +45,28 @@ class TariffServiceImplTest {
 
     @Test
     void getTariffInfoForLocation() {
-        Long courierId = 1L;
-        Long locationId = 2L;
+        Long tariffId = 1L;
 
         TariffInfoByLocationDto tariffInfoByLocationDto = getTariffInfoByLocationDto();
         TariffsInfo tariffsInfo = ModelUtils.getTariffsInfo();
 
-        when(courierRepository.existsCourierById(courierId)).thenReturn(true);
-        when(locationRepository.existsById(locationId)).thenReturn(true);
-        when(tariffsInfoRepository.findTariffsInfoLimitsByCourierIdAndLocationId(courierId, locationId))
+        when(tariffsInfoRepository.findById(tariffId))
             .thenReturn(Optional.ofNullable(tariffsInfo));
         when(modelMapper.map(tariffsInfo, TariffsForLocationDto.class))
             .thenReturn(tariffInfoByLocationDto.getTariffsForLocationDto());
 
-        TariffInfoByLocationDto result = tariffService.getTariffInfoForLocation(courierId, locationId);
-
+        TariffInfoByLocationDto result = tariffService.getTariffInfoForLocation(tariffId);
         assertEquals(tariffInfoByLocationDto, result);
     }
 
     @Test
-    void getTariffInfoForLocation_CourierNotFound() {
-        Long courierId = 1L;
-        Long locationId = 2L;
-
-        when(courierRepository.existsCourierById(courierId)).thenReturn(false);
-
-        assertThrows(NotFoundException.class,
-            () -> tariffService.getTariffInfoForLocation(courierId, locationId));
-    }
-
-    @Test
-    void getTariffInfoForLocation_LocationNotFound() {
-        Long courierId = 1L;
-        Long locationId = 2L;
-
-        when(courierRepository.existsCourierById(courierId)).thenReturn(true);
-        when(locationRepository.existsById(locationId)).thenReturn(false);
-
-        assertThrows(NotFoundException.class,
-            () -> tariffService.getTariffInfoForLocation(courierId, locationId));
-    }
-
-    @Test
     void getTariffInfoForLocation_TariffNotFound() {
-        Long courierId = 1L;
-        Long locationId = 2L;
+        Long tariffId = 1L;
 
-        when(courierRepository.existsCourierById(courierId)).thenReturn(true);
-        when(locationRepository.existsById(locationId)).thenReturn(true);
+        when(tariffsInfoRepository.findById(tariffId)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class,
-            () -> tariffService.getTariffInfoForLocation(courierId, locationId));
+            () -> tariffService.getTariffInfoForLocation(tariffId));
     }
 
     @Test

--- a/service/src/test/java/greencity/service/ubs/tariff/TariffServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/tariff/TariffServiceImplTest.java
@@ -44,7 +44,7 @@ class TariffServiceImplTest {
     private TariffServiceImpl tariffService;
 
     @Test
-    void getTariffInfoForLocation() {
+    void getTariffInfo() {
         Long tariffId = 1L;
 
         TariffInfoByLocationDto tariffInfoByLocationDto = getTariffInfoByLocationDto();
@@ -55,18 +55,18 @@ class TariffServiceImplTest {
         when(modelMapper.map(tariffsInfo, TariffsForLocationDto.class))
             .thenReturn(tariffInfoByLocationDto.getTariffsForLocationDto());
 
-        TariffInfoByLocationDto result = tariffService.getTariffInfoForLocation(tariffId);
+        TariffInfoByLocationDto result = tariffService.getTariffInfo(tariffId);
         assertEquals(tariffInfoByLocationDto, result);
     }
 
     @Test
-    void getTariffInfoForLocation_TariffNotFound() {
+    void getTariffInfo_TariffNotFound() {
         Long tariffId = 1L;
 
         when(tariffsInfoRepository.findById(tariffId)).thenReturn(Optional.empty());
 
         assertThrows(NotFoundException.class,
-            () -> tariffService.getTariffInfoForLocation(tariffId));
+            () -> tariffService.getTariffInfo(tariffId));
     }
 
     @Test


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
[#9294](https://github.com/ita-social-projects/GreenCity/issues/9294)

## Changed
- Modifed GET /ubs/tariffinfo/{locationId} endpoint to get tariff details by tariffId instead of courierId and locationId;
- Modifed GET /ubs/order-details-for-tariff endpoint to get tariff details by tariffId instead of tariffId + locationId.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Updates**
  * Simplified tariff-related endpoints to use tariff ID only; removed location-based parameters and updated paths.
  * Added clearer deactivated-tariff error message.

* **Tests**
  * Updated unit tests to reflect tariff-only flows and removed location-based scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->