### PR TITLE
Fixed users orders pagination

### DIFF
--- a/service/src/main/java/greencity/service/ubs/OrdersForUserServiceImpl.java
+++ b/service/src/main/java/greencity/service/ubs/OrdersForUserServiceImpl.java
@@ -29,7 +29,7 @@ public class OrdersForUserServiceImpl implements OrdersForUserService {
         String username = getUsername(userId);
 
         List<UserOrdersDto> userOrdersDtoList = ordersForUserRepository
-            .getAllOrdersByUserId(PageRequest.of(page.getPageNumber() * 10, 10, sort), userId)
+            .getAllOrdersByUserId(PageRequest.of(page.getPageNumber(), 10, sort), userId)
             .stream().map(this::getAllOrders)
             .collect(Collectors.toList());
         return new UserWithOrdersDto(username, userOrdersDtoList);

--- a/service/src/test/java/greencity/service/ubs/OrdersForUserServiceImplTest.java
+++ b/service/src/test/java/greencity/service/ubs/OrdersForUserServiceImplTest.java
@@ -38,12 +38,12 @@ class OrdersForUserServiceImplTest {
     @MethodSource("provideSortingOrdersAndColumnsForGetAllOrders")
     void getAllOrders(SortingOrder sortingOrder, String column) {
         Sort sort = Sort.by(Sort.Direction.valueOf(sortingOrder.toString()), column);
-        when(ordersForUserRepository.getAllOrdersByUserId(PageRequest.of(10, 10, sort), 1L))
+        when(ordersForUserRepository.getAllOrdersByUserId(PageRequest.of(1, 10, sort), 1L))
             .thenReturn(Page.empty());
         when(userRepository.getReferenceById(anyLong())).thenReturn(ModelUtils.getUser());
         ordersForUserService.getAllOrders(PageRequest.of(1, 1), 1L, sortingOrder, column);
 
-        verify(ordersForUserRepository).getAllOrdersByUserId(PageRequest.of(10, 10, sort), 1L);
+        verify(ordersForUserRepository).getAllOrdersByUserId(PageRequest.of(1, 10, sort), 1L);
     }
 
     private static Stream<Arguments> provideSortingOrdersAndColumnsForGetAllOrders() {
@@ -61,14 +61,14 @@ class OrdersForUserServiceImplTest {
         Page<Order> page = new PageImpl<>(List.of(order), pageable, 1);
         Sort sort = Sort.by(Sort.Direction.valueOf(SortingOrder.DESC.toString()), "payment_amount");
 
-        when(ordersForUserRepository.getAllOrdersByUserId(PageRequest.of(10, 10, sort), 1L))
+        when(ordersForUserRepository.getAllOrdersByUserId(PageRequest.of(0, 10, sort), 1L))
             .thenReturn(page);
         when(userRepository.getReferenceById(anyLong())).thenReturn(ModelUtils.getUser());
 
-        ordersForUserService.getAllOrders(PageRequest.of(1, 1),
+        ordersForUserService.getAllOrders(PageRequest.of(0, 1),
             1L, SortingOrder.DESC, "payment_amount");
 
-        verify(ordersForUserRepository).getAllOrdersByUserId(PageRequest.of(10, 10, sort), 1L);
+        verify(ordersForUserRepository).getAllOrdersByUserId(PageRequest.of(0, 10, sort), 1L);
         verify(userRepository).getReferenceById(anyLong());
     }
 
@@ -80,14 +80,14 @@ class OrdersForUserServiceImplTest {
         Page<Order> page = new PageImpl<>(List.of(order), pageable, 1);
         Sort sort = Sort.by(Sort.Direction.valueOf(SortingOrder.DESC.toString()), "payment_amount");
 
-        when(ordersForUserRepository.getAllOrdersByUserId(PageRequest.of(10, 10, sort), 1L))
+        when(ordersForUserRepository.getAllOrdersByUserId(PageRequest.of(0, 10, sort), 1L))
             .thenReturn(page);
         when(userRepository.getReferenceById(anyLong())).thenReturn(ModelUtils.getUser());
 
-        ordersForUserService.getAllOrders(PageRequest.of(1, 1),
+        ordersForUserService.getAllOrders(PageRequest.of(0, 1),
             1L, SortingOrder.DESC, "payment_amount");
 
-        verify(ordersForUserRepository).getAllOrdersByUserId(PageRequest.of(10, 10, sort), 1L);
+        verify(ordersForUserRepository).getAllOrdersByUserId(PageRequest.of(0, 10, sort), 1L);
         verify(userRepository).getReferenceById(anyLong());
     }
 }


### PR DESCRIPTION
# GreenCityUBS PR
## Issue Link 📋

## Changed
- fixed issue with orders pagination;
- fixed appropriate test cases;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed pagination logic for user orders—corrected an incorrect offset calculation that was preventing proper results when browsing multiple pages of orders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->