### PR TITLE
Fix/9295 unable to process order

### DIFF
--- a/core/src/test/java/greencity/ModelUtils.java
+++ b/core/src/test/java/greencity/ModelUtils.java
@@ -114,7 +114,7 @@ public class ModelUtils {
                 .phoneNumber("0678945221")
                 .build())
             .addressId(1L)
-            .locationId(1L)
+            .tariffId(1L)
             .paymentSystem(PaymentSystem.WAY_FOR_PAY)
             .build();
     }

--- a/service-api/src/main/java/greencity/dto/order/OrderResponseDto.java
+++ b/service-api/src/main/java/greencity/dto/order/OrderResponseDto.java
@@ -52,7 +52,7 @@ public class OrderResponseDto implements Serializable {
     private boolean shouldBePaid;
 
     @NotNull
-    private Long locationId;
+    private Long tariffId;
 
     private PaymentSystem paymentSystem;
 }

--- a/service/src/main/java/greencity/service/ubs/order/OrderServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/order/OrderServiceImpl.java
@@ -9,7 +9,6 @@ import static greencity.constant.QuartzConstants.QUARTZ_SCHEDULER_EXCEPTION;
 import static java.util.Objects.nonNull;
 import greencity.constant.AppConstant;
 import greencity.dto.address.AddressInfoDto;
-import greencity.dto.bag.BagDto;
 import greencity.dto.bag.BagForUserDto;
 import greencity.dto.bag.BagInfoDto;
 import greencity.dto.bag.BagMappingDto;

--- a/service/src/main/java/greencity/service/ubs/order/OrderServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/order/OrderServiceImpl.java
@@ -1,12 +1,7 @@
 package greencity.service.ubs.order;
 
 import static greencity.constant.AppConstant.ENROLLMENT_TO_THE_BONUS_ACCOUNT_EN;
-import static greencity.constant.ErrorMessage.CANNOT_ACCESS_ORDER_CANCELLATION_REASON;
-import static greencity.constant.ErrorMessage.ORDER_NOT_FOUND_BY_ID;
-import static greencity.constant.ErrorMessage.TARIFF_FOR_BAGS_AT_LOCATION_NOT_EXIST;
-import static greencity.constant.ErrorMessage.TOO_MUCH_POINTS_FOR_ORDER;
-import static greencity.constant.ErrorMessage.UBS_USER_NOT_FOUND_BY_ID;
-import static greencity.constant.ErrorMessage.USER_NOT_FOUND_BY_ID;
+import static greencity.constant.ErrorMessage.*;
 import static greencity.constant.QuartzConstants.PAYMENT_EXPIRY_CANCEL_EXCEPTION;
 import static greencity.constant.QuartzConstants.PAYMENT_EXPIRY_JOB_GROUP;
 import static greencity.constant.QuartzConstants.PAYMENT_EXPIRY_JOB_KEY;
@@ -21,13 +16,7 @@ import greencity.dto.bag.BagMappingDto;
 import greencity.dto.bag.BagTransDto;
 import greencity.dto.certificate.CertificateDto;
 import greencity.dto.notification.SenderInfoDto;
-import greencity.dto.order.OrderCancellationReasonDto;
-import greencity.dto.order.OrderDetailDto;
-import greencity.dto.order.OrderDetailInfoDto;
-import greencity.dto.order.OrderInfoDto;
-import greencity.dto.order.OrderPaymentDetailDto;
-import greencity.dto.order.OrderResponseDto;
-import greencity.dto.order.OrdersDataForUserDto;
+import greencity.dto.order.*;
 import greencity.dto.pageble.PageableDto;
 import greencity.dto.payment.PaymentWithStatusDto;
 import greencity.entity.order.Bag;
@@ -127,8 +116,9 @@ public class OrderServiceImpl implements OrderService {
             .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND_BY_ID + userId));
         UBSuser userData = ubsUserRepository.findById(ubsUserId)
             .orElseThrow(() -> new NotFoundException(UBS_USER_NOT_FOUND_BY_ID + ubsUserId));
+        TariffsInfo tariffsInfo = tariffsInfoRepository.findById(dto.getTariffId())
+            .orElseThrow(() -> new NotFoundException(TARIFF_NOT_FOUND + dto.getTariffId()));
 
-        TariffsInfo tariffsInfo = findTariffsInfoByBagIdsWithinLocation(getBagIds(dto.getBags()), dto.getLocationId());
         List<BagInfoDto> bagsOrdered = prepareBags(dto, order, tariffsInfo.getId());
         Set<CertificateDto> orderCertificates = new HashSet<>();
         long sumToPayInCoinsWithoutDiscount = calculateTotal(bagsOrdered);
@@ -369,12 +359,6 @@ public class OrderServiceImpl implements OrderService {
             .map(e -> e.getPrice() * e.getAmount() * AppConstant.CURRENCY_CONVERSION_RATE)
             .mapToLong(Double::longValue)
             .sum();
-    }
-
-    private TariffsInfo findTariffsInfoByBagIdsWithinLocation(List<Integer> bagIds, Long locationId) {
-        return tariffsInfoRepository.findTariffsInfoByBagIdAndLocationId(bagIds, locationId)
-            .orElseThrow(
-                () -> new NotFoundException(String.format(TARIFF_FOR_BAGS_AT_LOCATION_NOT_EXIST, bagIds, locationId)));
     }
 
     private List<Integer> getBagIds(List<BagDto> dto) {

--- a/service/src/main/java/greencity/service/ubs/order/OrderServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/order/OrderServiceImpl.java
@@ -361,12 +361,6 @@ public class OrderServiceImpl implements OrderService {
             .sum();
     }
 
-    private List<Integer> getBagIds(List<BagDto> dto) {
-        return dto.stream()
-            .map(BagDto::getId)
-            .toList();
-    }
-
     private Long formAndSaveOrder(
         Order order, Set<CertificateDto> orderCertificates, List<BagInfoDto> bagsOrdered,
         UBSuser userData, User currentUser, long sumToPayInCoins, TariffsInfo tariffsInfo) {

--- a/service/src/main/java/greencity/service/ubs/payment/ProcessPaymentServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/payment/ProcessPaymentServiceImpl.java
@@ -1,13 +1,6 @@
 package greencity.service.ubs.payment;
 
-import static greencity.constant.ErrorMessage.ORDER_ADDRESS_NOT_FOUND_BY_ID;
-import static greencity.constant.ErrorMessage.ORDER_ALREADY_PAID;
-import static greencity.constant.ErrorMessage.ORDER_IN_ONGOING_PROCESSING;
-import static greencity.constant.ErrorMessage.ORDER_NOT_FOUND_BY_ID;
-import static greencity.constant.ErrorMessage.ORDER_STATUS_AND_PAYMENT_CONDITION_FAILED;
-import static greencity.constant.ErrorMessage.ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST;
-import static greencity.constant.ErrorMessage.UNABLE_TO_CANCEL_PAYMENT_INVOICE;
-import static greencity.constant.ErrorMessage.USER_WITH_CURRENT_UUID_DOES_NOT_EXIST;
+import static greencity.constant.ErrorMessage.*;
 import static greencity.constant.QuartzConstants.NO_PAYMENT_ATTEMPT_FOR_ORDER;
 import static greencity.constant.QuartzConstants.PAYMENT_EXPIRY_JOB_GROUP;
 import static greencity.constant.QuartzConstants.PAYMENT_EXPIRY_JOB_KEY;
@@ -18,20 +11,15 @@ import greencity.client.WayForPayClient;
 import greencity.constant.AppConstant;
 import greencity.constant.ErrorMessage;
 import greencity.constant.OrderHistory;
-import greencity.dto.order.OrderAddressDto;
-import greencity.dto.order.OrderInfoDto;
-import greencity.dto.order.OrderResponseDto;
-import greencity.dto.order.OrderWayForPayClientDto;
-import greencity.dto.order.PaymentSystemResponse;
+import greencity.dto.order.*;
 import greencity.dto.payment.PaymentCancellationWayForPayRequestDto;
 import greencity.dto.payment.PaymentWayForPayRequestDto;
 import greencity.dto.payment.PaymentWithStatusDto;
 import greencity.dto.user.PersonalDataDto;
 import greencity.dto.user.UserPointDto;
-import greencity.entity.order.Certificate;
-import greencity.entity.order.ChangeOfPoints;
-import greencity.entity.order.Order;
-import greencity.entity.order.Payment;
+import greencity.entity.order.*;
+import greencity.entity.order.TariffLocation;
+import greencity.entity.user.Location;
 import greencity.entity.user.User;
 import greencity.entity.user.ubs.OrderAddress;
 import greencity.entity.user.ubs.UBSuser;
@@ -40,11 +28,7 @@ import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.address.AddressNotWithinLocationAreaException;
 import greencity.exceptions.http.AccessDeniedException;
-import greencity.repository.CertificateRepository;
-import greencity.repository.OrderAddressRepository;
-import greencity.repository.OrderRepository;
-import greencity.repository.UBSUserRepository;
-import greencity.repository.UserRepository;
+import greencity.repository.*;
 import greencity.service.phone.UAPhoneNumberUtil;
 import greencity.service.ubs.AddressService;
 import greencity.service.ubs.EventService;
@@ -90,11 +74,11 @@ public class ProcessPaymentServiceImpl implements ProcessPaymentService {
     private final Scheduler quartzScheduler;
     private final OrderBagService orderBagService;
     private final OrderAddressRepository orderAddressRepository;
+    private final TariffsInfoRepository tariffsInfoRepository;
 
     @Override
     @Transactional
     public PaymentSystemResponse processNewOrder(OrderResponseDto dto, String uuid) {
-        validateOrderRequestAddress(dto);
         adjustPaymentDetails(dto);
 
         Order order = orderRepository.save(mapOrder(dto));
@@ -120,7 +104,6 @@ public class ProcessPaymentServiceImpl implements ProcessPaymentService {
     @Override
     @Transactional
     public PaymentSystemResponse processExistingOrder(OrderResponseDto dto, String uuid, Long orderId) {
-        validateOrderRequestAddress(dto);
         User currentUser = userRepository.findByUuid(uuid);
         Order order = getOrder(orderId);
         validateOrderPaymentProcessingStatus(order);
@@ -271,19 +254,34 @@ public class ProcessPaymentServiceImpl implements ProcessPaymentService {
     }
 
     private UBSuser createOrUpdateUbsUser(OrderResponseDto dto, User currentUser, Order existingOrder) {
+        TariffsInfo tariff = tariffsInfoRepository.findById(dto.getTariffId())
+            .orElseThrow(() -> new NotFoundException(TARIFF_NOT_FOUND + dto.getTariffId()));
+
+        Long resolvedLocationId = resolveLocationIdForAddressAndTariff(tariff, dto.getAddressId());
+
         OrderAddressDto orderAddress;
 
         if (existingOrder == null) {
             orderAddress = addressService.formAndSaveOrderAddress(
-                dto.getAddressId(), dto.getLocationId(), currentUser.getId());
+                dto.getAddressId(), resolvedLocationId, currentUser.getId());
             return formAndSaveUbsUser(dto.getPersonalData(), null, orderAddress, currentUser);
         } else {
             orderAddress = modelMapper.map(existingOrder.getUbsUser().getOrderAddress(), OrderAddressDto.class);
             orderAddress = addressService.getOrUpdateOrderAddress(
-                orderAddress, dto.getAddressId(), dto.getLocationId(), currentUser.getId());
+                orderAddress, dto.getAddressId(), resolvedLocationId, currentUser.getId());
             return formAndSaveUbsUser(dto.getPersonalData(), existingOrder.getUbsUser().getId(), orderAddress,
                 currentUser);
         }
+    }
+
+    private Long resolveLocationIdForAddressAndTariff(TariffsInfo tariff, Long addressId) {
+        return tariff.getTariffLocations().stream()
+            .map(TariffLocation::getLocation)
+            .map(Location::getId)
+            .filter(locationId -> addressService.checkIfAddressMatchLocationArea(locationId, addressId))
+            .findFirst()
+            .orElseThrow(() -> new AddressNotWithinLocationAreaException(
+                AppConstant.ADDRESS_NOT_WITHIN_LOCATION_AREA_MESSAGE));
     }
 
     private Order mapOrder(OrderResponseDto dto) {
@@ -319,12 +317,6 @@ public class ProcessPaymentServiceImpl implements ProcessPaymentService {
     private Order getOrder(Long orderId) {
         return orderRepository.findById(orderId)
             .orElseThrow(() -> new NotFoundException(ORDER_WITH_CURRENT_ID_DOES_NOT_EXIST + orderId));
-    }
-
-    private void validateOrderRequestAddress(OrderResponseDto dto) {
-        if (!addressService.checkIfAddressMatchLocationArea(dto.getLocationId(), dto.getAddressId())) {
-            throw new AddressNotWithinLocationAreaException(AppConstant.ADDRESS_NOT_WITHIN_LOCATION_AREA_MESSAGE);
-        }
     }
 
     private void adjustPaymentDetails(OrderResponseDto dto) {

--- a/service/src/test/java/greencity/ModelUtils.java
+++ b/service/src/test/java/greencity/ModelUtils.java
@@ -438,7 +438,7 @@ public class ModelUtils {
             .addressId(1L)
             .additionalOrders(new HashSet<>(List.of("232-534-634")))
             .bags(Collections.singletonList(new BagDto(3, 999)))
-            .locationId(1L)
+            .tariffId(1L)
             .orderComment("comment")
             .certificates(Collections.emptySet())
             .pointsToUse(700)

--- a/service/src/test/java/greencity/service/ubs/order/OrderServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/order/OrderServiceImplTest.java
@@ -176,10 +176,10 @@ class OrderServiceImplTest {
         OrderResponseDto dto = new OrderResponseDto();
         dto.setBags(Collections.emptyList());
         dto.setPointsToUse(10);
-        dto.setLocationId(1L);
+        dto.setTariffId(tariffsInfo.getId());
         BagInfoDto bagInfoDto = getBagInfoDto();
 
-        when(tariffsInfoRepository.findTariffsInfoByBagIdAndLocationId(anyList(), anyLong()))
+        when(tariffsInfoRepository.findById(tariffsInfo.getId()))
             .thenReturn(Optional.of(tariffsInfo));
         doAnswer(invocation -> {
             List<BagInfoDto> inputList = invocation.getArgument(0);
@@ -208,10 +208,10 @@ class OrderServiceImplTest {
         OrderResponseDto dto = new OrderResponseDto();
         dto.setBags(Collections.emptyList());
         dto.setPointsToUse(0);
-        dto.setLocationId(1L);
+        dto.setTariffId(tariffsInfo.getId());
         order.setPayment(null);
 
-        when(tariffsInfoRepository.findTariffsInfoByBagIdAndLocationId(anyList(), anyLong()))
+        when(tariffsInfoRepository.findById(tariffsInfo.getId()))
             .thenReturn(Optional.of(tariffsInfo));
         when(bagCalculatorService.prepareBagsAndCalculateTotal(anyList(), anyList(), any()))
             .thenReturn(100L);
@@ -235,9 +235,9 @@ class OrderServiceImplTest {
         OrderResponseDto dto = new OrderResponseDto();
         dto.setBags(Collections.emptyList());
         dto.setPointsToUse(0);
-        dto.setLocationId(1L);
+        dto.setTariffId(tariffsInfo.getId());
 
-        when(tariffsInfoRepository.findTariffsInfoByBagIdAndLocationId(anyList(), anyLong()))
+        when(tariffsInfoRepository.findById(tariffsInfo.getId()))
             .thenReturn(Optional.of(tariffsInfo));
         when(bagCalculatorService.prepareBagsAndCalculateTotal(anyList(), anyList(), any()))
             .thenReturn(100L);

--- a/service/src/test/java/greencity/service/ubs/payment/ProcessPaymentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/payment/ProcessPaymentServiceImplTest.java
@@ -31,12 +31,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+
 import greencity.ModelUtils;
 import greencity.client.WayForPayClient;
 import greencity.constant.OrderHistory;
@@ -47,9 +43,8 @@ import greencity.dto.order.OrderWayForPayClientDto;
 import greencity.dto.order.PaymentSystemResponse;
 import greencity.dto.payment.PaymentCancellationWayForPayRequestDto;
 import greencity.dto.payment.PaymentWayForPayRequestDto;
-import greencity.entity.order.Certificate;
-import greencity.entity.order.Order;
-import greencity.entity.order.Payment;
+import greencity.entity.order.*;
+import greencity.entity.user.Location;
 import greencity.entity.user.User;
 import greencity.entity.user.ubs.OrderAddress;
 import greencity.entity.user.ubs.UBSuser;
@@ -61,11 +56,7 @@ import greencity.exceptions.BadRequestException;
 import greencity.exceptions.NotFoundException;
 import greencity.exceptions.address.AddressNotWithinLocationAreaException;
 import greencity.exceptions.http.AccessDeniedException;
-import greencity.repository.CertificateRepository;
-import greencity.repository.OrderAddressRepository;
-import greencity.repository.OrderRepository;
-import greencity.repository.UBSUserRepository;
-import greencity.repository.UserRepository;
+import greencity.repository.*;
 import greencity.service.ubs.AddressService;
 import greencity.service.ubs.EventService;
 import greencity.service.ubs.NotificationService;
@@ -76,10 +67,7 @@ import greencity.service.ubs.wayforpay.WayForPayService;
 import greencity.service.ubs.wayforpay.WayForPayStrategy;
 import greencity.util.OrderUtils;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -136,6 +124,8 @@ class ProcessPaymentServiceImplTest {
     private OrderAddressRepository orderAddressRepository;
     @Mock
     private OrderBagService orderBagService;
+    @Mock
+    private TariffsInfoRepository tariffsInfoRepository;
     @InjectMocks
     private ProcessPaymentServiceImpl service;
 
@@ -149,14 +139,23 @@ class ProcessPaymentServiceImplTest {
         Payment payment = getPayment();
         PaymentSystemResponse paymentSystemResponse = getPaymentSystemResponse();
 
+        Location location = new Location();
+        location.setId(10L);
+        TariffLocation tariffLocation = new TariffLocation();
+        tariffLocation.setLocation(location);
+        TariffsInfo tariff = new TariffsInfo();
+        tariff.setId(dto.getTariffId());
+        tariff.setTariffLocations(Set.of(tariffLocation));
+
+        when(tariffsInfoRepository.findById(dto.getTariffId())).thenReturn(Optional.of(tariff));
         when(modelMapper.map(dto, Order.class)).thenReturn(order);
         when(userRepository.findByUuid("uuid")).thenReturn(user);
-        when(addressService.checkIfAddressMatchLocationArea(dto.getAddressId(), dto.getLocationId())).thenReturn(true);
+        when(addressService.checkIfAddressMatchLocationArea(location.getId(), dto.getAddressId())).thenReturn(true);
         when(modelMapper.map(dto.getPersonalData(), UBSuser.class)).thenReturn(ubsUser);
         when(ubsUserRepository.save(any(UBSuser.class))).thenReturn(ubsUser);
         when(orderService.formAndSaveOrderRequest(eq(dto), any(Long.class), eq(user.getId()), nullable(Long.class)))
             .thenReturn(order.getId());
-        when(addressService.formAndSaveOrderAddress(dto.getAddressId(), dto.getLocationId(), user.getId()))
+        when(addressService.formAndSaveOrderAddress(dto.getAddressId(), location.getId(), user.getId()))
             .thenReturn(getOrderAddressDto());
         try (MockedStatic<OrderUtils> mocked = Mockito.mockStatic(OrderUtils.class)) {
             mocked.when(() -> OrderUtils.getLastPayment(any())).thenReturn(payment);
@@ -182,7 +181,7 @@ class ProcessPaymentServiceImplTest {
     void processNewOrder_shouldReturnWayForPayResponse_whenShouldBePaidFalse() {
         OrderResponseDto dto = getOrderResponseDto();
         dto.setShouldBePaid(false);
-        dto.setLocationId(1L);
+        dto.setTariffId(1L);
         dto.setAddressId(2L);
 
         Order order = getOrder();
@@ -192,8 +191,17 @@ class ProcessPaymentServiceImplTest {
 
         PaymentSystemResponse paymentSystemResponse = getPaymentSystemResponse();
 
+        Location location = new Location();
+        location.setId(10L);
+        TariffLocation tariffLocation = new TariffLocation();
+        tariffLocation.setLocation(location);
+        TariffsInfo tariff = new TariffsInfo();
+        tariff.setId(dto.getTariffId());
+        tariff.setTariffLocations(Set.of(tariffLocation));
+
+        when(tariffsInfoRepository.findById(dto.getTariffId())).thenReturn(Optional.of(tariff));
         when(modelMapper.map(dto, Order.class)).thenReturn(order);
-        when(addressService.formAndSaveOrderAddress(dto.getAddressId(), dto.getLocationId(), user.getId()))
+        when(addressService.formAndSaveOrderAddress(dto.getAddressId(), location.getId(), user.getId()))
             .thenReturn(getOrderAddressDto());
         when(userRepository.findByUuid("uuid")).thenReturn(user);
         when(addressService.checkIfAddressMatchLocationArea(anyLong(), anyLong())).thenReturn(true);
@@ -219,9 +227,17 @@ class ProcessPaymentServiceImplTest {
     @Test
     void processNewOrder_shouldThrowException_whenAddressNotValid() {
         OrderResponseDto dto = getOrderResponseDto();
-        dto.setLocationId(1L);
-        dto.setAddressId(2L);
+        Order order = getOrder();
 
+        Location location = new Location();
+        location.setId(100L);
+        TariffLocation tariffLocation = new TariffLocation();
+        tariffLocation.setLocation(location);
+        TariffsInfo tariff = new TariffsInfo();
+        tariff.setTariffLocations(Set.of(tariffLocation));
+
+        when(tariffsInfoRepository.findById(1L)).thenReturn(Optional.of(tariff));
+        when(modelMapper.map(dto, Order.class)).thenReturn(order);
         when(addressService.checkIfAddressMatchLocationArea(anyLong(), anyLong())).thenReturn(false);
 
         assertThrows(AddressNotWithinLocationAreaException.class,
@@ -243,9 +259,19 @@ class ProcessPaymentServiceImplTest {
         user.setOrders(new ArrayList<>(List.of(order)));
         user.setRecipientEmail(oldEmail);
 
-        when(addressService.checkIfAddressMatchLocationArea(dto.getLocationId(), dto.getAddressId()))
+        Location location = new Location();
+        location.setId(1L);
+        TariffLocation tariffLocation = new TariffLocation();
+        tariffLocation.setLocation(location);
+        TariffsInfo tariff = new TariffsInfo();
+        tariff.setId(dto.getTariffId());
+        tariff.setTariffLocations(Set.of(tariffLocation));
+
+        when(tariffsInfoRepository.findById(dto.getTariffId()))
+            .thenReturn(Optional.of(tariff));
+        when(addressService.checkIfAddressMatchLocationArea(location.getId(), dto.getAddressId()))
             .thenReturn(true);
-        when(addressService.formAndSaveOrderAddress(dto.getAddressId(), dto.getLocationId(), user.getId()))
+        when(addressService.formAndSaveOrderAddress(dto.getAddressId(), location.getId(), user.getId()))
             .thenReturn(addressDto);
         when(orderAddressRepository.findById(addressDto.getId())).thenReturn(Optional.of(orderAddress));
         when(modelMapper.map(dto, Order.class)).thenReturn(order);
@@ -279,12 +305,20 @@ class ProcessPaymentServiceImplTest {
         OrderAddressDto orderAddressDto = getOrderAddressDto();
         PaymentSystemResponse paymentSystemResponse = getPaymentSystemResponse();
 
-        when(addressService.checkIfAddressMatchLocationArea(dto.getAddressId(), dto.getLocationId()))
-            .thenReturn(true);
+        Location location = new Location();
+        location.setId(1L);
+        TariffLocation tariffLocation = new TariffLocation();
+        tariffLocation.setLocation(location);
+        TariffsInfo tariff = new TariffsInfo();
+        tariff.setId(dto.getTariffId());
+        tariff.setTariffLocations(Set.of(tariffLocation));
+
+        when(tariffsInfoRepository.findById(dto.getTariffId())).thenReturn(Optional.of(tariff));
+        when(addressService.checkIfAddressMatchLocationArea(location.getId(), dto.getAddressId())).thenReturn(true);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(userRepository.findByUuid("uuid")).thenReturn(user);
-        when(addressService.getOrUpdateOrderAddress(orderAddressDto, dto.getAddressId(), dto.getLocationId(),
-            user.getId()))
+        when(
+            addressService.getOrUpdateOrderAddress(orderAddressDto, dto.getAddressId(), location.getId(), user.getId()))
             .thenReturn(orderAddressDto);
         when(modelMapper.map(order.getUbsUser().getOrderAddress(), OrderAddressDto.class)).thenReturn(orderAddressDto);
         when(modelMapper.map(dto.getPersonalData(), UBSuser.class)).thenReturn(ubsUser);
@@ -323,8 +357,6 @@ class ProcessPaymentServiceImplTest {
         User user = getUser();
         user.setOrders(new ArrayList<>(List.of(order)));
 
-        when(addressService.checkIfAddressMatchLocationArea(dto.getAddressId(), dto.getLocationId()))
-            .thenReturn(true);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(userRepository.findByUuid("uuid")).thenReturn(user);
 
@@ -341,8 +373,6 @@ class ProcessPaymentServiceImplTest {
         User user = getUser();
         user.setOrders(new ArrayList<>(List.of(order)));
 
-        when(addressService.checkIfAddressMatchLocationArea(dto.getAddressId(), dto.getLocationId()))
-            .thenReturn(true);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(userRepository.findByUuid("uuid")).thenReturn(user);
 
@@ -359,8 +389,6 @@ class ProcessPaymentServiceImplTest {
         User user = getUser();
         user.setOrders(new ArrayList<>(List.of(order)));
 
-        when(addressService.checkIfAddressMatchLocationArea(dto.getAddressId(), dto.getLocationId()))
-            .thenReturn(true);
         when(orderRepository.findById(order.getId())).thenReturn(Optional.of(order));
         when(userRepository.findByUuid("uuid")).thenReturn(user);
 


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋
[#9295](https://github.com/ita-social-projects/GreenCity/issues/9295)

## Changed
- Replaced order validation logic from single `locationId` to `tariffId`. Tariff is now treated as an aggregate of locations and courier. Order address is validated against all locations of selected tariff.
- Removed dependency on client-provided `locationId`.
- Fixed related tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Order flow now accepts tariff IDs to link tariffs and determine the correct service location.

* **Bug Fixes**
  * Address validation strengthened to ensure addresses belong to the area associated with the selected tariff.

* **Refactor**
  * Public DTO field renamed from locationId to tariffId; order processing updated to resolve locations via tariff info and tests updated accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->